### PR TITLE
[Refactor] #3 요청 DTO 및 Validation 도입

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/badge/api/v1/BadgeController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/api/v1/BadgeController.java
@@ -1,6 +1,6 @@
 package com.offmode.boundedcontext.badge.api.v1;
 
-import com.offmode.boundedcontext.badge.dto.response.BadgeDto;
+import com.offmode.boundedcontext.badge.dto.response.BadgeResponse;
 import com.offmode.boundedcontext.badge.service.BadgeService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class BadgeController {
 
   // GET /api/badges/me  — 전체 배지 정의 + 획득 여부
   @GetMapping("/me")
-  public ResponseEntity<List<BadgeDto>> getMyBadges(@AuthenticationPrincipal Long userId) {
+  public ResponseEntity<List<BadgeResponse>> getMyBadges(@AuthenticationPrincipal Long userId) {
     return ResponseEntity.ok(badgeService.getUserBadges(userId));
   }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/badge/dto/response/BadgeResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/dto/response/BadgeResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
-public class BadgeDto {
+public class BadgeResponse {
   private final String key;
   private final String name;
   private final String badgeTitle;
@@ -16,7 +16,7 @@ public class BadgeDto {
   private final boolean earned;
   private final LocalDateTime earnedAt;
 
-  public BadgeDto(BadgeDefinition def, UserBadge userBadge) {
+  public BadgeResponse(BadgeDefinition def, UserBadge userBadge) {
     this.key = def.getKey();
     this.name = def.getName();
     this.badgeTitle = def.getBadgeTitle();

--- a/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
@@ -1,6 +1,6 @@
 package com.offmode.boundedcontext.badge.service;
 
-import com.offmode.boundedcontext.badge.dto.response.BadgeDto;
+import com.offmode.boundedcontext.badge.dto.response.BadgeResponse;
 import com.offmode.boundedcontext.badge.entity.UserBadge;
 import com.offmode.boundedcontext.badge.repository.UserBadgeRepository;
 import com.offmode.boundedcontext.badge.types.BadgeDefinition;
@@ -24,13 +24,13 @@ public class BadgeService {
   private final UserRepository userRepository;
 
   /** 모든 배지 정의 + 획득 여부 반환 */
-  public List<BadgeDto> getUserBadges(Long userId) {
+  public List<BadgeResponse> getUserBadges(Long userId) {
     Map<String, UserBadge> earned =
         userBadgeRepository.findByUserId(userId).stream()
             .collect(Collectors.toMap(UserBadge::getBadgeKey, ub -> ub));
 
     return Arrays.stream(BadgeDefinition.values())
-        .map(def -> new BadgeDto(def, earned.get(def.getKey())))
+        .map(def -> new BadgeResponse(def, earned.get(def.getKey())))
         .toList();
   }
 

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
@@ -1,11 +1,12 @@
 package com.offmode.boundedcontext.feed.api.v1;
 
+import com.offmode.boundedcontext.feed.dto.request.ReactRequest;
 import com.offmode.boundedcontext.feed.dto.response.FeedItemDto;
 import com.offmode.boundedcontext.feed.dto.response.FeedStatsDto;
 import com.offmode.boundedcontext.feed.entity.Verification;
 import com.offmode.boundedcontext.feed.service.FeedService;
+import jakarta.validation.Valid;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/v1/eed")
+@RequestMapping("/api/v1/feed")
 @RequiredArgsConstructor
 public class FeedController {
 
@@ -42,8 +43,8 @@ public class FeedController {
   public ResponseEntity<Void> react(
       @AuthenticationPrincipal Long userId,
       @PathVariable Long id,
-      @RequestBody Map<String, String> body) {
-    feedService.react(userId, id, body.get("emoji"));
+      @Valid @RequestBody ReactRequest request) {
+    feedService.react(userId, id, request.getEmoji());
     return ResponseEntity.ok().build();
   }
 

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
@@ -20,7 +20,7 @@ public class FeedController {
 
   private final FeedService feedService;
 
-  // POST /api/feed/verify
+  // POST /api/v1/feed/verify
   // multipart/form-data: photo (file), userMissionId, caption
   @PostMapping("/verify")
   public ResponseEntity<Verification> verify(
@@ -32,13 +32,13 @@ public class FeedController {
     return ResponseEntity.ok(feedService.verify(userId, userMissionId, photo, caption));
   }
 
-  // GET /api/feed/stats - 커뮤니티 통계
+  // GET /api/v1/feed/stats - 커뮤니티 통계
   @GetMapping("/stats")
   public ResponseEntity<FeedStatsResponse> getStats(@AuthenticationPrincipal Long userId) {
     return ResponseEntity.ok(feedService.getStats(userId));
   }
 
-  // POST /api/feed/{id}/react - 리액션 토글  body: { "emoji": "🔥" }
+  // POST /api/v1/feed/{id}/react - 리액션 토글  body: { "emoji": "🔥" }
   @PostMapping("/{id}/react")
   public ResponseEntity<Void> react(
       @AuthenticationPrincipal Long userId,
@@ -48,14 +48,14 @@ public class FeedController {
     return ResponseEntity.ok().build();
   }
 
-  // POST /api/feed/{id}/confirm - 피어 인증 (다른 사람의 인증 확인)
+  // POST /api/v1/feed/{id}/confirm - 피어 인증 (다른 사람의 인증 확인)
   @PostMapping("/{id}/confirm")
   public ResponseEntity<Void> confirm(@AuthenticationPrincipal Long userId, @PathVariable Long id) {
     feedService.confirm(userId, id);
     return ResponseEntity.ok().build();
   }
 
-  // GET /api/feed?page=0&size=20
+  // GET /api/v1/feed?page=0&size=20
   @GetMapping
   public ResponseEntity<List<FeedItemResponse>> getFeed(
       @AuthenticationPrincipal Long userId,

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
@@ -1,8 +1,8 @@
 package com.offmode.boundedcontext.feed.api.v1;
 
 import com.offmode.boundedcontext.feed.dto.request.ReactRequest;
-import com.offmode.boundedcontext.feed.dto.response.FeedItemDto;
-import com.offmode.boundedcontext.feed.dto.response.FeedStatsDto;
+import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
+import com.offmode.boundedcontext.feed.dto.response.FeedStatsResponse;
 import com.offmode.boundedcontext.feed.entity.Verification;
 import com.offmode.boundedcontext.feed.service.FeedService;
 import jakarta.validation.Valid;
@@ -34,7 +34,7 @@ public class FeedController {
 
   // GET /api/feed/stats - 커뮤니티 통계
   @GetMapping("/stats")
-  public ResponseEntity<FeedStatsDto> getStats(@AuthenticationPrincipal Long userId) {
+  public ResponseEntity<FeedStatsResponse> getStats(@AuthenticationPrincipal Long userId) {
     return ResponseEntity.ok(feedService.getStats(userId));
   }
 
@@ -57,7 +57,7 @@ public class FeedController {
 
   // GET /api/feed?page=0&size=20
   @GetMapping
-  public ResponseEntity<List<FeedItemDto>> getFeed(
+  public ResponseEntity<List<FeedItemResponse>> getFeed(
       @AuthenticationPrincipal Long userId,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int size) {

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/request/ReactRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/request/ReactRequest.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class ReactRequest {
 
   @NotBlank
-  @Size(max = 16)
+  @Size(max = 10)
   private String emoji;
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/request/ReactRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/request/ReactRequest.java
@@ -1,0 +1,13 @@
+package com.offmode.boundedcontext.feed.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ReactRequest {
+
+  @NotBlank
+  @Size(max = 16)
+  private String emoji;
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedItemResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedItemResponse.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 
 @Getter
 @AllArgsConstructor
-public class FeedItemDto {
+public class FeedItemResponse {
   private Long id;
   private String photoUrl;
   private String caption;
@@ -27,5 +27,5 @@ public class FeedItemDto {
   private boolean isOwn;
 
   // JPQL 쿼리 후 서비스에서 채움
-  @Setter private List<ReactionSummaryDto> reactions;
+  @Setter private List<ReactionSummaryResponse> reactions;
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedStatsResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedStatsResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class FeedStatsDto {
+public class FeedStatsResponse {
   private long activeToday; // 오늘 미션을 수락한 유저 수
   private int verificationRate; // 전체 인증 완료율 (%)
   private int streakDays; // 현재 유저의 연속 달성 일수

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/ReactionSummaryDto.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/ReactionSummaryDto.java
@@ -1,3 +1,0 @@
-package com.offmode.boundedcontext.feed.dto.response;
-
-public record ReactionSummaryDto(String emoji, long count, boolean myReact) {}

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/ReactionSummaryResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/ReactionSummaryResponse.java
@@ -1,0 +1,3 @@
+package com.offmode.boundedcontext.feed.dto.response;
+
+public record ReactionSummaryResponse(String emoji, long count, boolean myReact) {}

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/repository/VerificationRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/repository/VerificationRepository.java
@@ -1,6 +1,6 @@
 package com.offmode.boundedcontext.feed.repository;
 
-import com.offmode.boundedcontext.feed.dto.response.FeedItemDto;
+import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
 import com.offmode.boundedcontext.feed.entity.Verification;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +15,7 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
 
   @Query(
       """
-        SELECT new com.offmode.boundedcontext.feed.dto.response.FeedItemDto(
+        SELECT new com.offmode.boundedcontext.feed.dto.response.FeedItemResponse(
             v.id, v.photoUrl, v.caption, v.createdAt,
             u.name, u.avatar, u.level,
             um.missionIcon, um.missionText, um.missionCategory,
@@ -30,7 +30,7 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
         WHERE um.missionText = :missionText
         ORDER BY v.createdAt DESC
     """)
-  List<FeedItemDto> findFeedItems(
+  List<FeedItemResponse> findFeedItems(
       Pageable pageable, @Param("userId") Long userId, @Param("missionText") String missionText);
 
   // 유저의 verification 삭제 (user_id 기준)

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
@@ -1,9 +1,9 @@
 package com.offmode.boundedcontext.feed.service;
 
 import com.offmode.boundedcontext.badge.service.BadgeService;
-import com.offmode.boundedcontext.feed.dto.response.FeedItemDto;
-import com.offmode.boundedcontext.feed.dto.response.FeedStatsDto;
-import com.offmode.boundedcontext.feed.dto.response.ReactionSummaryDto;
+import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
+import com.offmode.boundedcontext.feed.dto.response.FeedStatsResponse;
+import com.offmode.boundedcontext.feed.dto.response.ReactionSummaryResponse;
 import com.offmode.boundedcontext.feed.entity.Reaction;
 import com.offmode.boundedcontext.feed.entity.Verification;
 import com.offmode.boundedcontext.feed.entity.VerificationConfirm;
@@ -12,7 +12,7 @@ import com.offmode.boundedcontext.feed.repository.VerificationConfirmRepository;
 import com.offmode.boundedcontext.feed.repository.VerificationRepository;
 import com.offmode.boundedcontext.mission.entity.UserMission;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
-import com.offmode.boundedcontext.user.dto.response.UserStatsDto;
+import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
@@ -170,7 +170,7 @@ public class FeedService {
             });
   }
 
-  public List<FeedItemDto> getFeed(Long userId, int page, int size) {
+  public List<FeedItemResponse> getFeed(Long userId, int page, int size) {
     // 오늘 내 미션 텍스트 조회 — 없으면 빈 피드 반환
     LocalDateTime todayStart = LocalDate.now().atStartOfDay();
     LocalDateTime todayEnd = LocalDate.now().plusDays(1).atStartOfDay();
@@ -188,17 +188,17 @@ public class FeedService {
     if (todayMission == null) return List.of();
 
     String missionText = todayMission.getMissionText();
-    List<FeedItemDto> items =
+    List<FeedItemResponse> items =
         verificationRepository.findFeedItems(PageRequest.of(page, size), userId, missionText);
     log.info("[GET-FEED] 필터 missionText='{}' → 조회된 피드 {}건", missionText, items.size());
     if (items.isEmpty()) return items;
 
     // 한 번의 쿼리로 전체 리액션 요약 조회
-    List<Long> ids = items.stream().map(FeedItemDto::getId).toList();
+    List<Long> ids = items.stream().map(FeedItemResponse::getId).toList();
     List<Object[]> rows = reactionRepository.findSummaries(ids, userId);
 
-    // verificationId → List<ReactionSummaryDto> 맵 구성
-    Map<Long, List<ReactionSummaryDto>> reactionMap = new java.util.HashMap<>();
+    // verificationId → List<ReactionSummaryResponse> 맵 구성
+    Map<Long, List<ReactionSummaryResponse>> reactionMap = new java.util.HashMap<>();
     for (Object[] row : rows) {
       Long vId = (Long) row[0];
       String emoji = (String) row[1];
@@ -206,7 +206,7 @@ public class FeedService {
       boolean myReact = ((Number) row[3]).longValue() > 0;
       reactionMap
           .computeIfAbsent(vId, k -> new java.util.ArrayList<>())
-          .add(new ReactionSummaryDto(emoji, count, myReact));
+          .add(new ReactionSummaryResponse(emoji, count, myReact));
     }
 
     items.forEach(
@@ -214,7 +214,7 @@ public class FeedService {
     return items;
   }
 
-  public FeedStatsDto getStats(Long userId) {
+  public FeedStatsResponse getStats(Long userId) {
     // 오늘 자정부터 현재까지 미션을 수락한 유저 수
     LocalDateTime todayStart = LocalDateTime.now().toLocalDate().atStartOfDay();
     long activeToday = userMissionRepository.countDistinctUsersSince(todayStart);
@@ -225,10 +225,10 @@ public class FeedService {
     int verificationRate = total == 0 ? 0 : (int) (verified * 100 / total);
 
     // 현재 유저 연속 달성 일수 (UserService의 getStats 재활용)
-    UserStatsDto userStats = userService.getStats(userId);
+    UserStatsResponse userStats = userService.getStats(userId);
     int streakDays = userStats.getStreak();
 
-    return new FeedStatsDto(activeToday, verificationRate, streakDays);
+    return new FeedStatsResponse(activeToday, verificationRate, streakDays);
   }
 
   private String getExtension(String filename) {

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/api/v1/MissionController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/api/v1/MissionController.java
@@ -1,8 +1,8 @@
 package com.offmode.boundedcontext.mission.api.v1;
 
 import com.offmode.boundedcontext.mission.dto.request.SetTodayMissionRequest;
-import com.offmode.boundedcontext.mission.dto.response.MissionWeightDto;
-import com.offmode.boundedcontext.mission.dto.response.UserMissionDto;
+import com.offmode.boundedcontext.mission.dto.response.MissionWeightResponse;
+import com.offmode.boundedcontext.mission.dto.response.UserMissionResponse;
 import com.offmode.boundedcontext.mission.entity.Mission;
 import com.offmode.boundedcontext.mission.entity.UserMission;
 import com.offmode.boundedcontext.mission.service.MissionService;
@@ -22,8 +22,8 @@ public class MissionController {
 
   // GET /api/missions/today
   @GetMapping("/today")
-  public ResponseEntity<UserMissionDto> today(@AuthenticationPrincipal Long userId) {
-    UserMissionDto mission = missionService.getTodayMissionDto(userId);
+  public ResponseEntity<UserMissionResponse> today(@AuthenticationPrincipal Long userId) {
+    UserMissionResponse mission = missionService.getTodayMissionResponse(userId);
     if (mission == null) return ResponseEntity.noContent().build();
     return ResponseEntity.ok(mission);
   }
@@ -40,7 +40,7 @@ public class MissionController {
 
   // GET /api/missions/history
   @GetMapping("/history")
-  public ResponseEntity<List<UserMissionDto>> history(@AuthenticationPrincipal Long userId) {
+  public ResponseEntity<List<UserMissionResponse>> history(@AuthenticationPrincipal Long userId) {
     return ResponseEntity.ok(missionService.getHistory(userId));
   }
 
@@ -53,7 +53,8 @@ public class MissionController {
   // GET /api/missions/weighted-pool
   // 사용자의 최근 수행 이력 기반으로 weight 가 낮은 미션은 룰렛에서 뽑힐 확률이 낮음
   @GetMapping("/weighted-pool")
-  public ResponseEntity<List<MissionWeightDto>> weightedPool(@AuthenticationPrincipal Long userId) {
+  public ResponseEntity<List<MissionWeightResponse>> weightedPool(
+      @AuthenticationPrincipal Long userId) {
     return ResponseEntity.ok(missionService.getWeightedPool(userId));
   }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/api/v1/MissionController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/api/v1/MissionController.java
@@ -1,12 +1,13 @@
 package com.offmode.boundedcontext.mission.api.v1;
 
+import com.offmode.boundedcontext.mission.dto.request.SetTodayMissionRequest;
 import com.offmode.boundedcontext.mission.dto.response.MissionWeightDto;
 import com.offmode.boundedcontext.mission.dto.response.UserMissionDto;
 import com.offmode.boundedcontext.mission.entity.Mission;
 import com.offmode.boundedcontext.mission.entity.UserMission;
 import com.offmode.boundedcontext.mission.service.MissionService;
+import jakarta.validation.Valid;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,10 +31,10 @@ public class MissionController {
   // POST /api/missions/today  body: { "icon": "...", "text": "...", "category": "..." }
   @PostMapping("/today")
   public ResponseEntity<UserMission> setToday(
-      @AuthenticationPrincipal Long userId, @RequestBody Map<String, String> body) {
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody SetTodayMissionRequest request) {
     UserMission mission =
         missionService.setTodayMission(
-            userId, body.get("icon"), body.get("text"), body.get("category"));
+            userId, request.getIcon(), request.getText(), request.getCategory());
     return ResponseEntity.ok(mission);
   }
 

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/request/SetTodayMissionRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/request/SetTodayMissionRequest.java
@@ -1,0 +1,22 @@
+package com.offmode.boundedcontext.mission.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SetTodayMissionRequest {
+
+  @NotBlank
+  @Size(max = 16)
+  private String icon;
+
+  @NotBlank
+  @Size(max = 100)
+  private String text;
+
+  @NotBlank
+  @Pattern(regexp = "Energy|Intellect|Vitality")
+  private String category;
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/MissionWeightResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/MissionWeightResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class MissionWeightDto {
+public class MissionWeightResponse {
   private Long id;
   private String icon;
   private String text;

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/UserMissionResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/UserMissionResponse.java
@@ -2,7 +2,7 @@ package com.offmode.boundedcontext.mission.dto.response;
 
 import java.time.LocalDateTime;
 
-public record UserMissionDto(
+public record UserMissionResponse(
     Long id,
     String missionIcon,
     String missionText,

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/repository/UserMissionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/repository/UserMissionRepository.java
@@ -1,6 +1,6 @@
 package com.offmode.boundedcontext.mission.repository;
 
-import com.offmode.boundedcontext.mission.dto.response.UserMissionDto;
+import com.offmode.boundedcontext.mission.dto.response.UserMissionResponse;
 import com.offmode.boundedcontext.mission.entity.UserMission;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -48,7 +48,7 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
   // 오늘 미션 + 인증 사진/캡션 포함
   @Query(
       """
-        SELECT new com.offmode.boundedcontext.mission.dto.response.UserMissionDto(
+        SELECT new com.offmode.boundedcontext.mission.dto.response.UserMissionResponse(
             um.id, um.missionIcon, um.missionText, um.missionCategory,
             um.status, um.assignedAt, um.verifiedAt, v.photoUrl, v.caption
         )
@@ -57,7 +57,7 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
         WHERE um.user.id = :userId AND um.assignedAt >= :start AND um.assignedAt < :end
         ORDER BY um.assignedAt DESC
     """)
-  List<UserMissionDto> findTodayWithPhoto(
+  List<UserMissionResponse> findTodayWithPhoto(
       @Param("userId") Long userId,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);
@@ -70,7 +70,7 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
   // 히스토리 + 인증 사진 포함
   @Query(
       """
-        SELECT new com.offmode.boundedcontext.mission.dto.response.UserMissionDto(
+        SELECT new com.offmode.boundedcontext.mission.dto.response.UserMissionResponse(
             um.id, um.missionIcon, um.missionText, um.missionCategory,
             um.status, um.assignedAt, um.verifiedAt, v.photoUrl, v.caption
         )
@@ -79,7 +79,7 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
         WHERE um.user.id = :userId
         ORDER BY um.assignedAt DESC
     """)
-  List<UserMissionDto> findHistoryWithPhoto(@Param("userId") Long userId);
+  List<UserMissionResponse> findHistoryWithPhoto(@Param("userId") Long userId);
 
   @Modifying
   @Query("DELETE FROM UserMission um WHERE um.user.id = :userId")

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
@@ -1,8 +1,8 @@
 package com.offmode.boundedcontext.mission.service;
 
 import com.offmode.boundedcontext.badge.service.BadgeService;
-import com.offmode.boundedcontext.mission.dto.response.MissionWeightDto;
-import com.offmode.boundedcontext.mission.dto.response.UserMissionDto;
+import com.offmode.boundedcontext.mission.dto.response.MissionWeightResponse;
+import com.offmode.boundedcontext.mission.dto.response.UserMissionResponse;
 import com.offmode.boundedcontext.mission.entity.Mission;
 import com.offmode.boundedcontext.mission.entity.UserMission;
 import com.offmode.boundedcontext.mission.repository.MissionRepository;
@@ -42,11 +42,11 @@ public class MissionService {
   }
 
   // 오늘의 미션 조회 + 인증 사진/캡션 포함 (여러 개면 가장 최근 것)
-  public UserMissionDto getTodayMissionDto(Long userId) {
+  public UserMissionResponse getTodayMissionResponse(Long userId) {
     LocalDate today = LocalDate.now();
     LocalDateTime start = today.atStartOfDay();
     LocalDateTime end = today.plusDays(1).atStartOfDay();
-    UserMissionDto dto =
+    UserMissionResponse dto =
         userMissionRepository.findTodayWithPhoto(userId, start, end).stream()
             .findFirst()
             .orElse(null);
@@ -135,7 +135,7 @@ public class MissionService {
   }
 
   // 내 미션 기록 (최근 30개, 인증 사진 포함)
-  public List<UserMissionDto> getHistory(Long userId) {
+  public List<UserMissionResponse> getHistory(Long userId) {
     return userMissionRepository.findHistoryWithPhoto(userId).stream().limit(30).toList();
   }
 
@@ -149,7 +149,7 @@ public class MissionService {
   // - 7~14일: weight 0.3
   // - 14~30일: weight 0.5
   // - 30일 초과 or 미수행: weight 1.0
-  public List<MissionWeightDto> getWeightedPool(Long userId) {
+  public List<MissionWeightResponse> getWeightedPool(Long userId) {
     List<Mission> allMissions = missionRepository.findAll();
 
     Map<String, LocalDateTime> latestMap =
@@ -169,7 +169,7 @@ public class MissionService {
                 else if (daysSince < 14) weight = 0.3;
                 else if (daysSince < 30) weight = 0.5;
               }
-              return new MissionWeightDto(
+              return new MissionWeightResponse(
                   m.getId(), m.getIcon(), m.getText(), m.getCategory(), weight);
             })
         .toList();

--- a/backend/src/main/java/com/offmode/boundedcontext/user/api/v1/UserController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/api/v1/UserController.java
@@ -1,7 +1,7 @@
 package com.offmode.boundedcontext.user.api.v1;
 
 import com.offmode.boundedcontext.user.dto.request.UpdateUserProfileRequest;
-import com.offmode.boundedcontext.user.dto.response.UserStatsDto;
+import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.UserService;
 import jakarta.validation.Valid;
@@ -25,7 +25,7 @@ public class UserController {
 
   // GET /api/users/me/stats
   @GetMapping("/me/stats")
-  public ResponseEntity<UserStatsDto> getStats(@AuthenticationPrincipal Long userId) {
+  public ResponseEntity<UserStatsResponse> getStats(@AuthenticationPrincipal Long userId) {
     return ResponseEntity.ok(userService.getStats(userId));
   }
 

--- a/backend/src/main/java/com/offmode/boundedcontext/user/api/v1/UserController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/api/v1/UserController.java
@@ -1,9 +1,10 @@
 package com.offmode.boundedcontext.user.api.v1;
 
+import com.offmode.boundedcontext.user.dto.request.UpdateUserProfileRequest;
 import com.offmode.boundedcontext.user.dto.response.UserStatsDto;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.UserService;
-import java.util.Map;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -40,17 +41,15 @@ public class UserController {
   // true }
   @PutMapping("/me")
   public ResponseEntity<User> updateMe(
-      @AuthenticationPrincipal Long userId, @RequestBody Map<String, Object> body) {
-    String name = (String) body.get("name");
-    String avatar = (String) body.get("avatar");
-    Integer missionHour =
-        body.get("missionHour") != null ? ((Number) body.get("missionHour")).intValue() : null;
-    Integer missionMinute =
-        body.get("missionMinute") != null ? ((Number) body.get("missionMinute")).intValue() : null;
-    Boolean autoRoulette =
-        body.get("autoRoulette") != null ? (Boolean) body.get("autoRoulette") : null;
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody UpdateUserProfileRequest request) {
     User updated =
-        userService.updateProfile(userId, name, avatar, missionHour, missionMinute, autoRoulette);
+        userService.updateProfile(
+            userId,
+            request.getName(),
+            request.getAvatar(),
+            request.getMissionHour(),
+            request.getMissionMinute(),
+            request.getAutoRoulette());
     return ResponseEntity.ok(updated);
   }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/user/dto/request/UpdateUserProfileRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/dto/request/UpdateUserProfileRequest.java
@@ -1,0 +1,26 @@
+package com.offmode.boundedcontext.user.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateUserProfileRequest {
+
+  @Size(max = 30)
+  private String name;
+
+  @Size(max = 500)
+  private String avatar;
+
+  @Min(0)
+  @Max(23)
+  private Integer missionHour;
+
+  @Min(0)
+  @Max(59)
+  private Integer missionMinute;
+
+  private Boolean autoRoulette;
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/user/dto/response/UserStatsResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/dto/response/UserStatsResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class UserStatsDto {
+public class UserStatsResponse {
   private long totalMissions; // 전체 미션 수 (pending + verified)
   private long totalVerified; // 인증 완료 미션 수
   private int streak; // 현재 연속 달성 일수

--- a/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
@@ -5,7 +5,7 @@ import com.offmode.boundedcontext.feed.repository.ReactionRepository;
 import com.offmode.boundedcontext.feed.repository.VerificationConfirmRepository;
 import com.offmode.boundedcontext.feed.repository.VerificationRepository;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
-import com.offmode.boundedcontext.user.dto.response.UserStatsDto;
+import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import com.offmode.global.exception.BusinessException;
@@ -63,7 +63,7 @@ public class UserService {
     }
   }
 
-  public UserStatsDto getStats(Long userId) {
+  public UserStatsResponse getStats(Long userId) {
     long totalMissions = userMissionRepository.findByUserIdOrderByAssignedAtDesc(userId).size();
     long totalVerified = userMissionRepository.countByUserIdAndStatus(userId, "verified");
 
@@ -80,7 +80,7 @@ public class UserService {
     List<LocalDateTime> verifiedTimes = userMissionRepository.findVerifiedDateTimes(userId);
     int streak = calcStreak(verifiedTimes);
 
-    return new UserStatsDto(
+    return new UserStatsResponse(
         totalMissions,
         totalVerified,
         streak,

--- a/backend/src/test/java/com/offmode/global/validation/RequestValidationTest.java
+++ b/backend/src/test/java/com/offmode/global/validation/RequestValidationTest.java
@@ -1,0 +1,50 @@
+package com.offmode.global.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.offmode.boundedcontext.feed.dto.request.ReactRequest;
+import com.offmode.boundedcontext.mission.dto.request.SetTodayMissionRequest;
+import com.offmode.boundedcontext.user.dto.request.UpdateUserProfileRequest;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class RequestValidationTest {
+
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  void updateUserProfileRejectsInvalidMissionTime() throws Exception {
+    UpdateUserProfileRequest request = new UpdateUserProfileRequest();
+    setField(request, "missionHour", 24);
+    setField(request, "missionMinute", 60);
+
+    assertThat(validator.validate(request)).hasSize(2);
+  }
+
+  @Test
+  void setTodayMissionRequiresSupportedCategory() throws Exception {
+    SetTodayMissionRequest request = new SetTodayMissionRequest();
+    setField(request, "icon", "🏃");
+    setField(request, "text", "30분 산책하기");
+    setField(request, "category", "Unknown");
+
+    assertThat(validator.validate(request))
+        .anyMatch(violation -> violation.getPropertyPath().toString().equals("category"));
+  }
+
+  @Test
+  void reactRequestRequiresEmoji() {
+    ReactRequest request = new ReactRequest();
+
+    assertThat(validator.validate(request))
+        .anyMatch(violation -> violation.getPropertyPath().toString().equals("emoji"));
+  }
+
+  private void setField(Object target, String name, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}

--- a/backend/src/test/java/com/offmode/global/validation/RequestValidationTest.java
+++ b/backend/src/test/java/com/offmode/global/validation/RequestValidationTest.java
@@ -42,6 +42,15 @@ class RequestValidationTest {
         .anyMatch(violation -> violation.getPropertyPath().toString().equals("emoji"));
   }
 
+  @Test
+  void reactRequestRejectsEmojiLongerThanColumnLength() throws Exception {
+    ReactRequest request = new ReactRequest();
+    setField(request, "emoji", "12345678901");
+
+    assertThat(validator.validate(request))
+        .anyMatch(violation -> violation.getPropertyPath().toString().equals("emoji"));
+  }
+
   private void setField(Object target, String name, Object value) throws Exception {
     Field field = target.getClass().getDeclaredField(name);
     field.setAccessible(true);


### PR DESCRIPTION
## 🔗 Issue

- close #3

---

## 📌 Summary

- `UpdateUserProfileRequest`, `SetTodayMissionRequest`, `ReactRequest`를 추가하고 컨트롤러의 `@RequestBody Map` 파싱을 제거했습니다.
- 요청 DTO에 Bean Validation을 적용해 프로필 시간 범위, 미션 필수값/카테고리, 리액션 emoji 입력을 검증하도록 했습니다.
- `dto/response` 아래 응답 타입명을 `*Dto`에서 `*Response`로 정리하고 관련 참조를 갱신했습니다.

---

## ✅ Test

- [x] `./gradlew.bat clean build`