### PR TITLE
[Fix] #60 인증 업로드 응답 직렬화 오류 수정

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
@@ -3,7 +3,7 @@ package com.offmode.boundedcontext.feed.api.v1;
 import com.offmode.boundedcontext.feed.dto.request.ReactRequest;
 import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
 import com.offmode.boundedcontext.feed.dto.response.FeedStatsResponse;
-import com.offmode.boundedcontext.feed.entity.Verification;
+import com.offmode.boundedcontext.feed.dto.response.VerificationResponse;
 import com.offmode.boundedcontext.feed.service.FeedService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -23,13 +23,14 @@ public class FeedController {
   // POST /api/v1/feed/verify
   // multipart/form-data: photo (file), userMissionId, caption
   @PostMapping("/verify")
-  public ResponseEntity<Verification> verify(
+  public ResponseEntity<VerificationResponse> verify(
       @AuthenticationPrincipal Long userId,
       @RequestParam Long userMissionId,
       @RequestParam(required = false) MultipartFile photo,
       @RequestParam(required = false) String caption)
       throws Exception {
-    return ResponseEntity.ok(feedService.verify(userId, userMissionId, photo, caption));
+    return ResponseEntity.ok(
+        VerificationResponse.from(feedService.verify(userId, userMissionId, photo, caption)));
   }
 
   // GET /api/v1/feed/stats - 커뮤니티 통계

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/VerificationResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/dto/response/VerificationResponse.java
@@ -1,0 +1,16 @@
+package com.offmode.boundedcontext.feed.dto.response;
+
+import com.offmode.boundedcontext.feed.entity.Verification;
+import java.time.LocalDateTime;
+
+public record VerificationResponse(
+    Long id, String photoUrl, String caption, LocalDateTime createdAt) {
+
+  public static VerificationResponse from(Verification verification) {
+    return new VerificationResponse(
+        verification.getId(),
+        verification.getPhotoUrl(),
+        verification.getCaption(),
+        verification.getCreatedAt());
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/api/v1/FeedControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/api/v1/FeedControllerTest.java
@@ -1,0 +1,62 @@
+package com.offmode.boundedcontext.feed.api.v1;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.boundedcontext.feed.entity.Verification;
+import com.offmode.boundedcontext.feed.service.FeedService;
+import com.offmode.global.config.SecurityConfig;
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+
+@WebMvcTest(controllers = FeedController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class FeedControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private FeedService feedService;
+  @MockitoBean private JwtProvider jwtProvider;
+
+  @Test
+  void verifyReturnsResponseDtoWithoutLazyAssociations() throws Exception {
+    when(jwtProvider.isValid("token")).thenReturn(true);
+    when(jwtProvider.getUserId("token")).thenReturn(1L);
+    when(feedService.verify(eq(1L), eq(10L), any(MultipartFile.class), eq("caption")))
+        .thenReturn(
+            Verification.builder()
+                .id(20L)
+                .photoUrl("https://cdn.example.com/verification.jpg")
+                .caption("caption")
+                .createdAt(LocalDateTime.of(2026, 5, 18, 12, 0))
+                .build());
+
+    mockMvc
+        .perform(
+            multipart("/api/v1/feed/verify")
+                .file("photo", "image".getBytes())
+                .param("userMissionId", "10")
+                .param("caption", "caption")
+                .header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(20L))
+        .andExpect(jsonPath("$.photoUrl").value("https://cdn.example.com/verification.jpg"))
+        .andExpect(jsonPath("$.caption").value("caption"))
+        .andExpect(jsonPath("$", not(hasKey("user"))))
+        .andExpect(jsonPath("$", not(hasKey("userMission"))));
+  }
+}

--- a/screens/VerifyScreen.jsx
+++ b/screens/VerifyScreen.jsx
@@ -195,7 +195,8 @@ export default function VerifyScreen({ mission, userMissionId, onBack, onVerifie
 
             {!photoUri ? (
               <View style={styles.cameraWrap}>
-                <CameraView ref={cameraRef} style={styles.camera} facing={facing}>
+                <CameraView ref={cameraRef} style={styles.camera} facing={facing} />
+                <View style={styles.cameraOverlay} pointerEvents="box-none">
                   <View style={[styles.corner, { top: 12, left: 12, borderRightWidth: 0, borderBottomWidth: 0 }]} />
                   <View style={[styles.corner, { top: 12, right: 12, borderLeftWidth: 0, borderBottomWidth: 0 }]} />
                   <View style={[styles.corner, { bottom: 72, left: 12, borderRightWidth: 0, borderTopWidth: 0 }]} />
@@ -207,7 +208,7 @@ export default function VerifyScreen({ mission, userMissionId, onBack, onVerifie
                       </TouchableOpacity>
                     </Animated.View>
                   </View>
-                </CameraView>
+                </View>
               </View>
             ) : (
               <View style={styles.takenPhotoWrap}>
@@ -275,8 +276,9 @@ function makeStyles(C) {
     content:     { paddingHorizontal: 20, paddingBottom: 40, gap: 16 },
     missionInfo: { flexDirection: 'row', alignItems: 'center', gap: 12, backgroundColor: C.surface, borderRadius: 14, borderWidth: 1, borderColor: C.greenBorder, paddingHorizontal: 14, paddingVertical: 12 },
     missionInfoIcon:  { fontSize: 28 },
-    cameraWrap:  { borderRadius: 20, overflow: 'hidden', borderWidth: 1, borderColor: C.border, height: 320 },
+    cameraWrap:  { borderRadius: 20, overflow: 'hidden', borderWidth: 1, borderColor: C.border, height: 320, position: 'relative' },
     camera:      { flex: 1 },
+    cameraOverlay: { ...StyleSheet.absoluteFillObject },
     corner:      { position: 'absolute', width: 22, height: 22, borderColor: C.green, borderWidth: 2.5 },
     shutterRow:  { position: 'absolute', bottom: 0, left: 0, right: 0, backgroundColor: 'rgba(0,0,0,0.45)', paddingVertical: 14, alignItems: 'center' },
     shutter:     { width: 68, height: 68, borderRadius: 34, backgroundColor: 'rgba(255,255,255,0.15)', borderWidth: 3, borderColor: '#fff', alignItems: 'center', justifyContent: 'center' },


### PR DESCRIPTION
## 🔗 Issue

- close #60

---

## 📌 Summary

- `POST /api/v1/feed/verify`가 `Verification` JPA 엔티티를 직접 반환하지 않도록 수정
- 인증 업로드 성공 응답용 `VerificationResponse` DTO 추가
- Hibernate lazy association이 응답 JSON에 포함되지 않는 컨트롤러 테스트 추가

---

## ✅ Test

- [x] `backend` 디렉터리에서 `./gradlew.bat check`
- [x] 앱을 통해서 실제로 동작을 행해보았을 때 에러가 나지 않고 정상적으로 동작함을 확인 완료