### PR TITLE
[Refactor] #2 예외 응답 표준화

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/auth/api/v1/AuthController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/auth/api/v1/AuthController.java
@@ -1,9 +1,9 @@
-package com.offmode.boundedcontext.auth.in.api.v1;
+package com.offmode.boundedcontext.auth.api.v1;
 
-import com.offmode.boundedcontext.auth.app.dto.request.AppleLoginRequest;
-import com.offmode.boundedcontext.auth.app.dto.request.KakaoLoginRequest;
-import com.offmode.boundedcontext.auth.app.dto.response.AuthResponse;
-import com.offmode.boundedcontext.auth.app.service.AuthService;
+import com.offmode.boundedcontext.auth.dto.request.AppleLoginRequest;
+import com.offmode.boundedcontext.auth.dto.request.KakaoLoginRequest;
+import com.offmode.boundedcontext.auth.dto.response.AuthResponse;
+import com.offmode.boundedcontext.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/backend/src/main/java/com/offmode/boundedcontext/auth/dto/request/AppleLoginRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/auth/dto/request/AppleLoginRequest.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.auth.app.dto.request;
+package com.offmode.boundedcontext.auth.dto.request;
 
 import lombok.Getter;
 

--- a/backend/src/main/java/com/offmode/boundedcontext/auth/dto/request/KakaoLoginRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/auth/dto/request/KakaoLoginRequest.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.auth.app.dto.request;
+package com.offmode.boundedcontext.auth.dto.request;
 
 import lombok.Getter;
 

--- a/backend/src/main/java/com/offmode/boundedcontext/auth/dto/response/AuthResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/auth/dto/response/AuthResponse.java
@@ -1,7 +1,7 @@
-package com.offmode.boundedcontext.auth.app.dto.response;
+package com.offmode.boundedcontext.auth.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/backend/src/main/java/com/offmode/boundedcontext/auth/service/AuthService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/auth/service/AuthService.java
@@ -1,10 +1,11 @@
-package com.offmode.boundedcontext.auth.app.service;
+package com.offmode.boundedcontext.auth.service;
 
-import com.offmode.boundedcontext.auth.app.dto.response.AuthResponse;
-import com.offmode.boundedcontext.mission.out.repository.UserMissionRepository;
-import com.offmode.boundedcontext.user.domain.entity.User;
-import com.offmode.boundedcontext.user.out.repository.UserRepository;
+import com.offmode.boundedcontext.auth.dto.response.AuthResponse;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import com.offmode.global.exception.BusinessException;
 import com.offmode.global.jwt.JwtProvider;
+import com.offmode.global.status.ErrorStatus;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import java.math.BigInteger;
@@ -24,7 +25,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class AuthService {
 
   private final UserRepository userRepository;
-  private final UserMissionRepository userMissionRepository;
   private final JwtProvider jwtProvider;
   private final WebClient.Builder webClientBuilder;
 
@@ -53,10 +53,10 @@ public class AuthService {
               .block();
     } catch (Exception e) {
       // Kakao API 오류(만료된 토큰 등)를 그대로 전파하지 않도록 래핑
-      throw new RuntimeException("카카오 토큰 검증 실패: " + e.getMessage());
+      throw new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED, e);
     }
 
-    if (kakaoUser == null) throw new RuntimeException("카카오 토큰 검증 실패");
+    if (kakaoUser == null) throw new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED);
 
     String providerId = String.valueOf(kakaoUser.get("id"));
     Map<?, ?> account = (Map<?, ?>) kakaoUser.get("kakao_account");
@@ -87,7 +87,7 @@ public class AuthService {
               .filter(k -> kid.equals(((Map<?, ?>) k).get("kid")))
               .map(k -> (Map<?, ?>) k)
               .findFirst()
-              .orElseThrow(() -> new RuntimeException("Apple 공개키 없음"));
+              .orElseThrow(() -> new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED));
 
       // RSA 공개키 생성
       byte[] nBytes = Base64.getUrlDecoder().decode((String) matchedKey.get("n"));
@@ -106,15 +106,17 @@ public class AuthService {
               .getPayload();
 
       if (!appleBundleId.equals(claims.getAudience().iterator().next())) {
-        throw new RuntimeException("Bundle ID 불일치");
+        throw new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED);
       }
 
       String providerId = claims.getSubject();
       String email = claims.get("email", String.class);
 
       return buildResponse("apple", providerId, email, fullName);
+    } catch (BusinessException e) {
+      throw e;
     } catch (Exception e) {
-      throw new RuntimeException("Apple 로그인 실패: " + e.getMessage(), e);
+      throw new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED, e);
     }
   }
 

