### PR TITLE
[Fix] #14 설정 > 정보 섹션 링크 연결

### DIFF
--- a/screens/SettingsScreen.jsx
+++ b/screens/SettingsScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import {
   View, Text, StyleSheet, ScrollView,
-  TouchableOpacity, Switch, Alert,
+  TouchableOpacity, Switch, Alert, Linking,
 } from 'react-native';
 import { useColors } from '../utils/useColors';
 import { useTheme } from '../utils/ThemeContext';
@@ -216,13 +216,19 @@ export default function SettingsScreen({
             icon="🛡️"
             label="개인정보 처리방침"
             right={<T v="sub">›</T>}
-            onPress={() => {}}
+            onPress={() => Linking.openURL('https://fuchsia-belief-040.notion.site/OFFMODE-34309a0b0e3e809b965bd62530627431')}
+          />
+          <SettingRow
+            icon="📄"
+            label="서비스 이용약관"
+            right={<T v="sub">›</T>}
+            onPress={() => Linking.openURL('https://fuchsia-belief-040.notion.site/35f09a0b0e3e80ffa48fde51b2de125b')}
           />
           <SettingRow
             icon="💬"
             label="문의하기"
             right={<T v="sub">›</T>}
-            onPress={() => {}}
+            onPress={() => Linking.openURL('https://fuchsia-belief-040.notion.site/Off-Mode-35f09a0b0e3e80af81a8ce27d686fd7d')}
           />
           <SettingRow
             icon="⭐"

--- a/screens/SettingsScreen.jsx
+++ b/screens/SettingsScreen.jsx
@@ -8,6 +8,11 @@ import { useTheme } from '../utils/ThemeContext';
 import T from '../components/ThemedText';
 import * as H from '../utils/haptics';
 
+const openLink = (url) =>
+  Linking.openURL(url).catch(() =>
+    Alert.alert('오류', '페이지를 열 수 없어요. 잠시 후 다시 시도해주세요.')
+  );
+
 /* ── 토글 스위치 ─────────────────────────────────────── */
 function OffSwitch({ value, onValueChange }) {
   return (
@@ -216,19 +221,19 @@ export default function SettingsScreen({
             icon="🛡️"
             label="개인정보 처리방침"
             right={<T v="sub">›</T>}
-            onPress={() => Linking.openURL('https://fuchsia-belief-040.notion.site/OFFMODE-34309a0b0e3e809b965bd62530627431')}
+            onPress={() => openLink('https://fuchsia-belief-040.notion.site/OFFMODE-34309a0b0e3e809b965bd62530627431')}
           />
           <SettingRow
             icon="📄"
             label="서비스 이용약관"
             right={<T v="sub">›</T>}
-            onPress={() => Linking.openURL('https://fuchsia-belief-040.notion.site/35f09a0b0e3e80ffa48fde51b2de125b')}
+            onPress={() => openLink('https://fuchsia-belief-040.notion.site/35f09a0b0e3e80ffa48fde51b2de125b')}
           />
           <SettingRow
             icon="💬"
             label="문의하기"
             right={<T v="sub">›</T>}
-            onPress={() => Linking.openURL('https://fuchsia-belief-040.notion.site/Off-Mode-35f09a0b0e3e80af81a8ce27d686fd7d')}
+            onPress={() => openLink('https://fuchsia-belief-040.notion.site/Off-Mode-35f09a0b0e3e80af81a8ce27d686fd7d')}
           />
           <SettingRow
             icon="⭐"


### PR DESCRIPTION
## Summary
- 개인정보 처리방침 → 노션 페이지 연결
- 서비스 이용약관 항목 추가 → 노션 페이지 연결
- 문의하기 → 노션 문의 페이지 연결
- `Linking.openURL` 실패 시 Alert로 에러 안내하는 `openLink` 헬퍼 추가

## Test plan
- [x] 개인정보 처리방침 탭 시 노션 페이지 열리는지 확인
- [x] 서비스 이용약관 탭 시 노션 페이지 열리는지 확인
- [x] 문의하기 탭 시 노션 문의 페이지 열리는지 확인
- [x] 링크 실패 시 Alert 노출 확인

> 앱 평가하기는 App Store 등록 후 URL 연결 예정

close #14
