### PR TITLE
[Fix] #13 카테고리-색상 매핑 불일치 수정

### DIFF
--- a/screens/MissionRouletteScreen.jsx
+++ b/screens/MissionRouletteScreen.jsx
@@ -55,8 +55,9 @@ function SlotMachine({ onDone, autoSpin = true, missions }) {
     translateY.setValue(0);
     Animated.timing(translateY, {
       toValue: targetY, duration: 3200,
-      easing: Easing.out(Easing.exp), useNativeDriver: true,
+      easing: Easing.out(Easing.cubic), useNativeDriver: true,
     }).start(() => {
+      translateY.setValue(targetY);
       setSpinning(false);
       setLanded(true);
       setFinalIdx(targetMissionIdx);
@@ -107,10 +108,10 @@ function SlotMachine({ onDone, autoSpin = true, missions }) {
 function makeSlotStyles(C) {
   return StyleSheet.create({
     root: {
-      height: SLOT_H, position: 'relative', overflow: 'hidden',
+      height: SLOT_H, overflow: 'hidden',
       borderRadius: 16, borderWidth: 1, borderColor: C.border, backgroundColor: C.surface,
     },
-    window:    { height: SLOT_H, overflow: 'hidden' },
+    window:    { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, overflow: 'hidden' },
     highlight: {
       position: 'absolute', top: ITEM_H, left: 0, right: 0, height: ITEM_H,
       borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.greenBorder,

--- a/screens/MissionRouletteScreen.jsx
+++ b/screens/MissionRouletteScreen.jsx
@@ -17,9 +17,9 @@ const REPEATS = 6;
 const SLOT_H  = ITEM_H * VISIBLE;
 
 function getCategoryColor(cat, C) {
-  if (cat === 'Energy')    return C.green;
+  if (cat === 'Energy')    return C.blue;
   if (cat === 'Intellect') return C.purple;
-  return C.blue;
+  return C.green;
 }
 
 function SlotMachine({ onDone, autoSpin = true, missions }) {

--- a/screens/MissionScreen.jsx
+++ b/screens/MissionScreen.jsx
@@ -256,9 +256,9 @@ function MissionIcon({ icon, styles, C }) {
 
 function MissionCard({ currentMission, userStats, mainBadge, earnedBadges, displayedText, onOpenVerify, styles, C }) {
   const cat       = currentMission?.category;
-  const catColor  = cat === 'Intellect' ? C.purple  : cat === 'Vitality' ? C.blue   : C.green;
-  const catFaint  = cat === 'Intellect' ? C.purpleFaint  : cat === 'Vitality' ? C.blueFaint  : C.greenFaint;
-  const catBorder = cat === 'Intellect' ? C.purpleBorder : cat === 'Vitality' ? C.blueBorder : C.greenBorder;
+  const catColor  = cat === 'Intellect' ? C.purple  : cat === 'Energy' ? C.blue   : C.green;
+  const catFaint  = cat === 'Intellect' ? C.purpleFaint  : cat === 'Energy' ? C.blueFaint  : C.greenFaint;
+  const catBorder = cat === 'Intellect' ? C.purpleBorder : cat === 'Energy' ? C.blueBorder : C.greenBorder;
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
@@ -291,9 +291,9 @@ function MissionCard({ currentMission, userStats, mainBadge, earnedBadges, displ
             </T>
           </View>
           <View style={styles.statsBlock}>
-            <StatBar label="Energy"    color={C.green}  fill={userStats?.energyFill    ?? 0} styles={styles} />
+            <StatBar label="Vitality"  color={C.green}  fill={userStats?.vitalityFill  ?? 0} styles={styles} />
             <StatBar label="Intellect" color={C.purple} fill={userStats?.intellectFill ?? 0} styles={styles} />
-            <StatBar label="Vitality"  color={C.blue}   fill={userStats?.vitalityFill  ?? 0} styles={styles} />
+            <StatBar label="Energy"    color={C.blue}   fill={userStats?.energyFill    ?? 0} styles={styles} />
           </View>
           {(mainBadge || earnedBadges.length > 0) && (
             <View style={styles.badgeRow}>

--- a/screens/ProfileScreen.jsx
+++ b/screens/ProfileScreen.jsx
@@ -32,9 +32,9 @@ const F = 'Kkukkukk';
 const { width } = Dimensions.get('window');
 
 const GRAD_FOR_CAT = {
-  Energy:    ['#acd8a7', '#2e7d4f'],
+  Vitality:  ['#acd8a7', '#2e7d4f'],
   Intellect: ['#c3aef0', '#5a2da0'],
-  Vitality:  ['#87ceeb', '#2a7ab8'],
+  Energy:    ['#87ceeb', '#2a7ab8'],
 };
 
 function SkeletonBox({ w, h, radius = 8, style }) {
@@ -466,9 +466,9 @@ function MissionHistory({ s, hist, C, weekGroups, weekLabels }) {
   const items = weekGroups[weekIdx] ?? [];
 
   const catColor = (cat) => {
-    if (cat === 'Energy')    return C.green;
+    if (cat === 'Energy')    return C.blue;
     if (cat === 'Intellect') return C.purple;
-    return C.blue;
+    return C.green;
   };
 
   return (
@@ -553,9 +553,9 @@ export default function ProfileScreen({ profile, onSaveProfile, currentMission }
   };
 
   const STATS = userStats ? [
-    { label: 'Energy',    color: C.green,  fill: userStats.energyFill,   level: userStats.energyLevel },
+    { label: 'Vitality',  color: C.green,  fill: userStats.vitalityFill,  level: userStats.vitalityLevel },
     { label: 'Intellect', color: C.purple, fill: userStats.intellectFill, level: userStats.intellectLevel },
-    { label: 'Vitality',  color: C.blue,   fill: userStats.vitalityFill,  level: userStats.vitalityLevel },
+    { label: 'Energy',    color: C.blue,   fill: userStats.energyFill,    level: userStats.energyLevel },
   ] : [];
   const totalMissions = userStats?.totalMissions ?? 0;
   const verifiedCount = userStats?.totalVerified ?? 0;


### PR DESCRIPTION
## Summary

- `MissionRouletteScreen`, `MissionScreen`, `ProfileScreen`에서 카테고리별 색상 매핑 오류 수정
- `Energy → blue`, `Intellect → purple`, `Vitality → green` 으로 CLAUDE.md 스펙에 맞게 통일
- 슬롯머신 Easing을 `Easing.out(Easing.cubic)`으로 교체하여 룰렛이 정확한 위치에 정지하도록 수정

## Test plan

- [x] 미션 룰렛 돌린 후 선택된 미션이 초록 하이라이트 중앙에 정확히 정지 확인
- [x] Energy 카테고리 미션 → 파란색으로 표시 확인
- [x] Intellect 카테고리 미션 → 보라색으로 표시 확인
- [x] Vitality 카테고리 미션 → 초록색으로 표시 확인
- [x] ProfileScreen 스탯바 색상 및 순서 정상 확인

Closes #13