### PR TITLE
[Infra] #1 운영 보안 설정 분리

### DIFF
--- a/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
@@ -5,10 +5,14 @@ import com.offmode.global.dto.response.ApiResponse;
 import com.offmode.global.jwt.JwtAuthFilter;
 import com.offmode.global.status.ErrorStatus;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -28,18 +32,16 @@ public class SecurityConfig {
 
   private final JwtAuthFilter jwtAuthFilter;
   private final ObjectMapper objectMapper;
+  private final Environment environment;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    return http.csrf(AbstractHttpConfigurer::disable)
+    http.csrf(AbstractHttpConfigurer::disable)
         .cors(cors -> cors.configurationSource(corsSource()))
         .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/api/auth/**", "/h2-console/**", "/health", "/uploads/**")
-                    .permitAll()
-                    .anyRequest()
-                    .authenticated())
+                auth.requestMatchers(getPublicEndpoints()).permitAll().anyRequest().authenticated())
         .exceptionHandling(
             exception ->
                 exception
@@ -49,21 +51,56 @@ public class SecurityConfig {
                     .accessDeniedHandler(
                         (request, response, accessDeniedException) ->
                             writeErrorResponse(response, ErrorStatus.AUTH_ACCESS_DENIED)))
-        .headers(h -> h.frameOptions(FrameOptionsConfig::disable)) // H2 콘솔용
-        .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
-        .build();
+        .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+    if (isDevProfile()) {
+      http.headers(h -> h.frameOptions(FrameOptionsConfig::disable));
+    }
+
+    return http.build();
   }
 
   @Bean
   public CorsConfigurationSource corsSource() {
     CorsConfiguration config = new CorsConfiguration();
-    config.setAllowedOriginPatterns(List.of("*"));
+    config.setAllowedOrigins(getCorsAllowedOrigins());
+    config.setAllowedOriginPatterns(getCorsAllowedOriginPatterns());
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
     config.setAllowedHeaders(List.of("*"));
     config.setAllowCredentials(true);
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", config);
     return source;
+  }
+
+  private String[] getPublicEndpoints() {
+    List<String> endpoints = new ArrayList<>(List.of("/api/auth/**", "/health", "/uploads/**"));
+    if (isDevProfile()) {
+      endpoints.add("/h2-console/**");
+    }
+    return endpoints.toArray(String[]::new);
+  }
+
+  private boolean isDevProfile() {
+    return environment.matchesProfiles("dev");
+  }
+
+  private List<String> getCorsAllowedOrigins() {
+    return getStringListProperty("offmode.security.cors.allowed-origins");
+  }
+
+  private List<String> getCorsAllowedOriginPatterns() {
+    return getStringListProperty("offmode.security.cors.allowed-origin-patterns");
+  }
+
+  private List<String> getStringListProperty(String key) {
+    return Binder.get(environment)
+        .bind(key, Bindable.listOf(String.class))
+        .orElseGet(List::of)
+        .stream()
+        .map(String::trim)
+        .filter(value -> !value.isBlank())
+        .toList();
   }
 
   private void writeErrorResponse(HttpServletResponse response, ErrorStatus errorStatus)

--- a/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
@@ -90,6 +90,9 @@ public class SecurityConfig {
   }
 
   private List<String> getCorsAllowedOriginPatterns() {
+    if (!isDevProfile()) {
+      return List.of();
+    }
     return getStringListProperty("offmode.security.cors.allowed-origin-patterns");
   }
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -19,3 +19,9 @@ spring:
   sql:
     init:
       mode: always
+
+offmode:
+  security:
+    cors:
+      allowed-origin-patterns:
+        - "*"

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -15,3 +15,8 @@ spring:
   sql:
     init:
       mode: never               # prod에서는 data.sql 실행 안 함
+
+offmode:
+  security:
+    cors:
+      allowed-origins: ${CORS_ALLOWED_ORIGINS:}

--- a/backend/src/test/java/com/offmode/global/config/SecurityConfigDevProfileTest.java
+++ b/backend/src/test/java/com/offmode/global/config/SecurityConfigDevProfileTest.java
@@ -1,0 +1,33 @@
+package com.offmode.global.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("dev")
+@WebMvcTest(controllers = SecurityConfigTestController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class SecurityConfigDevProfileTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private JwtProvider jwtProvider;
+
+  @Test
+  void h2ConsoleIsPublicAndFrameOptionsHeaderIsDisabledInDevProfile() throws Exception {
+    mockMvc
+        .perform(get("/h2-console/test"))
+        .andExpect(status().isOk())
+        .andExpect(header().doesNotExist("X-Frame-Options"));
+  }
+}

--- a/backend/src/test/java/com/offmode/global/config/SecurityConfigProdProfileTest.java
+++ b/backend/src/test/java/com/offmode/global/config/SecurityConfigProdProfileTest.java
@@ -1,0 +1,33 @@
+package com.offmode.global.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("prod")
+@WebMvcTest(controllers = SecurityConfigTestController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class SecurityConfigProdProfileTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private JwtProvider jwtProvider;
+
+  @Test
+  void h2ConsoleRequiresAuthenticationAndKeepsFrameOptionsHeaderInProdProfile() throws Exception {
+    mockMvc
+        .perform(get("/h2-console/test"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(header().string("X-Frame-Options", "DENY"));
+  }
+}

--- a/backend/src/test/java/com/offmode/global/config/SecurityConfigTest.java
+++ b/backend/src/test/java/com/offmode/global/config/SecurityConfigTest.java
@@ -1,0 +1,72 @@
+package com.offmode.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.offmode.global.jwt.JwtAuthFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+class SecurityConfigTest {
+
+  @Test
+  void publicEndpointsIncludeH2ConsoleOnlyInDevProfile() {
+    MockEnvironment devEnvironment = new MockEnvironment();
+    devEnvironment.setActiveProfiles("dev");
+    MockEnvironment prodEnvironment = new MockEnvironment();
+    prodEnvironment.setActiveProfiles("prod");
+    SecurityConfig devConfig = createSecurityConfig(devEnvironment);
+    SecurityConfig prodConfig = createSecurityConfig(prodEnvironment);
+
+    String[] devEndpoints = ReflectionTestUtils.invokeMethod(devConfig, "getPublicEndpoints");
+    String[] prodEndpoints = ReflectionTestUtils.invokeMethod(prodConfig, "getPublicEndpoints");
+
+    assertThat(devEndpoints).contains("/h2-console/**");
+    assertThat(prodEndpoints).doesNotContain("/h2-console/**");
+  }
+
+  @Test
+  void corsUsesConfiguredAllowedOrigins() {
+    MockEnvironment environment =
+        new MockEnvironment()
+            .withProperty(
+                "offmode.security.cors.allowed-origins",
+                "https://offmode.example.com,https://www.offmode.example.com");
+    SecurityConfig config = createSecurityConfig(environment);
+
+    CorsConfiguration corsConfiguration = getCorsConfiguration(config);
+
+    assertThat(corsConfiguration.getAllowedOrigins())
+        .containsExactly("https://offmode.example.com", "https://www.offmode.example.com");
+    assertThat(corsConfiguration.getAllowedOriginPatterns()).isEmpty();
+    assertThat(corsConfiguration.getAllowCredentials()).isTrue();
+  }
+
+  @Test
+  void corsUsesConfiguredAllowedOriginPatterns() {
+    MockEnvironment environment =
+        new MockEnvironment()
+            .withProperty("offmode.security.cors.allowed-origin-patterns", "http://localhost:*");
+    SecurityConfig config = createSecurityConfig(environment);
+
+    CorsConfiguration corsConfiguration = getCorsConfiguration(config);
+
+    assertThat(corsConfiguration.getAllowedOrigins()).isEmpty();
+    assertThat(corsConfiguration.getAllowedOriginPatterns()).containsExactly("http://localhost:*");
+  }
+
+  private SecurityConfig createSecurityConfig(MockEnvironment environment) {
+    return new SecurityConfig(mock(JwtAuthFilter.class), new ObjectMapper(), environment);
+  }
+
+  private CorsConfiguration getCorsConfiguration(SecurityConfig config) {
+    UrlBasedCorsConfigurationSource source = (UrlBasedCorsConfigurationSource) config.corsSource();
+    CorsConfiguration corsConfiguration = source.getCorsConfigurations().get("/**");
+    assertThat(corsConfiguration).isNotNull();
+    return corsConfiguration;
+  }
+}

--- a/backend/src/test/java/com/offmode/global/config/SecurityConfigTest.java
+++ b/backend/src/test/java/com/offmode/global/config/SecurityConfigTest.java
@@ -7,27 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.offmode.global.jwt.JwtAuthFilter;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 class SecurityConfigTest {
-
-  @Test
-  void publicEndpointsIncludeH2ConsoleOnlyInDevProfile() {
-    MockEnvironment devEnvironment = new MockEnvironment();
-    devEnvironment.setActiveProfiles("dev");
-    MockEnvironment prodEnvironment = new MockEnvironment();
-    prodEnvironment.setActiveProfiles("prod");
-    SecurityConfig devConfig = createSecurityConfig(devEnvironment);
-    SecurityConfig prodConfig = createSecurityConfig(prodEnvironment);
-
-    String[] devEndpoints = ReflectionTestUtils.invokeMethod(devConfig, "getPublicEndpoints");
-    String[] prodEndpoints = ReflectionTestUtils.invokeMethod(prodConfig, "getPublicEndpoints");
-
-    assertThat(devEndpoints).contains("/h2-console/**");
-    assertThat(prodEndpoints).doesNotContain("/h2-console/**");
-  }
 
   @Test
   void corsUsesConfiguredAllowedOrigins() {
@@ -51,12 +34,25 @@ class SecurityConfigTest {
     MockEnvironment environment =
         new MockEnvironment()
             .withProperty("offmode.security.cors.allowed-origin-patterns", "http://localhost:*");
+    environment.setActiveProfiles("dev");
     SecurityConfig config = createSecurityConfig(environment);
 
     CorsConfiguration corsConfiguration = getCorsConfiguration(config);
 
     assertThat(corsConfiguration.getAllowedOrigins()).isEmpty();
     assertThat(corsConfiguration.getAllowedOriginPatterns()).containsExactly("http://localhost:*");
+  }
+
+  @Test
+  void corsIgnoresAllowedOriginPatternsOutsideDevProfile() {
+    MockEnvironment environment =
+        new MockEnvironment().withProperty("offmode.security.cors.allowed-origin-patterns", "*");
+    environment.setActiveProfiles("prod");
+    SecurityConfig config = createSecurityConfig(environment);
+
+    CorsConfiguration corsConfiguration = getCorsConfiguration(config);
+
+    assertThat(corsConfiguration.getAllowedOriginPatterns()).isEmpty();
   }
 
   private SecurityConfig createSecurityConfig(MockEnvironment environment) {

--- a/backend/src/test/java/com/offmode/global/config/SecurityConfigTestController.java
+++ b/backend/src/test/java/com/offmode/global/config/SecurityConfigTestController.java
@@ -1,0 +1,13 @@
+package com.offmode.global.config;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class SecurityConfigTestController {
+
+  @GetMapping("/h2-console/test")
+  String h2Console() {
+    return "ok";
+  }
+}


### PR DESCRIPTION
## 🔗 Issue

- close #1

---

## 📌 Summary

- dev 프로필에서만 H2 console 접근과 frame options disable이 적용되도록 분리
- prod CORS origin을 CORS_ALLOWED_ORIGINS 환경 변수 기반 allowlist로 변경
- dev/prod 보안 설정 분리와 CORS 설정 반영 테스트 추가

---

## ✅ Test

- [x] ./gradlew.bat clean build