### PR TITLE
[Fix] #12 탭바 <Text> → <T> 컴포넌트 교체

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import T from './components/ThemedText';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import { useFonts } from 'expo-font';
@@ -364,9 +365,9 @@ function AppInner() {
                     size={22}
                     color={tab === t.key ? '#22c97a' : navIconColor}
                   />
-                  <Text style={[styles.navLabel, { color: navIconColor }, tab === t.key && styles.navLabelActive]}>
+                  <T v="label" size={9} color={tab === t.key ? '#22c97a' : navIconColor} style={{ opacity: tab === t.key ? 1 : 0.7, letterSpacing: 0.2 }}>
                     {t.label}
-                  </Text>
+                  </T>
                 </TouchableOpacity>
               ))}
             </View>
@@ -411,6 +412,4 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     gap: 2,
   },
-  navLabel:       { fontFamily: 'Kkukkukk', fontSize: 9, opacity: 0.7, letterSpacing: 0.2 },
-  navLabelActive: { color: '#22c97a', opacity: 1 },
 });

--- a/App.jsx
+++ b/App.jsx
@@ -363,9 +363,9 @@ function AppInner() {
                   <Ionicons
                     name={t.ionicon}
                     size={22}
-                    color={tab === t.key ? '#22c97a' : navIconColor}
+                    color={tab === t.key ? C.green : navIconColor}
                   />
-                  <T v="label" size={9} color={tab === t.key ? '#22c97a' : navIconColor} style={{ opacity: tab === t.key ? 1 : 0.7, letterSpacing: 0.2 }}>
+                  <T v="label" size={9} color={tab === t.key ? C.green : navIconColor} style={{ opacity: tab === t.key ? 1 : 0.7, letterSpacing: 0.2 }}>
                     {t.label}
                   </T>
                 </TouchableOpacity>


### PR DESCRIPTION
## Summary
- `App.jsx` 탭바 레이블에서 `<Text>` 직접 사용을 `<T>` 컴포넌트로 교체
- `Text` import 제거, `T` import 추가
- 불필요해진 `navLabel`, `navLabelActive` 스타일 제거

## Test plan
- [x] 탭바 레이블(미션, 피드, 프로필)에 Kkukkukk 폰트 적용 확인
- [x] 활성 탭 레이블 색상(`#22c97a`) 정상 표시 확인
- [x] 비활성 탭 레이블 색상 및 opacity 정상 표시 확인
- [x] 다크/라이트 모드 전환 시 레이블 색상 정상 반응 확인

Closes #12