--- a/backend/src/main/java/com/offmode/boundedcontext/badge/api/v1/BadgeController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/api/v1/BadgeController.java
@@ -1,7 +1,7 @@
-package com.offmode.boundedcontext.badge.in.api.v1;
+package com.offmode.boundedcontext.badge.api.v1;
 
-import com.offmode.boundedcontext.badge.app.dto.response.BadgeDto;
-import com.offmode.boundedcontext.badge.app.service.BadgeService;
+import com.offmode.boundedcontext.badge.dto.response.BadgeDto;
+import com.offmode.boundedcontext.badge.service.BadgeService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/com/offmode/boundedcontext/badge/dto/response/BadgeDto.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/dto/response/BadgeDto.java
@@ -1,7 +1,7 @@
-package com.offmode.boundedcontext.badge.app.dto.response;
+package com.offmode.boundedcontext.badge.dto.response;
 
-import com.offmode.boundedcontext.badge.domain.entity.UserBadge;
-import com.offmode.boundedcontext.badge.domain.types.BadgeDefinition;
+import com.offmode.boundedcontext.badge.entity.UserBadge;
+import com.offmode.boundedcontext.badge.types.BadgeDefinition;
 import java.time.LocalDateTime;
 import lombok.Getter;
 

--- a/backend/src/main/java/com/offmode/boundedcontext/badge/entity/UserBadge.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/entity/UserBadge.java
@@ -1,7 +1,7 @@
-package com.offmode.boundedcontext.badge.domain.entity;
+package com.offmode.boundedcontext.badge.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.user.entity.User;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;

--- a/backend/src/main/java/com/offmode/boundedcontext/badge/repository/UserBadgeRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/repository/UserBadgeRepository.java
@@ -1,6 +1,6 @@
-package com.offmode.boundedcontext.badge.out.repository;
+package com.offmode.boundedcontext.badge.repository;
 
-import com.offmode.boundedcontext.badge.domain.entity.UserBadge;
+import com.offmode.boundedcontext.badge.entity.UserBadge;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
@@ -1,12 +1,12 @@
-package com.offmode.boundedcontext.badge.app.service;
+package com.offmode.boundedcontext.badge.service;
 
-import com.offmode.boundedcontext.badge.app.dto.response.BadgeDto;
-import com.offmode.boundedcontext.badge.domain.entity.UserBadge;
-import com.offmode.boundedcontext.badge.domain.types.BadgeDefinition;
-import com.offmode.boundedcontext.badge.out.repository.UserBadgeRepository;
-import com.offmode.boundedcontext.mission.out.repository.UserMissionRepository;
-import com.offmode.boundedcontext.user.domain.entity.User;
-import com.offmode.boundedcontext.user.out.repository.UserRepository;
+import com.offmode.boundedcontext.badge.dto.response.BadgeDto;
+import com.offmode.boundedcontext.badge.entity.UserBadge;
+import com.offmode.boundedcontext.badge.repository.UserBadgeRepository;
+import com.offmode.boundedcontext.badge.types.BadgeDefinition;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;

--- a/backend/src/main/java/com/offmode/boundedcontext/badge/types/BadgeDefinition.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/types/BadgeDefinition.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.badge.domain.types;
+package com.offmode.boundedcontext.badge.types;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
@@ -1,9 +1,9 @@
-package com.offmode.boundedcontext.feed.in.api.v1;
+package com.offmode.boundedcontext.feed.api.v1;
 
-import com.offmode.boundedcontext.feed.app.dto.response.FeedItemDto;
-import com.offmode.boundedcontext.feed.app.dto.response.FeedStatsDto;
-import com.offmode.boundedcontext.feed.app.service.FeedService;
-import com.offmode.boundedcontext.feed.domain.entity.Verification;
+import com.offmode.boundedcontext.feed.dto.response.FeedItemDto;
+import com.offmode.boundedcontext.feed.dto.response.FeedStatsDto;
+import com.offmode.boundedcontext.feed.entity.Verification;
+import com.offmode.boundedcontext.feed.service.FeedService;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedItemDto.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedItemDto.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.feed.app.dto.response;
+package com.offmode.boundedcontext.feed.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedStatsDto.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedStatsDto.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.feed.app.dto.response;
+package com.offmode.boundedcontext.feed.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/ReactionSummaryDto.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/ReactionSummaryDto.java
@@ -1,3 +1,3 @@
-package com.offmode.boundedcontext.feed.app.dto.response;
+package com.offmode.boundedcontext.feed.dto.response;
 
 public record ReactionSummaryDto(String emoji, long count, boolean myReact) {}

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/entity/Reaction.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/entity/Reaction.java
@@ -1,6 +1,6 @@
-package com.offmode.boundedcontext.feed.domain.entity;
+package com.offmode.boundedcontext.feed.entity;
 
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.user.entity.User;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/entity/Verification.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/entity/Verification.java
@@ -1,7 +1,7 @@
-package com.offmode.boundedcontext.feed.domain.entity;
+package com.offmode.boundedcontext.feed.entity;
 
