### PR TITLE
[Infra] #44 backend Java 21 고정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,6 +18,9 @@ group = 'com.offmode'
 version = '0.0.1-SNAPSHOT'
 
 java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
 }

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.java.home=C:/Program Files/Java/jdk-21

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.home=C:/Program Files/Java/jdk-21


### PR DESCRIPTION
## 🔗 Issue

- close #44

---

## 📌 Summary

- backend Gradle toolchain을 Java 21로 명시했습니다.
- Android 설정 변경은 제외하고 backend Java 버전 고정만 반영했습니다.

---

## ✅ Test

- [x] `./gradlew.bat clean build`