### PR TITLE
[Test] #59 동일 미션 피드 조회 시나리오 테스트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ backend/offmode-db*
 # Ignore Kotlin plugin data
 .kotlin
 /.expo/
+/uploads/*

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/repository/VerificationRepositoryTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/repository/VerificationRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.offmode.boundedcontext.feed.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
+import com.offmode.boundedcontext.feed.entity.Verification;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+class VerificationRepositoryTest {
+
+  @Autowired private VerificationRepository verificationRepository;
+  @Autowired private UserMissionRepository userMissionRepository;
+  @Autowired private UserRepository userRepository;
+
+  @Test
+  void findFeedItemsReturnsOnlyVerificationsWithSameMissionText() {
+    User viewer = saveUser("viewer");
+    User sameMissionUser = saveUser("same");
+    User differentMissionUser = saveUser("different");
+    saveVerification(sameMissionUser, "물 마시기", "same-caption");
+    saveVerification(differentMissionUser, "산책하기", "different-caption");
+
+    List<FeedItemResponse> result =
+        verificationRepository.findFeedItems(PageRequest.of(0, 20), viewer.getId(), "물 마시기");
+
+    assertThat(result).extracting(FeedItemResponse::getCaption).containsExactly("same-caption");
+    assertThat(result).extracting(FeedItemResponse::getMissionText).containsExactly("물 마시기");
+  }
+
+  private User saveUser(String providerId) {
+    return userRepository.save(
+        User.builder().provider("kakao").providerId(providerId).name(providerId).build());
+  }
+
+  private void saveVerification(User user, String missionText, String caption) {
+    UserMission mission =
+        userMissionRepository.save(
+            UserMission.builder()
+                .user(user)
+                .missionIcon("icon")
+                .missionText(missionText)
+                .missionCategory(MissionCategory.VITALITY)
+                .build());
+    verificationRepository.save(
+        Verification.builder().user(user).userMission(mission).caption(caption).build());
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
@@ -2,10 +2,13 @@ package com.offmode.boundedcontext.feed.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.offmode.boundedcontext.badge.service.BadgeService;
+import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
 import com.offmode.boundedcontext.feed.entity.Reaction;
 import com.offmode.boundedcontext.feed.entity.Verification;
 import com.offmode.boundedcontext.feed.repository.ReactionRepository;
@@ -19,6 +22,7 @@ import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.file.ImageUploadService;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -128,5 +132,38 @@ class FeedServiceTest {
     feedService.react(1L, 20L, "🔥");
 
     verify(reactionRepository).delete(reaction);
+  }
+
+  @Test
+  void getFeedReturnsEmptyListWhenUserHasNoTodayMission() {
+    when(userMissionRepository.findFirstByUserIdAndAssignedAtBetweenOrderByAssignedAtDesc(
+            eq(1L), any(), any()))
+        .thenReturn(Optional.empty());
+
+    List<FeedItemResponse> result = feedService.getFeed(1L, 0, 20);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getFeedQueriesFeedByTodayMissionText() {
+    User user = User.builder().id(1L).provider("kakao").providerId("viewer").build();
+    UserMission todayMission =
+        UserMission.builder()
+            .id(10L)
+            .user(user)
+            .missionText("같은 미션")
+            .missionCategory(MissionCategory.VITALITY)
+            .status(MissionStatus.PENDING)
+            .build();
+    when(userMissionRepository.findFirstByUserIdAndAssignedAtBetweenOrderByAssignedAtDesc(
+            eq(1L), any(), any()))
+        .thenReturn(Optional.of(todayMission));
+    when(verificationRepository.findFeedItems(any(), eq(1L), eq("같은 미션"))).thenReturn(List.of());
+
+    List<FeedItemResponse> result = feedService.getFeed(1L, 0, 20);
+
+    assertThat(result).isEmpty();
+    verify(verificationRepository).findFeedItems(any(), eq(1L), eq("같은 미션"));
   }
 }


### PR DESCRIPTION
## 🔗 Issue

- close #59

---

## 📌 Summary

- FeedService가 오늘 미션이 없을 때 빈 피드를 반환하는 테스트 추가
- FeedService가 오늘 미션 text로 피드 repository를 조회하는지 테스트 추가
- VerificationRepository가 동일 missionText 인증만 반환하고 다른 미션 인증은 제외하는 JPA 테스트 추가

---

## ✅ Test

- [x] backend에서 ./gradlew.bat spotlessApply
- [x] backend에서 ./gradlew.bat test