### PR TITLE
[Test] #7 핵심 서비스 및 예외 흐름 테스트 추가

### DIFF
--- a/backend/src/test/java/com/offmode/boundedcontext/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/auth/service/AuthServiceTest.java
@@ -1,0 +1,116 @@
+package com.offmode.boundedcontext.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.offmode.boundedcontext.auth.dto.response.AuthResponse;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.jwt.JwtProvider;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private JwtProvider jwtProvider;
+
+  private AuthService authService;
+
+  @BeforeEach
+  void setUp() {
+    authService = new AuthService(userRepository, jwtProvider, kakaoSuccessBuilder());
+    ReflectionTestUtils.setField(authService, "kakaoUserInfoUrl", "https://kakao.test/me");
+    ReflectionTestUtils.setField(authService, "kakaoRequestTimeoutSeconds", 5L);
+    ReflectionTestUtils.setField(authService, "appleBundleId", "com.minnnj.offmode");
+    ReflectionTestUtils.setField(authService, "appleKeysUrl", "https://apple.test/keys");
+  }
+
+  @Test
+  void kakaoLoginCreatesUserAndReturnsJwt() {
+    User saved =
+        User.builder()
+            .id(1L)
+            .provider("kakao")
+            .providerId("123")
+            .email("kakao@example.com")
+            .name("카카오")
+            .build();
+    when(userRepository.findByProviderAndProviderId("kakao", "123")).thenReturn(Optional.empty());
+    when(userRepository.save(any(User.class))).thenReturn(saved);
+    when(jwtProvider.generate(1L)).thenReturn("jwt-token");
+
+    AuthResponse response = authService.kakaoLogin("access-token");
+
+    assertThat(response.getToken()).isEqualTo("jwt-token");
+    assertThat(response.getUser()).isSameAs(saved);
+    assertThat(response.isNew()).isTrue();
+  }
+
+  @Test
+  void kakaoLoginWrapsKakaoApiFailure() {
+    authService = new AuthService(userRepository, jwtProvider, kakaoFailureBuilder());
+    ReflectionTestUtils.setField(authService, "kakaoUserInfoUrl", "https://kakao.test/me");
+    ReflectionTestUtils.setField(authService, "kakaoRequestTimeoutSeconds", 5L);
+
+    assertThatThrownBy(() -> authService.kakaoLogin("bad-token"))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage("OAuth 인증에 실패했습니다.");
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void appleLoginRejectsMalformedIdentityToken() {
+    assertThatThrownBy(() -> authService.appleLogin("malformed-token", "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage("OAuth 인증에 실패했습니다.");
+  }
+
+  private WebClient.Builder kakaoSuccessBuilder() {
+    return WebClient.builder()
+        .exchangeFunction(
+            request -> {
+              String body =
+                  """
+                  {
+                    "id": 123,
+                    "kakao_account": {
+                      "email": "kakao@example.com",
+                      "profile": { "nickname": "카카오" }
+                    }
+                  }
+                  """;
+              return Mono.just(
+                  ClientResponse.create(HttpStatus.OK)
+                      .header("Content-Type", "application/json")
+                      .body(body)
+                      .build());
+            });
+  }
+
+  private WebClient.Builder kakaoFailureBuilder() {
+    return WebClient.builder()
+        .exchangeFunction(
+            request ->
+                Mono.just(
+                    ClientResponse.create(HttpStatus.UNAUTHORIZED)
+                        .header("Content-Type", "application/json")
+                        .body("{}")
+                        .build()));
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/auth/service/AuthServiceTest.java
@@ -76,6 +76,10 @@ class AuthServiceTest {
 
   @Test
   void appleLoginRejectsMalformedIdentityToken() {
+    authService = new AuthService(userRepository, jwtProvider, appleKeysBuilder());
+    ReflectionTestUtils.setField(authService, "appleBundleId", "com.minnnj.offmode");
+    ReflectionTestUtils.setField(authService, "appleKeysUrl", "https://apple.test/keys");
+
     assertThatThrownBy(() -> authService.appleLogin("malformed-token", "Apple User"))
         .isInstanceOf(BusinessException.class)
         .hasMessage("OAuth 인증에 실패했습니다.");
@@ -111,6 +115,20 @@ class AuthServiceTest {
                     ClientResponse.create(HttpStatus.UNAUTHORIZED)
                         .header("Content-Type", "application/json")
                         .body("{}")
+                        .build()));
+  }
+
+  private WebClient.Builder appleKeysBuilder() {
+    return WebClient.builder()
+        .exchangeFunction(
+            request ->
+                Mono.just(
+                    ClientResponse.create(HttpStatus.OK)
+                        .header("Content-Type", "application/json")
+                        .body(
+                            """
+                            { "keys": [] }
+                            """)
                         .build()));
   }
 }

--- a/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
@@ -1,0 +1,84 @@
+package com.offmode.boundedcontext.badge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.offmode.boundedcontext.badge.entity.UserBadge;
+import com.offmode.boundedcontext.badge.repository.UserBadgeRepository;
+import com.offmode.boundedcontext.badge.types.BadgeDefinition;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BadgeServiceTest {
+
+  @Mock private UserBadgeRepository userBadgeRepository;
+  @Mock private UserMissionRepository userMissionRepository;
+  @Mock private UserRepository userRepository;
+
+  @Test
+  void checkAndAwardAwardsFirstMissionAcceptedBadge() {
+    BadgeService service =
+        new BadgeService(userBadgeRepository, userMissionRepository, userRepository);
+    User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
+    when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
+    when(userMissionRepository.existsByUserId(1L)).thenReturn(true);
+    when(userRepository.getReferenceById(1L)).thenReturn(user);
+    when(userBadgeRepository.save(any(UserBadge.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    List<BadgeDefinition> awarded = service.checkAndAward(1L);
+
+    assertThat(awarded).contains(BadgeDefinition.OFFMODE_ENTRY);
+  }
+
+  @Test
+  void checkAndAwardAwardsVerifiedCountAndCategoryBadges() {
+    BadgeService service =
+        new BadgeService(userBadgeRepository, userMissionRepository, userRepository);
+    User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
+    when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(10L);
+    when(userMissionRepository.countByUserIdAndStatusAndMissionCategory(
+            1L, MissionStatus.VERIFIED, MissionCategory.ENERGY))
+        .thenReturn(10L);
+    when(userRepository.getReferenceById(1L)).thenReturn(user);
+    when(userBadgeRepository.save(any(UserBadge.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    List<BadgeDefinition> awarded = service.checkAndAward(1L);
+
+    assertThat(awarded)
+        .contains(
+            BadgeDefinition.EXPLORER_LV01, BadgeDefinition.COLLECTOR_LV02, BadgeDefinition.WALKER);
+  }
+
+  @Test
+  void checkAndAwardAwardsSevenDayStreakBadge() {
+    BadgeService service =
+        new BadgeService(userBadgeRepository, userMissionRepository, userRepository);
+    User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
+    LocalDateTime start = LocalDateTime.now().minusDays(6);
+    when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(java.util.stream.IntStream.range(0, 7).mapToObj(start::plusDays).toList());
+    when(userRepository.getReferenceById(1L)).thenReturn(user);
+    when(userBadgeRepository.save(any(UserBadge.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    List<BadgeDefinition> awarded = service.checkAndAward(1L);
+
+    assertThat(awarded).contains(BadgeDefinition.SPEEDRUNNER);
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
@@ -13,6 +13,7 @@ import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,8 @@ class BadgeServiceTest {
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
     when(userMissionRepository.existsByUserId(1L)).thenReturn(true);
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(Collections.emptyList());
     when(userRepository.getReferenceById(1L)).thenReturn(user);
     when(userBadgeRepository.save(any(UserBadge.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
@@ -53,6 +56,8 @@ class BadgeServiceTest {
     when(userMissionRepository.countByUserIdAndStatusAndMissionCategory(
             1L, MissionStatus.VERIFIED, MissionCategory.ENERGY))
         .thenReturn(10L);
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(Collections.emptyList());
     when(userRepository.getReferenceById(1L)).thenReturn(user);
     when(userBadgeRepository.save(any(UserBadge.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
@@ -1,0 +1,132 @@
+package com.offmode.boundedcontext.feed.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.offmode.boundedcontext.badge.service.BadgeService;
+import com.offmode.boundedcontext.feed.entity.Reaction;
+import com.offmode.boundedcontext.feed.entity.Verification;
+import com.offmode.boundedcontext.feed.repository.ReactionRepository;
+import com.offmode.boundedcontext.feed.repository.VerificationConfirmRepository;
+import com.offmode.boundedcontext.feed.repository.VerificationRepository;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.service.UserService;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.file.ImageUploadService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FeedServiceTest {
+
+  @Mock private VerificationRepository verificationRepository;
+  @Mock private VerificationConfirmRepository confirmRepository;
+  @Mock private ReactionRepository reactionRepository;
+  @Mock private UserMissionRepository userMissionRepository;
+  @Mock private UserService userService;
+  @Mock private BadgeService badgeService;
+  @Mock private ImageUploadService imageUploadService;
+
+  private FeedService feedService;
+
+  @BeforeEach
+  void setUp() {
+    feedService =
+        new FeedService(
+            verificationRepository,
+            confirmRepository,
+            reactionRepository,
+            userMissionRepository,
+            userService,
+            badgeService,
+            imageUploadService);
+  }
+
+  @Test
+  void verifyRejectsOtherUsersMission() {
+    User owner = User.builder().id(1L).provider("kakao").providerId("owner").build();
+    UserMission mission = UserMission.builder().id(10L).user(owner).build();
+    when(userMissionRepository.findById(10L)).thenReturn(Optional.of(mission));
+
+    assertThatThrownBy(() -> feedService.verify(2L, 10L, null, "caption"))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage("접근 권한이 없습니다.");
+  }
+
+  @Test
+  void verifyRejectsDuplicateVerification() {
+    User owner = User.builder().id(1L).provider("kakao").providerId("owner").build();
+    UserMission mission = UserMission.builder().id(10L).user(owner).build();
+    when(userMissionRepository.findById(10L)).thenReturn(Optional.of(mission));
+    when(verificationRepository.existsByUserMissionId(10L)).thenReturn(true);
+
+    assertThatThrownBy(() -> feedService.verify(1L, 10L, null, "caption"))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage("이미 인증 사진을 올린 미션입니다.");
+  }
+
+  @Test
+  void confirmRejectsSelfConfirm() {
+    User owner = User.builder().id(1L).provider("kakao").providerId("owner").build();
+    Verification verification = Verification.builder().id(20L).user(owner).build();
+    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+
+    assertThatThrownBy(() -> feedService.confirm(1L, 20L))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage("자신의 인증은 확인할 수 없습니다.");
+  }
+
+  @Test
+  void confirmMarksMissionVerifiedWhenThresholdReached() {
+    User owner = User.builder().id(1L).provider("kakao").providerId("owner").level(1).build();
+    User confirmer = User.builder().id(2L).provider("kakao").providerId("confirmer").build();
+    UserMission mission =
+        UserMission.builder()
+            .id(10L)
+            .user(owner)
+            .missionText("산책")
+            .missionCategory(MissionCategory.VITALITY)
+            .status(MissionStatus.PENDING)
+            .build();
+    Verification verification =
+        Verification.builder().id(20L).user(owner).userMission(mission).build();
+    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(confirmRepository.existsByVerificationIdAndUserId(20L, 2L)).thenReturn(false);
+    when(userService.getById(2L)).thenReturn(confirmer);
+    when(confirmRepository.countByVerificationId(20L)).thenReturn(1L);
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(1L);
+
+    feedService.confirm(2L, 20L);
+
+    assertThat(mission.getStatus()).isEqualTo(MissionStatus.VERIFIED);
+    assertThat(mission.getVerifiedAt()).isNotNull();
+    verify(userMissionRepository).save(mission);
+    verify(userService).levelUp(1L, 1);
+    verify(badgeService).checkAndAward(1L);
+  }
+
+  @Test
+  void reactTogglesExistingReactionOff() {
+    User user = User.builder().id(1L).provider("kakao").providerId("user").build();
+    Verification verification = Verification.builder().id(20L).build();
+    Reaction reaction =
+        Reaction.builder().id(30L).verification(verification).user(user).emoji("🔥").build();
+    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(reactionRepository.findByVerificationIdAndUserIdAndEmoji(20L, 1L, "🔥"))
+        .thenReturn(Optional.of(reaction));
+
+    feedService.react(1L, 20L, "🔥");
+
+    verify(reactionRepository).delete(reaction);
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/mission/service/MissionServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/mission/service/MissionServiceTest.java
@@ -1,0 +1,142 @@
+package com.offmode.boundedcontext.mission.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.offmode.boundedcontext.badge.service.BadgeService;
+import com.offmode.boundedcontext.mission.dto.response.MissionWeightResponse;
+import com.offmode.boundedcontext.mission.entity.Mission;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.repository.MissionRepository;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MissionServiceTest {
+
+  @Mock private MissionRepository missionRepository;
+  @Mock private UserMissionRepository userMissionRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private BadgeService badgeService;
+
+  @Test
+  void setTodayMissionCreatesMissionWhenTodayMissionDoesNotExist() {
+    MissionService service =
+        new MissionService(missionRepository, userMissionRepository, userRepository, badgeService);
+    User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
+    when(userMissionRepository.findFirstByUserIdAndAssignedAtBetweenOrderByAssignedAtDesc(
+            eq(1L), any(), any()))
+        .thenReturn(Optional.empty());
+    when(userRepository.getReferenceById(1L)).thenReturn(user);
+    when(userMissionRepository.save(any(UserMission.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    UserMission result = service.setTodayMission(1L, "🚶", "산책하기", MissionCategory.VITALITY);
+
+    assertThat(result.getUser()).isSameAs(user);
+    assertThat(result.getMissionText()).isEqualTo("산책하기");
+    assertThat(result.getStatus()).isEqualTo(MissionStatus.PENDING);
+    verify(badgeService).checkAndAward(1L);
+  }
+
+  @Test
+  void setTodayMissionOverwritesPendingMission() {
+    MissionService service =
+        new MissionService(missionRepository, userMissionRepository, userRepository, badgeService);
+    UserMission existing =
+        UserMission.builder()
+            .id(10L)
+            .missionIcon("old")
+            .missionText("기존")
+            .missionCategory(MissionCategory.ENERGY)
+            .status(MissionStatus.PENDING)
+            .verifiedAt(LocalDateTime.now())
+            .build();
+    when(userMissionRepository.findFirstByUserIdAndAssignedAtBetweenOrderByAssignedAtDesc(
+            eq(1L), any(), any()))
+        .thenReturn(Optional.of(existing));
+    when(userMissionRepository.save(existing)).thenReturn(existing);
+
+    UserMission result = service.setTodayMission(1L, "new", "새 미션", MissionCategory.INTELLECT);
+
+    assertThat(result.getId()).isEqualTo(10L);
+    assertThat(result.getMissionIcon()).isEqualTo("new");
+    assertThat(result.getMissionText()).isEqualTo("새 미션");
+    assertThat(result.getMissionCategory()).isEqualTo(MissionCategory.INTELLECT);
+    assertThat(result.getStatus()).isEqualTo(MissionStatus.PENDING);
+    assertThat(result.getVerifiedAt()).isNull();
+  }
+
+  @Test
+  void setTodayMissionCreatesNewMissionWhenExistingMissionIsVerified() {
+    MissionService service =
+        new MissionService(missionRepository, userMissionRepository, userRepository, badgeService);
+    User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
+    UserMission existing =
+        UserMission.builder()
+            .id(10L)
+            .user(user)
+            .missionText("완료")
+            .missionCategory(MissionCategory.ENERGY)
+            .status(MissionStatus.VERIFIED)
+            .build();
+    when(userMissionRepository.findFirstByUserIdAndAssignedAtBetweenOrderByAssignedAtDesc(
+            eq(1L), any(), any()))
+        .thenReturn(Optional.of(existing));
+    when(userRepository.getReferenceById(1L)).thenReturn(user);
+    when(userMissionRepository.save(any(UserMission.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    UserMission result = service.setTodayMission(1L, "new", "새 미션", MissionCategory.INTELLECT);
+
+    assertThat(result).isNotSameAs(existing);
+    assertThat(result.getUser()).isSameAs(user);
+    assertThat(result.getMissionText()).isEqualTo("새 미션");
+  }
+
+  @Test
+  void weightedPoolReducesWeightForRecentlyAssignedMission() {
+    MissionService service =
+        new MissionService(missionRepository, userMissionRepository, userRepository, badgeService);
+    when(missionRepository.findAll())
+        .thenReturn(
+            List.of(
+                Mission.builder()
+                    .id(1L)
+                    .icon("a")
+                    .text("최근")
+                    .category(MissionCategory.ENERGY)
+                    .build(),
+                Mission.builder()
+                    .id(2L)
+                    .icon("b")
+                    .text("처음")
+                    .category(MissionCategory.VITALITY)
+                    .build()));
+    List<Object[]> latestAssigned = new ArrayList<>();
+    latestAssigned.add(new Object[] {"최근", LocalDateTime.now().minusDays(3)});
+    when(userMissionRepository.findLatestAssignedAtPerMissionText(1L)).thenReturn(latestAssigned);
+
+    List<MissionWeightResponse> result = service.getWeightedPool(1L);
+
+    assertThat(result)
+        .extracting(MissionWeightResponse::getText, MissionWeightResponse::getWeight)
+        .containsExactlyInAnyOrder(
+            org.assertj.core.groups.Tuple.tuple("최근", 0.1),
+            org.assertj.core.groups.Tuple.tuple("처음", 1.0));
+  }
+}


### PR DESCRIPTION
## 🔗 Issue

- close #7

---

## 📌 Summary

- AuthService, MissionService 핵심 정상/예외 흐름 단위 테스트 추가
- FeedService 인증/confirm/reaction 주요 예외 및 상태 변경 테스트 추가
- BadgeService 첫 미션/완료 횟수/카테고리/연속 달성 배지 테스트 추가

---

## ✅ Test

- [x] backend에서 ./gradlew.bat spotlessApply
- [x] backend에서 ./gradlew.bat test