### PR TITLE
[Fix] #47 인증 사진 업로드 검증 강화

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
@@ -17,27 +17,18 @@ import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
+import com.offmode.global.file.ImageUploadService;
 import com.offmode.global.status.ErrorStatus;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Slf4j
 @Service
@@ -50,22 +41,12 @@ public class FeedService {
   private final UserMissionRepository userMissionRepository;
   private final UserService userService;
   private final BadgeService badgeService;
-  private final Optional<S3Client> s3Client;
+  private final ImageUploadService imageUploadService;
 
   private static final int VERIFY_THRESHOLD = 1;
 
-  @Value("${file.upload-dir:./uploads}")
-  private String uploadDir;
-
-  @Value("${r2.bucket:}")
-  private String r2Bucket;
-
-  @Value("${r2.public-url:}")
-  private String r2PublicUrl;
-
   @Transactional
-  public Verification verify(Long userId, Long userMissionId, MultipartFile photo, String caption)
-      throws IOException {
+  public Verification verify(Long userId, Long userMissionId, MultipartFile photo, String caption) {
     UserMission mission =
         userMissionRepository
             .findById(userMissionId)
@@ -82,26 +63,7 @@ public class FeedService {
     // 사진 저장 (R2 우선, 없으면 로컬)
     String photoUrl = null;
     if (photo != null && !photo.isEmpty()) {
-      String ext = getExtension(photo.getOriginalFilename());
-      String filename = "verifications/" + UUID.randomUUID() + ext;
-      if (s3Client.isPresent() && !r2Bucket.isBlank()) {
-        s3Client
-            .get()
-            .putObject(
-                PutObjectRequest.builder()
-                    .bucket(r2Bucket)
-                    .key(filename)
-                    .contentType(photo.getContentType())
-                    .build(),
-                RequestBody.fromInputStream(photo.getInputStream(), photo.getSize()));
-        photoUrl = r2PublicUrl + "/" + filename;
-      } else {
-        String localName = UUID.randomUUID() + ext;
-        Path dir = Paths.get(uploadDir).toAbsolutePath();
-        Files.createDirectories(dir);
-        photo.transferTo(dir.resolve(localName));
-        photoUrl = "/uploads/" + localName;
-      }
+      photoUrl = imageUploadService.uploadVerificationImage(photo);
     }
 
     // 인증 저장 (상태는 "pending" 유지 — 피어 인증 후 완료 처리)
@@ -231,10 +193,5 @@ public class FeedService {
     int streakDays = userStats.getStreak();
 
     return new FeedStatsResponse(activeToday, verificationRate, streakDays);
-  }
-
-  private String getExtension(String filename) {
-    if (filename == null || !filename.contains(".")) return ".jpg";
-    return filename.substring(filename.lastIndexOf('.'));
   }
 }

--- a/backend/src/main/java/com/offmode/global/config/S3Config.java
+++ b/backend/src/main/java/com/offmode/global/config/S3Config.java
@@ -23,9 +23,15 @@ public class S3Config {
   @Value("${r2.endpoint:}")
   private String endpoint;
 
+  @Value("${r2.bucket:}")
+  private String bucket;
+
+  @Value("${r2.public-url:}")
+  private String publicUrl;
+
   @Bean
   public Optional<S3Client> s3Client() {
-    if (accessKey == null || accessKey.isBlank()) {
+    if (!hasCompleteR2Config()) {
       return Optional.empty();
     }
     return Optional.of(
@@ -36,5 +42,17 @@ public class S3Config {
                 StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
             .httpClient(UrlConnectionHttpClient.builder().build())
             .build());
+  }
+
+  private boolean hasCompleteR2Config() {
+    return hasText(accessKey)
+        && hasText(secretKey)
+        && hasText(endpoint)
+        && hasText(bucket)
+        && hasText(publicUrl);
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
   }
 }

--- a/backend/src/main/java/com/offmode/global/file/ImageUploadService.java
+++ b/backend/src/main/java/com/offmode/global/file/ImageUploadService.java
@@ -1,0 +1,141 @@
+package com.offmode.global.file;
+
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.status.ErrorStatus;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class ImageUploadService {
+
+  private static final long MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
+  private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png");
+  private static final Map<String, String> CONTENT_TYPES_BY_EXTENSION =
+      Map.of(
+          "jpg", "image/jpeg",
+          "jpeg", "image/jpeg",
+          "png", "image/png");
+
+  private final Optional<S3Client> s3Client;
+
+  @Value("${file.upload-dir:./uploads}")
+  private String uploadDir;
+
+  @Value("${r2.bucket:}")
+  private String r2Bucket;
+
+  @Value("${r2.public-url:}")
+  private String r2PublicUrl;
+
+  public String uploadVerificationImage(MultipartFile file) {
+    validateImage(file);
+
+    String extension = getAllowedExtension(file.getOriginalFilename());
+    String contentType = CONTENT_TYPES_BY_EXTENSION.get(extension);
+    String storageKey = "verifications/" + UUID.randomUUID() + "." + extension;
+
+    try {
+      if (s3Client.isPresent()) {
+        validateR2StorageConfig();
+        uploadToR2(file, storageKey, contentType);
+        return r2PublicUrl + "/" + storageKey;
+      }
+
+      return uploadToLocal(file, extension);
+    } catch (IOException | RuntimeException e) {
+      if (e instanceof BusinessException businessException) {
+        throw businessException;
+      }
+      throw new BusinessException(ErrorStatus.FILE_UPLOAD_FAILED, e);
+    }
+  }
+
+  private void validateImage(MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      throw new BusinessException(ErrorStatus.FILE_EMPTY);
+    }
+
+    if (file.getSize() > MAX_IMAGE_SIZE_BYTES) {
+      throw new BusinessException(ErrorStatus.FILE_INVALID_TYPE);
+    }
+
+    String extension = getAllowedExtension(file.getOriginalFilename());
+    String expectedContentType = CONTENT_TYPES_BY_EXTENSION.get(extension);
+    if (!expectedContentType.equalsIgnoreCase(
+        Optional.ofNullable(file.getContentType()).orElse(""))) {
+      throw new BusinessException(ErrorStatus.FILE_INVALID_TYPE);
+    }
+
+    try (InputStream inputStream = file.getInputStream()) {
+      BufferedImage image = ImageIO.read(inputStream);
+      if (image == null) {
+        throw new BusinessException(ErrorStatus.FILE_INVALID_IMAGE);
+      }
+    } catch (IOException e) {
+      throw new BusinessException(ErrorStatus.FILE_INVALID_IMAGE, e);
+    }
+  }
+
+  private String getAllowedExtension(String originalFilename) {
+    String filename = Optional.ofNullable(originalFilename).orElse("");
+    int dotIndex = filename.lastIndexOf('.');
+    if (dotIndex < 0 || dotIndex == filename.length() - 1) {
+      throw new BusinessException(ErrorStatus.FILE_INVALID_TYPE);
+    }
+
+    String extension = filename.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
+    if (!ALLOWED_EXTENSIONS.contains(extension)) {
+      throw new BusinessException(ErrorStatus.FILE_INVALID_TYPE);
+    }
+    return extension;
+  }
+
+  private void validateR2StorageConfig() {
+    if (r2Bucket.isBlank() || r2PublicUrl.isBlank()) {
+      throw new BusinessException(ErrorStatus.FILE_STORAGE_CONFIG_INVALID);
+    }
+  }
+
+  private void uploadToR2(MultipartFile file, String storageKey, String contentType)
+      throws IOException {
+    s3Client
+        .get()
+        .putObject(
+            PutObjectRequest.builder()
+                .bucket(r2Bucket)
+                .key(storageKey)
+                .contentType(contentType)
+                .build(),
+            RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+  }
+
+  private String uploadToLocal(MultipartFile file, String extension) throws IOException {
+    String localName = UUID.randomUUID() + "." + extension;
+    Path dir = Paths.get(uploadDir).toAbsolutePath().normalize();
+    Files.createDirectories(dir);
+    Path target = dir.resolve(localName).normalize();
+    if (!target.startsWith(dir)) {
+      throw new BusinessException(ErrorStatus.FILE_UPLOAD_FAILED);
+    }
+    file.transferTo(target);
+    return "/uploads/" + localName;
+  }
+}

--- a/backend/src/main/java/com/offmode/global/file/ImageUploadService.java
+++ b/backend/src/main/java/com/offmode/global/file/ImageUploadService.java
@@ -17,6 +17,7 @@ import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -26,7 +27,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 @RequiredArgsConstructor
 public class ImageUploadService {
 
-  private static final long MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
   private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png");
   private static final Map<String, String> CONTENT_TYPES_BY_EXTENSION =
       Map.of(
@@ -45,6 +45,9 @@ public class ImageUploadService {
   @Value("${r2.public-url:}")
   private String r2PublicUrl;
 
+  @Value("${spring.servlet.multipart.max-file-size:10MB}")
+  private DataSize maxImageSize;
+
   public String uploadVerificationImage(MultipartFile file) {
     validateImage(file);
 
@@ -53,9 +56,10 @@ public class ImageUploadService {
     String storageKey = "verifications/" + UUID.randomUUID() + "." + extension;
 
     try {
-      if (s3Client.isPresent()) {
+      S3Client configuredS3Client = s3Client.orElse(null);
+      if (configuredS3Client != null) {
         validateR2StorageConfig();
-        uploadToR2(file, storageKey, contentType);
+        uploadToR2(configuredS3Client, file, storageKey, contentType);
         return r2PublicUrl + "/" + storageKey;
       }
 
@@ -73,8 +77,8 @@ public class ImageUploadService {
       throw new BusinessException(ErrorStatus.FILE_EMPTY);
     }
 
-    if (file.getSize() > MAX_IMAGE_SIZE_BYTES) {
-      throw new BusinessException(ErrorStatus.FILE_INVALID_TYPE);
+    if (file.getSize() > maxImageSize.toBytes()) {
+      throw new BusinessException(ErrorStatus.FILE_TOO_LARGE);
     }
 
     String extension = getAllowedExtension(file.getOriginalFilename());
@@ -114,17 +118,16 @@ public class ImageUploadService {
     }
   }
 
-  private void uploadToR2(MultipartFile file, String storageKey, String contentType)
+  private void uploadToR2(
+      S3Client configuredS3Client, MultipartFile file, String storageKey, String contentType)
       throws IOException {
-    s3Client
-        .get()
-        .putObject(
-            PutObjectRequest.builder()
-                .bucket(r2Bucket)
-                .key(storageKey)
-                .contentType(contentType)
-                .build(),
-            RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+    configuredS3Client.putObject(
+        PutObjectRequest.builder()
+            .bucket(r2Bucket)
+            .key(storageKey)
+            .contentType(contentType)
+            .build(),
+        RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
   }
 
   private String uploadToLocal(MultipartFile file, String extension) throws IOException {

--- a/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
+++ b/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
@@ -37,6 +37,7 @@ public enum ErrorStatus {
   FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE_400_001", "업로드할 파일이 비어있습니다."),
   FILE_INVALID_TYPE(HttpStatus.BAD_REQUEST, "FILE_400_002", "허용되지 않은 파일 형식입니다."),
   FILE_INVALID_IMAGE(HttpStatus.BAD_REQUEST, "FILE_400_003", "유효한 이미지 파일이 아닙니다."),
+  FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "FILE_400_004", "업로드 가능한 파일 크기를 초과했습니다."),
   FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_001", "파일 업로드에 실패했습니다."),
   FILE_STORAGE_CONFIG_INVALID(
       HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_002", "파일 저장소 설정이 올바르지 않습니다.");

--- a/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
+++ b/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
@@ -31,7 +31,15 @@ public enum ErrorStatus {
       HttpStatus.CONFLICT, "VERIFICATION_409_001", "이미 인증 사진을 올린 미션입니다."),
   VERIFICATION_SELF_CONFIRM_NOT_ALLOWED(
       HttpStatus.BAD_REQUEST, "VERIFICATION_400_001", "자신의 인증은 확인할 수 없습니다."),
-  VERIFICATION_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "VERIFICATION_409_002", "이미 인증해준 게시물입니다.");
+  VERIFICATION_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "VERIFICATION_409_002", "이미 인증해준 게시물입니다."),
+
+  // File
+  FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE_400_001", "업로드할 파일이 비어있습니다."),
+  FILE_INVALID_TYPE(HttpStatus.BAD_REQUEST, "FILE_400_002", "허용되지 않은 파일 형식입니다."),
+  FILE_INVALID_IMAGE(HttpStatus.BAD_REQUEST, "FILE_400_003", "유효한 이미지 파일이 아닙니다."),
+  FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_001", "파일 업로드에 실패했습니다."),
+  FILE_STORAGE_CONFIG_INVALID(
+      HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_002", "파일 저장소 설정이 올바르지 않습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/backend/src/test/java/com/offmode/global/file/ImageUploadServiceTest.java
+++ b/backend/src/test/java/com/offmode/global/file/ImageUploadServiceTest.java
@@ -10,11 +10,13 @@ import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.imageio.ImageIO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.unit.DataSize;
 
 class ImageUploadServiceTest {
 
@@ -28,7 +30,9 @@ class ImageUploadServiceTest {
     String url = service.uploadVerificationImage(file);
 
     assertThat(url).startsWith("/uploads/").endsWith(".png");
-    assertThat(Files.list(tempDir)).hasSize(1);
+    try (Stream<Path> storedFiles = Files.list(tempDir)) {
+      assertThat(storedFiles).hasSize(1);
+    }
   }
 
   @Test
@@ -55,11 +59,27 @@ class ImageUploadServiceTest {
             e -> assertThat(e.getErrorStatus()).isEqualTo(ErrorStatus.FILE_INVALID_IMAGE));
   }
 
+  @Test
+  void uploadVerificationImageRejectsTooLargeFile() throws Exception {
+    ImageUploadService service = createService(DataSize.ofBytes(1));
+    MockMultipartFile file = new MockMultipartFile("photo", "mission.png", "image/png", pngBytes());
+
+    assertThatThrownBy(() -> service.uploadVerificationImage(file))
+        .isInstanceOfSatisfying(
+            BusinessException.class,
+            e -> assertThat(e.getErrorStatus()).isEqualTo(ErrorStatus.FILE_TOO_LARGE));
+  }
+
   private ImageUploadService createService() {
+    return createService(DataSize.ofMegabytes(10));
+  }
+
+  private ImageUploadService createService(DataSize maxImageSize) {
     ImageUploadService service = new ImageUploadService(Optional.empty());
     ReflectionTestUtils.setField(service, "uploadDir", tempDir.toString());
     ReflectionTestUtils.setField(service, "r2Bucket", "");
     ReflectionTestUtils.setField(service, "r2PublicUrl", "");
+    ReflectionTestUtils.setField(service, "maxImageSize", maxImageSize);
     return service;
   }
 

--- a/backend/src/test/java/com/offmode/global/file/ImageUploadServiceTest.java
+++ b/backend/src/test/java/com/offmode/global/file/ImageUploadServiceTest.java
@@ -1,0 +1,72 @@
+package com.offmode.global.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.status.ErrorStatus;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ImageUploadServiceTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void uploadVerificationImageStoresValidPngLocally() throws Exception {
+    ImageUploadService service = createService();
+    MockMultipartFile file = new MockMultipartFile("photo", "mission.png", "image/png", pngBytes());
+
+    String url = service.uploadVerificationImage(file);
+
+    assertThat(url).startsWith("/uploads/").endsWith(".png");
+    assertThat(Files.list(tempDir)).hasSize(1);
+  }
+
+  @Test
+  void uploadVerificationImageRejectsUnsupportedExtension() {
+    ImageUploadService service = createService();
+    MockMultipartFile file =
+        new MockMultipartFile("photo", "mission.txt", "text/plain", "not-image".getBytes());
+
+    assertThatThrownBy(() -> service.uploadVerificationImage(file))
+        .isInstanceOfSatisfying(
+            BusinessException.class,
+            e -> assertThat(e.getErrorStatus()).isEqualTo(ErrorStatus.FILE_INVALID_TYPE));
+  }
+
+  @Test
+  void uploadVerificationImageRejectsNonImageBytes() {
+    ImageUploadService service = createService();
+    MockMultipartFile file =
+        new MockMultipartFile("photo", "mission.png", "image/png", "not-image".getBytes());
+
+    assertThatThrownBy(() -> service.uploadVerificationImage(file))
+        .isInstanceOfSatisfying(
+            BusinessException.class,
+            e -> assertThat(e.getErrorStatus()).isEqualTo(ErrorStatus.FILE_INVALID_IMAGE));
+  }
+
+  private ImageUploadService createService() {
+    ImageUploadService service = new ImageUploadService(Optional.empty());
+    ReflectionTestUtils.setField(service, "uploadDir", tempDir.toString());
+    ReflectionTestUtils.setField(service, "r2Bucket", "");
+    ReflectionTestUtils.setField(service, "r2PublicUrl", "");
+    return service;
+  }
+
+  private byte[] pngBytes() throws Exception {
+    BufferedImage image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ImageIO.write(image, "png", outputStream);
+    return outputStream.toByteArray();
+  }
+}


### PR DESCRIPTION
## 🔗 Issue

- close #47

---

## 📌 Summary

- `ImageUploadService`를 추가해 인증 사진 확장자, Content-Type, 실제 이미지 여부를 검증하도록 했습니다.
- 파일 저장 로직을 `FeedService`에서 분리하고, 로컬 저장 시 UUID 파일명과 정규화된 경로를 사용하도록 정리했습니다.
- R2 설정이 모두 있는 경우에만 S3Client를 생성하고, 파일 업로드 실패 케이스를 표준 에러 응답으로 처리했습니다.

---

## ✅ Test

- [x] `./gradlew.bat clean build`