-import com.offmode.boundedcontext.mission.domain.entity.UserMission;
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.user.entity.User;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/entity/VerificationConfirm.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/entity/VerificationConfirm.java
@@ -1,6 +1,6 @@
-package com.offmode.boundedcontext.feed.domain.entity;
+package com.offmode.boundedcontext.feed.entity;
 
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.user.entity.User;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/repository/ReactionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/repository/ReactionRepository.java
@@ -1,6 +1,6 @@
-package com.offmode.boundedcontext.feed.out.repository;
+package com.offmode.boundedcontext.feed.repository;
 
-import com.offmode.boundedcontext.feed.domain.entity.Reaction;
+import com.offmode.boundedcontext.feed.entity.Reaction;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/repository/VerificationConfirmRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/repository/VerificationConfirmRepository.java
@@ -1,6 +1,6 @@
-package com.offmode.boundedcontext.feed.out.repository;
+package com.offmode.boundedcontext.feed.repository;
 
-import com.offmode.boundedcontext.feed.domain.entity.VerificationConfirm;
+import com.offmode.boundedcontext.feed.entity.VerificationConfirm;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/repository/VerificationRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/repository/VerificationRepository.java
@@ -1,7 +1,7 @@
-package com.offmode.boundedcontext.feed.out.repository;
+package com.offmode.boundedcontext.feed.repository;
 
