### PR TITLE
[Refactor] #4 미션 상태값과 카테고리 enum화

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
@@ -5,6 +5,8 @@ import com.offmode.boundedcontext.badge.entity.UserBadge;
 import com.offmode.boundedcontext.badge.repository.UserBadgeRepository;
 import com.offmode.boundedcontext.badge.types.BadgeDefinition;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDate;
@@ -60,9 +62,9 @@ public class BadgeService {
       case REAL_WORLD_RULER -> verifiedCount(userId) >= 100;
 
         // 유형별
-      case WALKER -> verifiedByCategory(userId, "Energy") >= 10;
-      case BEAUTY_CURATOR -> verifiedByCategory(userId, "Intellect") >= 10;
-      case LOCAL_HIPSTER -> verifiedByCategory(userId, "Vitality") >= 10;
+      case WALKER -> verifiedByCategory(userId, MissionCategory.ENERGY) >= 10;
+      case BEAUTY_CURATOR -> verifiedByCategory(userId, MissionCategory.INTELLECT) >= 10;
+      case LOCAL_HIPSTER -> verifiedByCategory(userId, MissionCategory.VITALITY) >= 10;
 
         // 시간대
       case DAWN_MASTER -> verifiedByHour(userId, 0, 6) >= 5;
@@ -74,7 +76,9 @@ public class BadgeService {
 
         // 유니크
       case OFFMODE_ENTRY -> userMissionRepository.existsByUserId(userId);
-      case SKY_COLLECTOR -> userMissionRepository.countVerifiedByTextKeyword(userId, "하늘") >= 10;
+      case SKY_COLLECTOR ->
+          userMissionRepository.countByStatusAndTextKeyword(userId, MissionStatus.VERIFIED, "하늘")
+              >= 10;
       case SPEEDRUNNER -> maxConsecutiveDays(userId) >= 7;
     };
   }
@@ -82,22 +86,23 @@ public class BadgeService {
   // ── 공통 쿼리 헬퍼 ───────────────────────────────────────
 
   private long verifiedCount(Long userId) {
-    return userMissionRepository.countByUserIdAndStatus(userId, "verified");
+    return userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED);
   }
 
-  private long verifiedByCategory(Long userId, String category) {
+  private long verifiedByCategory(Long userId, MissionCategory category) {
     return userMissionRepository.countByUserIdAndStatusAndMissionCategory(
-        userId, "verified", category);
+        userId, MissionStatus.VERIFIED, category);
   }
 
   private long verifiedByHour(Long userId, int fromHour, int toHour) {
-    return userMissionRepository.countVerifiedByHourRange(userId, fromHour, toHour);
+    return userMissionRepository.countByStatusAndHourRange(
+        userId, MissionStatus.VERIFIED, fromHour, toHour);
   }
 
   /** 최대 연속 미션 달성 일수 계산 */
   private int maxConsecutiveDays(Long userId) {
     List<LocalDate> dates =
-        userMissionRepository.findVerifiedDateTimes(userId).stream()
+        userMissionRepository.findVerifiedDateTimes(userId, MissionStatus.VERIFIED).stream()
             .map(LocalDateTime::toLocalDate)
             .distinct()
             .sorted()

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedItemResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/FeedItemResponse.java
@@ -1,6 +1,7 @@
 package com.offmode.boundedcontext.feed.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -28,4 +29,36 @@ public class FeedItemResponse {
 
   // JPQL 쿼리 후 서비스에서 채움
   @Setter private List<ReactionSummaryResponse> reactions;
+
+  public FeedItemResponse(
+      Long id,
+      String photoUrl,
+      String caption,
+      LocalDateTime createdAt,
+      String userName,
+      String userAvatar,
+      Integer userLevel,
+      String missionIcon,
+      String missionText,
+      MissionCategory missionCategory,
+      long verifyCount,
+      boolean myVerify,
+      boolean isOwn,
+      List<ReactionSummaryResponse> reactions) {
+    this(
+        id,
+        photoUrl,
+        caption,
+        createdAt,
+        userName,
+        userAvatar,
+        userLevel,
+        missionIcon,
+        missionText,
+        missionCategory.value(),
+        verifyCount,
+        myVerify,
+        isOwn,
+        reactions);
+  }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
@@ -12,6 +12,7 @@ import com.offmode.boundedcontext.feed.repository.VerificationConfirmRepository;
 import com.offmode.boundedcontext.feed.repository.VerificationRepository;
 import com.offmode.boundedcontext.mission.entity.UserMission;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.UserService;
@@ -138,14 +139,15 @@ public class FeedService {
     long count = confirmRepository.countByVerificationId(verificationId);
     if (count >= VERIFY_THRESHOLD) {
       UserMission mission = v.getUserMission();
-      if (!"verified".equals(mission.getStatus())) {
-        mission.setStatus("verified");
+      if (!MissionStatus.VERIFIED.equals(mission.getStatus())) {
+        mission.setStatus(MissionStatus.VERIFIED);
         mission.setVerifiedAt(LocalDateTime.now());
         userMissionRepository.save(mission);
 
         // 레벨업 + 배지 체크 (미션 주인에게)
         Long ownerId = mission.getUser().getId();
-        long verifiedCount = userMissionRepository.countByUserIdAndStatus(ownerId, "verified");
+        long verifiedCount =
+            userMissionRepository.countByUserIdAndStatus(ownerId, MissionStatus.VERIFIED);
         userService.levelUp(ownerId, (int) verifiedCount);
         badgeService.checkAndAward(ownerId);
       }
@@ -221,7 +223,7 @@ public class FeedService {
 
     // 전체 인증 완료율
     long total = userMissionRepository.count();
-    long verified = userMissionRepository.countByStatus("verified");
+    long verified = userMissionRepository.countByStatus(MissionStatus.VERIFIED);
     int verificationRate = total == 0 ? 0 : (int) (verified * 100 / total);
 
     // 현재 유저 연속 달성 일수 (UserService의 getStats 재활용)

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/api/v1/MissionController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/api/v1/MissionController.java
@@ -34,7 +34,7 @@ public class MissionController {
       @AuthenticationPrincipal Long userId, @Valid @RequestBody SetTodayMissionRequest request) {
     UserMission mission =
         missionService.setTodayMission(
-            userId, request.getIcon(), request.getText(), request.getCategory());
+            userId, request.getIcon(), request.getText(), request.getMissionCategory());
     return ResponseEntity.ok(mission);
   }
 

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/request/SetTodayMissionRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/request/SetTodayMissionRequest.java
@@ -1,7 +1,7 @@
 package com.offmode.boundedcontext.mission.dto.request;
 
+import com.offmode.boundedcontext.mission.types.MissionCategory;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
@@ -16,7 +16,9 @@ public class SetTodayMissionRequest {
   @Size(max = 100)
   private String text;
 
-  @NotBlank
-  @Pattern(regexp = "Energy|Intellect|Vitality")
-  private String category;
+  @NotBlank @ValidMissionCategory private String category;
+
+  public MissionCategory getMissionCategory() {
+    return MissionCategory.from(category);
+  }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/request/ValidMissionCategory.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/request/ValidMissionCategory.java
@@ -1,0 +1,22 @@
+package com.offmode.boundedcontext.mission.dto.request;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = ValidMissionCategoryValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidMissionCategory {
+
+  String message() default "허용되지 않은 미션 카테고리입니다";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/request/ValidMissionCategoryValidator.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/request/ValidMissionCategoryValidator.java
@@ -1,0 +1,14 @@
+package com.offmode.boundedcontext.mission.dto.request;
+
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidMissionCategoryValidator
+    implements ConstraintValidator<ValidMissionCategory, String> {
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    return value == null || value.isBlank() || MissionCategory.contains(value);
+  }
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/MissionWeightResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/MissionWeightResponse.java
@@ -1,5 +1,6 @@
 package com.offmode.boundedcontext.mission.dto.response;
 
+import com.offmode.boundedcontext.mission.types.MissionCategory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,4 +12,9 @@ public class MissionWeightResponse {
   private String text;
   private String category;
   private double weight; // 0.0 ~ 1.0  (낮을수록 뽑힐 확률 낮음)
+
+  public MissionWeightResponse(
+      Long id, String icon, String text, MissionCategory category, double weight) {
+    this(id, icon, text, category.value(), weight);
+  }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/UserMissionResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/dto/response/UserMissionResponse.java
@@ -1,5 +1,7 @@
 package com.offmode.boundedcontext.mission.dto.response;
 
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
 import java.time.LocalDateTime;
 
 public record UserMissionResponse(
@@ -11,4 +13,27 @@ public record UserMissionResponse(
     LocalDateTime assignedAt,
     LocalDateTime verifiedAt,
     String photoUrl,
-    String caption) {}
+    String caption) {
+
+  public UserMissionResponse(
+      Long id,
+      String missionIcon,
+      String missionText,
+      MissionCategory missionCategory,
+      MissionStatus status,
+      LocalDateTime assignedAt,
+      LocalDateTime verifiedAt,
+      String photoUrl,
+      String caption) {
+    this(
+        id,
+        missionIcon,
+        missionText,
+        missionCategory.value(),
+        status.value(),
+        assignedAt,
+        verifiedAt,
+        photoUrl,
+        caption);
+  }
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/entity/Mission.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/entity/Mission.java
@@ -1,5 +1,6 @@
 package com.offmode.boundedcontext.mission.entity;
 
+import com.offmode.boundedcontext.mission.types.MissionCategory;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,5 +23,5 @@ public class Mission {
   private String text;
 
   @Column(nullable = false)
-  private String category; // "Vitality" | "Energy" | "Intellect"
+  private MissionCategory category;
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/entity/UserMission.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/entity/UserMission.java
@@ -1,6 +1,8 @@
 package com.offmode.boundedcontext.mission.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -32,11 +34,11 @@ public class UserMission {
   private String missionText;
 
   @Column(nullable = false)
-  private String missionCategory;
+  private MissionCategory missionCategory;
 
   @Column(nullable = false)
   @Builder.Default
-  private String status = "pending"; // "pending" | "verified"
+  private MissionStatus status = MissionStatus.PENDING;
 
   @CreationTimestamp private LocalDateTime assignedAt;
 

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/repository/UserMissionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/repository/UserMissionRepository.java
@@ -2,6 +2,8 @@ package com.offmode.boundedcontext.mission.repository;
 
 import com.offmode.boundedcontext.mission.dto.response.UserMissionResponse;
 import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -19,31 +21,39 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
 
   boolean existsByUserId(Long userId);
 
-  long countByUserIdAndStatus(Long userId, String status);
+  long countByUserIdAndStatus(Long userId, MissionStatus status);
 
-  long countByUserIdAndStatusAndMissionCategory(Long userId, String status, String category);
+  long countByUserIdAndStatusAndMissionCategory(
+      Long userId, MissionStatus status, MissionCategory category);
 
   // 글로벌 통계 (전체 유저)
-  long countByStatus(String status);
+  long countByStatus(MissionStatus status);
 
   @Query("SELECT COUNT(DISTINCT um.user.id) FROM UserMission um WHERE um.assignedAt >= :since")
   long countDistinctUsersSince(@Param("since") LocalDateTime since);
 
   // 카테고리 내 미션 텍스트 검색 (하늘 수집가용)
   @Query(
-      "SELECT COUNT(um) FROM UserMission um WHERE um.user.id = :userId AND um.status = 'verified' AND um.missionText LIKE %:keyword%")
-  long countVerifiedByTextKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
+      "SELECT COUNT(um) FROM UserMission um WHERE um.user.id = :userId AND um.status = :status AND um.missionText LIKE %:keyword%")
+  long countByStatusAndTextKeyword(
+      @Param("userId") Long userId,
+      @Param("status") MissionStatus status,
+      @Param("keyword") String keyword);
 
   // 시간대별 인증 수 (새벽/오후/저녁)
   @Query(
-      "SELECT COUNT(um) FROM UserMission um WHERE um.user.id = :userId AND um.status = 'verified' AND HOUR(um.verifiedAt) >= :fromHour AND HOUR(um.verifiedAt) < :toHour")
-  long countVerifiedByHourRange(
-      @Param("userId") Long userId, @Param("fromHour") int fromHour, @Param("toHour") int toHour);
+      "SELECT COUNT(um) FROM UserMission um WHERE um.user.id = :userId AND um.status = :status AND HOUR(um.verifiedAt) >= :fromHour AND HOUR(um.verifiedAt) < :toHour")
+  long countByStatusAndHourRange(
+      @Param("userId") Long userId,
+      @Param("status") MissionStatus status,
+      @Param("fromHour") int fromHour,
+      @Param("toHour") int toHour);
 
   // 연속 달성 계산용: 인증된 미션의 verifiedAt 목록 (오름차순) - Java에서 LocalDate 추출
   @Query(
-      "SELECT um.verifiedAt FROM UserMission um WHERE um.user.id = :userId AND um.status = 'verified' ORDER BY um.verifiedAt ASC")
-  List<java.time.LocalDateTime> findVerifiedDateTimes(@Param("userId") Long userId);
+      "SELECT um.verifiedAt FROM UserMission um WHERE um.user.id = :userId AND um.status = :status ORDER BY um.verifiedAt ASC")
+  List<java.time.LocalDateTime> findVerifiedDateTimes(
+      @Param("userId") Long userId, @Param("status") MissionStatus status);
 
   // 오늘 미션 + 인증 사진/캡션 포함
   @Query(

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
@@ -7,6 +7,8 @@ import com.offmode.boundedcontext.mission.entity.Mission;
 import com.offmode.boundedcontext.mission.entity.UserMission;
 import com.offmode.boundedcontext.mission.repository.MissionRepository;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDate;
@@ -62,7 +64,8 @@ public class MissionService {
   // 룰렛에서 선택한 미션을 오늘 미션으로 저장
   // 이미 오늘 미션이 있으면 새로 선택한 미션으로 덮어씀 (단, 이미 verified면 유지)
   @Transactional
-  public UserMission setTodayMission(Long userId, String icon, String text, String category) {
+  public UserMission setTodayMission(
+      Long userId, String icon, String text, MissionCategory category) {
     LocalDate today = LocalDate.now();
     LocalDateTime start = today.atStartOfDay();
     LocalDateTime end = today.plusDays(1).atStartOfDay();
@@ -80,7 +83,7 @@ public class MissionService {
                       existing.getId(),
                       existing.getMissionText(),
                       existing.getStatus());
-                  if ("verified".equals(existing.getStatus())) {
+                  if (MissionStatus.VERIFIED.equals(existing.getStatus())) {
                     // 이미 완료된 미션은 수정하지 않고 새 미션을 추가 생성
                     log.info("[SET-MISSION] 기존 미션이 verified → 새 미션 신규 생성");
                     User user = userRepository.getReferenceById(userId);
@@ -101,7 +104,7 @@ public class MissionService {
                   existing.setMissionIcon(icon);
                   existing.setMissionText(text);
                   existing.setMissionCategory(category);
-                  existing.setStatus("pending");
+                  existing.setStatus(MissionStatus.PENDING);
                   existing.setVerifiedAt(null);
                   UserMission saved = userMissionRepository.save(existing);
                   log.info(

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/types/MissionCategory.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/types/MissionCategory.java
@@ -1,0 +1,30 @@
+package com.offmode.boundedcontext.mission.types;
+
+import java.util.Arrays;
+
+public enum MissionCategory {
+  ENERGY("Energy"),
+  INTELLECT("Intellect"),
+  VITALITY("Vitality");
+
+  private final String value;
+
+  MissionCategory(String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return value;
+  }
+
+  public static MissionCategory from(String value) {
+    return Arrays.stream(values())
+        .filter(category -> category.value.equals(value))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Unknown mission category: " + value));
+  }
+
+  public static boolean contains(String value) {
+    return Arrays.stream(values()).anyMatch(category -> category.value.equals(value));
+  }
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/types/MissionCategoryConverter.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/types/MissionCategoryConverter.java
@@ -1,0 +1,18 @@
+package com.offmode.boundedcontext.mission.types;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class MissionCategoryConverter implements AttributeConverter<MissionCategory, String> {
+
+  @Override
+  public String convertToDatabaseColumn(MissionCategory attribute) {
+    return attribute != null ? attribute.value() : null;
+  }
+
+  @Override
+  public MissionCategory convertToEntityAttribute(String dbData) {
+    return dbData != null ? MissionCategory.from(dbData) : null;
+  }
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/types/MissionStatus.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/types/MissionStatus.java
@@ -1,0 +1,25 @@
+package com.offmode.boundedcontext.mission.types;
+
+import java.util.Arrays;
+
+public enum MissionStatus {
+  PENDING("pending"),
+  VERIFIED("verified");
+
+  private final String value;
+
+  MissionStatus(String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return value;
+  }
+
+  public static MissionStatus from(String value) {
+    return Arrays.stream(values())
+        .filter(status -> status.value.equals(value))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Unknown mission status: " + value));
+  }
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/types/MissionStatusConverter.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/types/MissionStatusConverter.java
@@ -1,0 +1,18 @@
+package com.offmode.boundedcontext.mission.types;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class MissionStatusConverter implements AttributeConverter<MissionStatus, String> {
+
+  @Override
+  public String convertToDatabaseColumn(MissionStatus attribute) {
+    return attribute != null ? attribute.value() : null;
+  }
+
+  @Override
+  public MissionStatus convertToEntityAttribute(String dbData) {
+    return dbData != null ? MissionStatus.from(dbData) : null;
+  }
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
@@ -5,6 +5,8 @@ import com.offmode.boundedcontext.feed.repository.ReactionRepository;
 import com.offmode.boundedcontext.feed.repository.VerificationConfirmRepository;
 import com.offmode.boundedcontext.feed.repository.VerificationRepository;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
@@ -65,19 +67,21 @@ public class UserService {
 
   public UserStatsResponse getStats(Long userId) {
     long totalMissions = userMissionRepository.findByUserIdOrderByAssignedAtDesc(userId).size();
-    long totalVerified = userMissionRepository.countByUserIdAndStatus(userId, "verified");
+    long totalVerified =
+        userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED);
 
     long energy =
         userMissionRepository.countByUserIdAndStatusAndMissionCategory(
-            userId, "verified", "Energy");
+            userId, MissionStatus.VERIFIED, MissionCategory.ENERGY);
     long intellect =
         userMissionRepository.countByUserIdAndStatusAndMissionCategory(
-            userId, "verified", "Intellect");
+            userId, MissionStatus.VERIFIED, MissionCategory.INTELLECT);
     long vitality =
         userMissionRepository.countByUserIdAndStatusAndMissionCategory(
-            userId, "verified", "Vitality");
+            userId, MissionStatus.VERIFIED, MissionCategory.VITALITY);
 
-    List<LocalDateTime> verifiedTimes = userMissionRepository.findVerifiedDateTimes(userId);
+    List<LocalDateTime> verifiedTimes =
+        userMissionRepository.findVerifiedDateTimes(userId, MissionStatus.VERIFIED);
     int streak = calcStreak(verifiedTimes);
 
     return new UserStatsResponse(

--- a/backend/src/test/java/com/offmode/boundedcontext/mission/types/MissionEnumConverterTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/mission/types/MissionEnumConverterTest.java
@@ -1,0 +1,25 @@
+package com.offmode.boundedcontext.mission.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MissionEnumConverterTest {
+
+  @Test
+  void missionCategoryKeepsExistingDatabaseValue() {
+    MissionCategoryConverter converter = new MissionCategoryConverter();
+
+    assertThat(converter.convertToDatabaseColumn(MissionCategory.ENERGY)).isEqualTo("Energy");
+    assertThat(converter.convertToEntityAttribute("Intellect"))
+        .isEqualTo(MissionCategory.INTELLECT);
+  }
+
+  @Test
+  void missionStatusKeepsExistingDatabaseValue() {
+    MissionStatusConverter converter = new MissionStatusConverter();
+
+    assertThat(converter.convertToDatabaseColumn(MissionStatus.PENDING)).isEqualTo("pending");
+    assertThat(converter.convertToEntityAttribute("verified")).isEqualTo(MissionStatus.VERIFIED);
+  }
+}


### PR DESCRIPTION
## 🔗 Issue

- close #4

---

## 📌 Summary

- `MissionStatus`, `MissionCategory` enum과 JPA converter를 추가해 기존 DB 문자열 값을 유지하면서 도메인 로직을 enum 기반으로 정리했습니다.
- 미션 상태/카테고리를 사용하는 서비스, repository 쿼리, DTO projection을 enum 타입에 맞게 갱신했습니다.
- 기존 API 요청/응답 값과 `data.sql` 호환성을 유지하도록 문자열 변환 생성자와 카테고리 검증을 추가했습니다.

---

## ✅ Test

- [x] `./gradlew.bat clean build`