-import com.offmode.boundedcontext.feed.app.dto.response.FeedItemDto;
-import com.offmode.boundedcontext.feed.domain.entity.Verification;
+import com.offmode.boundedcontext.feed.dto.response.FeedItemDto;
+import com.offmode.boundedcontext.feed.entity.Verification;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,7 +15,7 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
 
   @Query(
       """
-        SELECT new com.offmode.boundedcontext.feed.app.dto.response.FeedItemDto(
+        SELECT new com.offmode.boundedcontext.feed.dto.response.FeedItemDto(
             v.id, v.photoUrl, v.caption, v.createdAt,
             u.name, u.avatar, u.level,
             um.missionIcon, um.missionText, um.missionCategory,

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
@@ -1,20 +1,22 @@
-package com.offmode.boundedcontext.feed.app.service;
+package com.offmode.boundedcontext.feed.service;
 
-import com.offmode.boundedcontext.badge.app.service.BadgeService;
-import com.offmode.boundedcontext.feed.app.dto.response.FeedItemDto;
-import com.offmode.boundedcontext.feed.app.dto.response.FeedStatsDto;
-import com.offmode.boundedcontext.feed.app.dto.response.ReactionSummaryDto;
-import com.offmode.boundedcontext.feed.domain.entity.Reaction;
-import com.offmode.boundedcontext.feed.domain.entity.Verification;
-import com.offmode.boundedcontext.feed.domain.entity.VerificationConfirm;
-import com.offmode.boundedcontext.feed.out.repository.ReactionRepository;
-import com.offmode.boundedcontext.feed.out.repository.VerificationConfirmRepository;
-import com.offmode.boundedcontext.feed.out.repository.VerificationRepository;
-import com.offmode.boundedcontext.mission.domain.entity.UserMission;
-import com.offmode.boundedcontext.mission.out.repository.UserMissionRepository;
-import com.offmode.boundedcontext.user.app.dto.response.UserStatsDto;
-import com.offmode.boundedcontext.user.app.service.UserService;
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.badge.service.BadgeService;
+import com.offmode.boundedcontext.feed.dto.response.FeedItemDto;
+import com.offmode.boundedcontext.feed.dto.response.FeedStatsDto;
+import com.offmode.boundedcontext.feed.dto.response.ReactionSummaryDto;
+import com.offmode.boundedcontext.feed.entity.Reaction;
+import com.offmode.boundedcontext.feed.entity.Verification;
+import com.offmode.boundedcontext.feed.entity.VerificationConfirm;
+import com.offmode.boundedcontext.feed.repository.ReactionRepository;
+import com.offmode.boundedcontext.feed.repository.VerificationConfirmRepository;
+import com.offmode.boundedcontext.feed.repository.VerificationRepository;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.user.dto.response.UserStatsDto;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.service.UserService;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.status.ErrorStatus;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -66,14 +68,14 @@ public class FeedService {
     UserMission mission =
         userMissionRepository
             .findById(userMissionId)
-            .orElseThrow(() -> new RuntimeException("미션 없음"));
+            .orElseThrow(() -> new BusinessException(ErrorStatus.MISSION_NOT_FOUND));
 
     if (!mission.getUser().getId().equals(userId)) {
-      throw new RuntimeException("권한 없음");
+      throw new BusinessException(ErrorStatus.AUTH_ACCESS_DENIED);
     }
 
     if (verificationRepository.existsByUserMissionId(userMissionId)) {
-      throw new RuntimeException("이미 인증 사진을 올린 미션입니다");
+      throw new BusinessException(ErrorStatus.VERIFICATION_ALREADY_SUBMITTED);
     }
 
     // 사진 저장 (R2 우선, 없으면 로컬)
@@ -117,16 +119,16 @@ public class FeedService {
     Verification v =
         verificationRepository
             .findById(verificationId)
-            .orElseThrow(() -> new RuntimeException("인증 없음"));
+            .orElseThrow(() -> new BusinessException(ErrorStatus.VERIFICATION_NOT_FOUND));
 
     // 본인 인증은 불가
     if (v.getUser().getId().equals(userId)) {
-      throw new RuntimeException("자신의 인증은 확인할 수 없습니다");
+      throw new BusinessException(ErrorStatus.VERIFICATION_SELF_CONFIRM_NOT_ALLOWED);
     }
 
     // 이미 인증해줬는지 확인
     if (confirmRepository.existsByVerificationIdAndUserId(verificationId, userId)) {
-      throw new RuntimeException("이미 인증해준 게시물입니다");
+      throw new BusinessException(ErrorStatus.VERIFICATION_ALREADY_CONFIRMED);
     }
 
     User confirmer = userService.getById(userId);
@@ -155,7 +157,7 @@ public class FeedService {
     Verification v =
         verificationRepository
             .findById(verificationId)
-            .orElseThrow(() -> new RuntimeException("인증 없음"));
+            .orElseThrow(() -> new BusinessException(ErrorStatus.VERIFICATION_NOT_FOUND));
 
     reactionRepository
         .findByVerificationIdAndUserIdAndEmoji(verificationId, userId, emoji)

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/api/v1/MissionController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/api/v1/MissionController.java
@@ -1,10 +1,10 @@
-package com.offmode.boundedcontext.mission.in.api.v1;
+package com.offmode.boundedcontext.mission.api.v1;
 
-import com.offmode.boundedcontext.mission.app.dto.response.MissionWeightDto;
-import com.offmode.boundedcontext.mission.app.dto.response.UserMissionDto;
-import com.offmode.boundedcontext.mission.app.service.MissionService;
-import com.offmode.boundedcontext.mission.domain.entity.Mission;
-import com.offmode.boundedcontext.mission.domain.entity.UserMission;
+import com.offmode.boundedcontext.mission.dto.response.MissionWeightDto;
+import com.offmode.boundedcontext.mission.dto.response.UserMissionDto;
+import com.offmode.boundedcontext.mission.entity.Mission;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.service.MissionService;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/MissionWeightDto.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/MissionWeightDto.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.mission.app.dto.response;
+package com.offmode.boundedcontext.mission.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/UserMissionDto.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/UserMissionDto.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.mission.app.dto.response;
+package com.offmode.boundedcontext.mission.dto.response;
 
 import java.time.LocalDateTime;
 

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/entity/Mission.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/entity/Mission.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.mission.domain.entity;
+package com.offmode.boundedcontext.mission.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/entity/UserMission.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/entity/UserMission.java
@@ -1,7 +1,7 @@
-package com.offmode.boundedcontext.mission.domain.entity;
+package com.offmode.boundedcontext.mission.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.user.entity.User;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/repository/MissionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/repository/MissionRepository.java
@@ -1,6 +1,6 @@
-package com.offmode.boundedcontext.mission.out.repository;
+package com.offmode.boundedcontext.mission.repository;
 
-import com.offmode.boundedcontext.mission.domain.entity.Mission;
+import com.offmode.boundedcontext.mission.entity.Mission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {}

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/repository/UserMissionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/repository/UserMissionRepository.java
@@ -1,7 +1,7 @@
-package com.offmode.boundedcontext.mission.out.repository;
+package com.offmode.boundedcontext.mission.repository;
 
-import com.offmode.boundedcontext.mission.app.dto.response.UserMissionDto;
-import com.offmode.boundedcontext.mission.domain.entity.UserMission;
+import com.offmode.boundedcontext.mission.dto.response.UserMissionDto;
+import com.offmode.boundedcontext.mission.entity.UserMission;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -48,12 +48,12 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
   // 오늘 미션 + 인증 사진/캡션 포함
   @Query(
       """
-        SELECT new com.offmode.boundedcontext.mission.app.dto.response.UserMissionDto(
+        SELECT new com.offmode.boundedcontext.mission.dto.response.UserMissionDto(
             um.id, um.missionIcon, um.missionText, um.missionCategory,
             um.status, um.assignedAt, um.verifiedAt, v.photoUrl, v.caption
         )
         FROM UserMission um
-        LEFT JOIN com.offmode.boundedcontext.feed.domain.entity.Verification v ON v.userMission = um
+        LEFT JOIN com.offmode.boundedcontext.feed.entity.Verification v ON v.userMission = um
         WHERE um.user.id = :userId AND um.assignedAt >= :start AND um.assignedAt < :end
         ORDER BY um.assignedAt DESC
     """)
@@ -70,12 +70,12 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
   // 히스토리 + 인증 사진 포함
   @Query(
       """
-        SELECT new com.offmode.boundedcontext.mission.app.dto.response.UserMissionDto(
+        SELECT new com.offmode.boundedcontext.mission.dto.response.UserMissionDto(
             um.id, um.missionIcon, um.missionText, um.missionCategory,
             um.status, um.assignedAt, um.verifiedAt, v.photoUrl, v.caption
         )
         FROM UserMission um
-        LEFT JOIN com.offmode.boundedcontext.feed.domain.entity.Verification v ON v.userMission = um
+        LEFT JOIN com.offmode.boundedcontext.feed.entity.Verification v ON v.userMission = um
         WHERE um.user.id = :userId
         ORDER BY um.assignedAt DESC
     """)

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
@@ -1,14 +1,14 @@
-package com.offmode.boundedcontext.mission.app.service;
+package com.offmode.boundedcontext.mission.service;
 
-import com.offmode.boundedcontext.badge.app.service.BadgeService;
-import com.offmode.boundedcontext.mission.app.dto.response.MissionWeightDto;
-import com.offmode.boundedcontext.mission.app.dto.response.UserMissionDto;
-import com.offmode.boundedcontext.mission.domain.entity.Mission;
-import com.offmode.boundedcontext.mission.domain.entity.UserMission;
-import com.offmode.boundedcontext.mission.out.repository.MissionRepository;
-import com.offmode.boundedcontext.mission.out.repository.UserMissionRepository;
-import com.offmode.boundedcontext.user.domain.entity.User;
-import com.offmode.boundedcontext.user.out.repository.UserRepository;
+import com.offmode.boundedcontext.badge.service.BadgeService;
+import com.offmode.boundedcontext.mission.dto.response.MissionWeightDto;
+import com.offmode.boundedcontext.mission.dto.response.UserMissionDto;
+import com.offmode.boundedcontext.mission.entity.Mission;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.repository.MissionRepository;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;

--- a/backend/src/main/java/com/offmode/boundedcontext/user/api/v1/UserController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/api/v1/UserController.java
@@ -1,8 +1,8 @@
-package com.offmode.boundedcontext.user.in.api.v1;
+package com.offmode.boundedcontext.user.api.v1;
 
-import com.offmode.boundedcontext.user.app.dto.response.UserStatsDto;
-import com.offmode.boundedcontext.user.app.service.UserService;
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.user.dto.response.UserStatsDto;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.service.UserService;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/com/offmode/boundedcontext/user/dto/response/UserStatsDto.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/dto/response/UserStatsDto.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.user.app.dto.response;
+package com.offmode.boundedcontext.user.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/src/main/java/com/offmode/boundedcontext/user/entity/User.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/entity/User.java
@@ -1,4 +1,4 @@
-package com.offmode.boundedcontext.user.domain.entity;
+package com.offmode.boundedcontext.user.entity;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/offmode/boundedcontext/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package com.offmode.boundedcontext.user.out.repository;
+package com.offmode.boundedcontext.user.repository;
 
-import com.offmode.boundedcontext.user.domain.entity.User;
+import com.offmode.boundedcontext.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
@@ -1,13 +1,15 @@
-package com.offmode.boundedcontext.user.app.service;
+package com.offmode.boundedcontext.user.service;
 
-import com.offmode.boundedcontext.badge.out.repository.UserBadgeRepository;
-import com.offmode.boundedcontext.feed.out.repository.ReactionRepository;
-import com.offmode.boundedcontext.feed.out.repository.VerificationConfirmRepository;
-import com.offmode.boundedcontext.feed.out.repository.VerificationRepository;
-import com.offmode.boundedcontext.mission.out.repository.UserMissionRepository;
-import com.offmode.boundedcontext.user.app.dto.response.UserStatsDto;
-import com.offmode.boundedcontext.user.domain.entity.User;
-import com.offmode.boundedcontext.user.out.repository.UserRepository;
+import com.offmode.boundedcontext.badge.repository.UserBadgeRepository;
+import com.offmode.boundedcontext.feed.repository.ReactionRepository;
+import com.offmode.boundedcontext.feed.repository.VerificationConfirmRepository;
+import com.offmode.boundedcontext.feed.repository.VerificationRepository;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.user.dto.response.UserStatsDto;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.status.ErrorStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,7 +31,9 @@ public class UserService {
   private final UserBadgeRepository userBadgeRepository;
 
   public User getById(Long id) {
-    return userRepository.findById(id).orElseThrow(() -> new RuntimeException("유저 없음"));
+    return userRepository
+        .findById(id)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
   }
 
   @Transactional

--- a/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
@@ -45,12 +45,10 @@ public class SecurityConfig {
                 exception
                     .authenticationEntryPoint(
                         (request, response, authException) ->
-                            writeErrorResponse(
-                                response, ErrorStatus.UNAUTHORIZED, request.getRequestURI()))
+                            writeErrorResponse(response, ErrorStatus.UNAUTHORIZED))
                     .accessDeniedHandler(
                         (request, response, accessDeniedException) ->
-                            writeErrorResponse(
-                                response, ErrorStatus.AUTH_ACCESS_DENIED, request.getRequestURI())))
+                            writeErrorResponse(response, ErrorStatus.AUTH_ACCESS_DENIED)))
         .headers(h -> h.frameOptions(FrameOptionsConfig::disable)) // H2 콘솔용
         .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
@@ -68,8 +66,7 @@ public class SecurityConfig {
     return source;
   }
 
-  private void writeErrorResponse(
-      HttpServletResponse response, ErrorStatus errorStatus, String path)
+  private void writeErrorResponse(HttpServletResponse response, ErrorStatus errorStatus)
       throws java.io.IOException {
     response.setStatus(errorStatus.getHttpStatus().value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
@@ -1,13 +1,19 @@
 package com.offmode.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.offmode.global.dto.response.ApiResponse;
 import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -21,6 +27,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
   private final JwtAuthFilter jwtAuthFilter;
+  private final ObjectMapper objectMapper;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -33,7 +40,18 @@ public class SecurityConfig {
                     .permitAll()
                     .anyRequest()
                     .authenticated())
-        .headers(h -> h.frameOptions(f -> f.disable())) // H2 콘솔용
+        .exceptionHandling(
+            exception ->
+                exception
+                    .authenticationEntryPoint(
+                        (request, response, authException) ->
+                            writeErrorResponse(
+                                response, ErrorStatus.UNAUTHORIZED, request.getRequestURI()))
+                    .accessDeniedHandler(
+                        (request, response, accessDeniedException) ->
+                            writeErrorResponse(
+                                response, ErrorStatus.AUTH_ACCESS_DENIED, request.getRequestURI())))
+        .headers(h -> h.frameOptions(FrameOptionsConfig::disable)) // H2 콘솔용
         .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }
@@ -48,5 +66,14 @@ public class SecurityConfig {
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", config);
     return source;
+  }
+
+  private void writeErrorResponse(
+      HttpServletResponse response, ErrorStatus errorStatus, String path)
+      throws java.io.IOException {
+    response.setStatus(errorStatus.getHttpStatus().value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    objectMapper.writeValue(response.getWriter(), ApiResponse.onFailure(errorStatus).getBody());
   }
 }

--- a/backend/src/main/java/com/offmode/global/dto/response/ApiResponse.java
+++ b/backend/src/main/java/com/offmode/global/dto/response/ApiResponse.java
@@ -1,0 +1,42 @@
+package com.offmode.global.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.offmode.global.status.ErrorStatus;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+  private final Boolean isSuccess;
+  private final String code;
+  private final String message;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final T result;
+
+  private ApiResponse(Boolean isSuccess, String code, String message, T result) {
+    this.isSuccess = isSuccess;
+    this.code = code;
+    this.message = message;
+    this.result = result;
+  }
+
+  public static ResponseEntity<ApiResponse<?>> onFailure(ErrorStatus error) {
+    return new ResponseEntity<>(
+        new ApiResponse<>(false, error.getCode(), error.getMessage(), null), error.getHttpStatus());
+  }
+
+  public static ResponseEntity<ApiResponse<?>> onFailure(ErrorStatus error, String message) {
+    return new ResponseEntity<>(
+        new ApiResponse<>(false, error.getCode(), error.getMessage(message), null),
+        error.getHttpStatus());
+  }
+
+  public static ResponseEntity<ApiResponse<?>> onFailure(ErrorStatus error, Object data) {
+    return new ResponseEntity<>(
+        new ApiResponse<>(false, error.getCode(), error.getMessage(), data), error.getHttpStatus());
+  }
+}

--- a/backend/src/main/java/com/offmode/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/offmode/global/exception/BusinessException.java
@@ -9,18 +9,6 @@ public class BusinessException extends RuntimeException {
   private final ErrorStatus errorStatus;
   private final Object data;
 
-  public BusinessException(String message) {
-    super(message);
-    this.errorStatus = ErrorStatus.INTERNAL_SERVER_ERROR;
-    this.data = null;
-  }
-
-  public BusinessException(String message, Throwable cause) {
-    super(message, cause);
-    this.errorStatus = ErrorStatus.INTERNAL_SERVER_ERROR;
-    this.data = null;
-  }
-
   public BusinessException(ErrorStatus errorStatus) {
     super(errorStatus.getMessage());
     this.errorStatus = errorStatus;

--- a/backend/src/main/java/com/offmode/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/offmode/global/exception/BusinessException.java
@@ -1,0 +1,41 @@
+package com.offmode.global.exception;
+
+import com.offmode.global.status.ErrorStatus;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final ErrorStatus errorStatus;
+  private final Object data;
+
+  public BusinessException(String message) {
+    super(message);
+    this.errorStatus = ErrorStatus.INTERNAL_SERVER_ERROR;
+    this.data = null;
+  }
+
+  public BusinessException(String message, Throwable cause) {
+    super(message, cause);
+    this.errorStatus = ErrorStatus.INTERNAL_SERVER_ERROR;
+    this.data = null;
+  }
+
+  public BusinessException(ErrorStatus errorStatus) {
+    super(errorStatus.getMessage());
+    this.errorStatus = errorStatus;
+    this.data = null;
+  }
+
+  public BusinessException(ErrorStatus errorStatus, Object data) {
+    super(errorStatus.getMessage());
+    this.errorStatus = errorStatus;
+    this.data = data;
+  }
+
+  public BusinessException(ErrorStatus errorStatus, Throwable cause) {
+    super(errorStatus.getMessage(), cause);
+    this.errorStatus = errorStatus;
+    this.data = null;
+  }
+}

--- a/backend/src/main/java/com/offmode/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/offmode/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,60 @@
+package com.offmode.global.exception;
+
+import com.offmode.global.dto.response.ApiResponse;
+import com.offmode.global.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MultipartException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ApiResponse<?>> handleBusinessException(BusinessException e) {
+    log.warn("Business exception: {}", e.getMessage());
+
+    if (e.getData() != null) {
+      return ApiResponse.onFailure(e.getErrorStatus(), e.getData());
+    }
+
+    return ApiResponse.onFailure(e.getErrorStatus(), e.getMessage());
+  }
+
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ApiResponse<?>> handleAuthenticationException(AuthenticationException e) {
+    return ApiResponse.onFailure(ErrorStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ApiResponse<?>> handleAccessDeniedException(AccessDeniedException e) {
+    return ApiResponse.onFailure(ErrorStatus.AUTH_ACCESS_DENIED);
+  }
+
+  @ExceptionHandler({
+    HttpMessageNotReadableException.class,
+    MethodArgumentNotValidException.class,
+    MethodArgumentTypeMismatchException.class,
+    MissingServletRequestParameterException.class,
+    MultipartException.class,
+    IllegalArgumentException.class
+  })
+  public ResponseEntity<ApiResponse<?>> handleBadRequest(Exception e) {
+    return ApiResponse.onFailure(ErrorStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiResponse<?>> handleException(Exception e, HttpServletRequest request) {
+    log.error("Unhandled exception on path={}", request.getRequestURI(), e);
+    return ApiResponse.onFailure(ErrorStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/backend/src/main/java/com/offmode/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/offmode/global/exception/GlobalExceptionHandler.java
@@ -40,10 +40,20 @@ public class GlobalExceptionHandler {
     return ApiResponse.onFailure(ErrorStatus.AUTH_ACCESS_DENIED);
   }
 
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
+    return ApiResponse.onFailure(ErrorStatus.VALIDATION_ERROR);
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ApiResponse<?>> handleMethodArgumentTypeMismatchException(
+      MethodArgumentTypeMismatchException e) {
+    return ApiResponse.onFailure(ErrorStatus.VALIDATION_ERROR);
+  }
+
   @ExceptionHandler({
     HttpMessageNotReadableException.class,
-    MethodArgumentNotValidException.class,
-    MethodArgumentTypeMismatchException.class,
     MissingServletRequestParameterException.class,
     MultipartException.class,
     IllegalArgumentException.class

--- a/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
+++ b/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
@@ -1,0 +1,45 @@
+package com.offmode.global.status;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus {
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러, 관리자에게 문의 바랍니다."),
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
+  VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALID_400_001", "입력값이 올바르지 않습니다."),
+
+  // Auth
+  AUTH_OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "OAuth 인증에 실패했습니다."),
+  AUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_403_001", "접근 권한이 없습니다."),
+
+  // User
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_001", "해당 사용자를 찾을 수 없습니다."),
+
+  // Mission
+  MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION_404_001", "해당 미션을 찾을 수 없습니다."),
+
+  // Verification
+  VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "VERIFICATION_404_001", "해당 인증을 찾을 수 없습니다."),
+  VERIFICATION_ALREADY_SUBMITTED(
+      HttpStatus.CONFLICT, "VERIFICATION_409_001", "이미 인증 사진을 올린 미션입니다."),
+  VERIFICATION_SELF_CONFIRM_NOT_ALLOWED(
+      HttpStatus.BAD_REQUEST, "VERIFICATION_400_001", "자신의 인증은 확인할 수 없습니다."),
+  VERIFICATION_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "VERIFICATION_409_002", "이미 인증해준 게시물입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  public String getMessage(String message) {
+    return Optional.ofNullable(message)
+        .filter(Predicate.not(String::isBlank))
+        .orElse(this.getMessage());
+  }
+}

--- a/backend/src/test/java/com/offmode/global/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/offmode/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,41 @@
+package com.offmode.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.offmode.global.dto.response.ApiResponse;
+import com.offmode.global.status.ErrorStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class GlobalExceptionHandlerTest {
+
+  private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+  @Test
+  void businessExceptionReturnsMappedStatusAndCode() {
+    ResponseEntity<ApiResponse<?>> response =
+        handler.handleBusinessException(
+            new BusinessException(ErrorStatus.VERIFICATION_ALREADY_CONFIRMED));
+
+    assertThat(response.getStatusCode())
+        .isEqualTo(ErrorStatus.VERIFICATION_ALREADY_CONFIRMED.getHttpStatus());
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getIsSuccess()).isFalse();
+    assertThat(response.getBody().getCode()).isEqualTo("VERIFICATION_409_002");
+  }
+
+  @Test
+  void unexpectedExceptionReturnsGenericServerError() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users/me");
+
+    ResponseEntity<ApiResponse<?>> response =
+        handler.handleException(new IllegalStateException("hidden detail"), request);
+
+    assertThat(response.getStatusCode())
+        .isEqualTo(ErrorStatus.INTERNAL_SERVER_ERROR.getHttpStatus());
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getCode()).isEqualTo("COMMON_500");
+    assertThat(response.getBody().getMessage()).isEqualTo("서버 에러, 관리자에게 문의 바랍니다.");
+  }
+}

--- a/backend/src/test/java/com/offmode/global/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/offmode/global/exception/GlobalExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import com.offmode.global.status.ErrorStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 class GlobalExceptionHandlerTest {
 
@@ -37,5 +38,18 @@ class GlobalExceptionHandlerTest {
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody().getCode()).isEqualTo("COMMON_500");
     assertThat(response.getBody().getMessage()).isEqualTo("서버 에러, 관리자에게 문의 바랍니다.");
+  }
+
+  @Test
+  void typeMismatchReturnsValidationError() {
+    MethodArgumentTypeMismatchException exception =
+        new MethodArgumentTypeMismatchException("abc", Long.class, "id", null, null);
+
+    ResponseEntity<ApiResponse<?>> response =
+        handler.handleMethodArgumentTypeMismatchException(exception);
+
+    assertThat(response.getStatusCode()).isEqualTo(ErrorStatus.VALIDATION_ERROR.getHttpStatus());
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getCode()).isEqualTo("VALID_400_001");
   }
 }


### PR DESCRIPTION
## 🔗 Issue

- close #2

---

## 📌 Summary

- `ErrorStatus`, `BusinessException`, `ApiResponse`, `GlobalExceptionHandler`를 추가해 API 에러 응답을 표준화했습니다.
- 인증/인가 실패와 핵심 서비스 예외를 일관된 HTTP status 및 에러 코드로 반환하도록 정리했습니다.
- `docs/ddd.md` 기준에 맞춰 패키지 선언과 실제 디렉토리 구조를 정리했습니다.

---

## ✅ Test

- [x] `./gradlew.bat clean build`