### PR TITLE
[Fix] #46 Apple OAuth 토큰 검증 강화

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/auth/service/AuthService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/auth/service/AuthService.java
@@ -147,10 +147,7 @@ public class AuthService {
       log.warn("Apple public keys response was empty or malformed");
       throw new BusinessException(ErrorStatus.AUTH_APPLE_KEY_UNAVAILABLE);
     }
-    return keys.stream()
-        .filter(Map.class::isInstance)
-        .map(k -> (Map<String, Object>) k)
-        .toList();
+    return keys.stream().filter(Map.class::isInstance).map(k -> (Map<String, Object>) k).toList();
   }
 
   // kid 기반으로 Apple 공개키를 선택. JJWT가 서명 검증·exp 만료 검증을 담당한다.

--- a/backend/src/main/java/com/offmode/boundedcontext/auth/service/AuthService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/auth/service/AuthService.java
@@ -7,8 +7,12 @@ import com.offmode.global.exception.BusinessException;
 import com.offmode.global.jwt.JwtProvider;
 import com.offmode.global.status.ErrorStatus;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.LocatorAdapter;
+import io.jsonwebtoken.ProtectedHeader;
 import java.math.BigInteger;
+import java.security.Key;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
@@ -42,6 +46,12 @@ public class AuthService {
 
   @Value("${apple.keys-url}")
   private String appleKeysUrl;
+
+  @Value("${apple.issuer:https://appleid.apple.com}")
+  private String appleIssuer;
+
+  @Value("${apple.request-timeout-seconds:5}")
+  private long appleRequestTimeoutSeconds;
 
   // ── Kakao ──────────────────────────────────────────────
   public AuthResponse kakaoLogin(String accessToken) {
@@ -82,54 +92,96 @@ public class AuthService {
 
   // ── Apple ──────────────────────────────────────────────
   public AuthResponse appleLogin(String identityToken, String fullName) {
+    if (identityToken == null || identityToken.isBlank()) {
+      throw new BusinessException(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+    }
+
+    List<Map<String, Object>> applePublicKeys = fetchApplePublicKeys();
+
+    Claims claims;
     try {
-      // Apple 공개키 목록 조회
-      Map<?, ?> keysResponse =
-          webClientBuilder.build().get().uri(appleKeysUrl).retrieve().bodyToMono(Map.class).block();
-
-      List<?> keys = (List<?>) keysResponse.get("keys");
-
-      // identityToken 헤더에서 kid 추출
-      String[] parts = identityToken.split("\\.");
-      String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
-      String kid = headerJson.replaceAll(".*\"kid\":\"([^\"]+)\".*", "$1");
-
-      // kid 일치하는 Apple 공개키 찾기
-      Map<?, ?> matchedKey =
-          keys.stream()
-              .filter(k -> kid.equals(((Map<?, ?>) k).get("kid")))
-              .map(k -> (Map<?, ?>) k)
-              .findFirst()
-              .orElseThrow(() -> new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED));
-
-      // RSA 공개키 생성
-      byte[] nBytes = Base64.getUrlDecoder().decode((String) matchedKey.get("n"));
-      byte[] eBytes = Base64.getUrlDecoder().decode((String) matchedKey.get("e"));
-      PublicKey publicKey =
-          KeyFactory.getInstance("RSA")
-              .generatePublic(
-                  new RSAPublicKeySpec(new BigInteger(1, nBytes), new BigInteger(1, eBytes)));
-
-      // JWT 검증
-      Claims claims =
+      claims =
           Jwts.parser()
-              .verifyWith((java.security.interfaces.RSAPublicKey) publicKey)
+              .keyLocator(new ApplePublicKeyLocator(applePublicKeys))
+              .requireIssuer(appleIssuer)
+              .requireAudience(appleBundleId)
               .build()
               .parseSignedClaims(identityToken)
               .getPayload();
+    } catch (JwtException | IllegalArgumentException e) {
+      log.warn("Apple identity token validation failed: {}", e.getMessage());
+      throw new BusinessException(ErrorStatus.AUTH_APPLE_INVALID_TOKEN, e);
+    }
 
-      if (!appleBundleId.equals(claims.getAudience().iterator().next())) {
-        throw new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED);
-      }
+    String providerId = claims.getSubject();
+    if (providerId == null || providerId.isBlank()) {
+      log.warn("Apple identity token missing sub claim");
+      throw new BusinessException(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+    }
+    String email = claims.get("email", String.class);
 
-      String providerId = claims.getSubject();
-      String email = claims.get("email", String.class);
+    AuthResponse response = buildResponse("apple", providerId, email, fullName);
+    log.info(
+        "Apple login succeeded, userId={}, isNew={}", response.getUser().getId(), response.isNew());
+    return response;
+  }
 
-      return buildResponse("apple", providerId, email, fullName);
-    } catch (BusinessException e) {
-      throw e;
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> fetchApplePublicKeys() {
+    Map<?, ?> response;
+    try {
+      response =
+          webClientBuilder
+              .build()
+              .get()
+              .uri(appleKeysUrl)
+              .retrieve()
+              .bodyToMono(Map.class)
+              .timeout(Duration.ofSeconds(appleRequestTimeoutSeconds))
+              .block();
     } catch (Exception e) {
-      throw new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED, e);
+      log.warn("Apple public keys fetch failed", e);
+      throw new BusinessException(ErrorStatus.AUTH_APPLE_KEY_UNAVAILABLE, e);
+    }
+    if (response == null || !(response.get("keys") instanceof List<?> keys) || keys.isEmpty()) {
+      log.warn("Apple public keys response was empty or malformed");
+      throw new BusinessException(ErrorStatus.AUTH_APPLE_KEY_UNAVAILABLE);
+    }
+    return keys.stream()
+        .filter(Map.class::isInstance)
+        .map(k -> (Map<String, Object>) k)
+        .toList();
+  }
+
+  // kid 기반으로 Apple 공개키를 선택. JJWT가 서명 검증·exp 만료 검증을 담당한다.
+  private static class ApplePublicKeyLocator extends LocatorAdapter<Key> {
+    private final List<Map<String, Object>> keys;
+
+    ApplePublicKeyLocator(List<Map<String, Object>> keys) {
+      this.keys = keys;
+    }
+
+    @Override
+    protected Key locate(ProtectedHeader header) {
+      String kid = header.getKeyId();
+      if (kid == null || kid.isBlank()) return null;
+      return keys.stream()
+          .filter(k -> kid.equals(k.get("kid")))
+          .findFirst()
+          .map(ApplePublicKeyLocator::toPublicKey)
+          .orElse(null);
+    }
+
+    private static PublicKey toPublicKey(Map<String, Object> key) {
+      try {
+        byte[] nBytes = Base64.getUrlDecoder().decode((String) key.get("n"));
+        byte[] eBytes = Base64.getUrlDecoder().decode((String) key.get("e"));
+        return KeyFactory.getInstance("RSA")
+            .generatePublic(
+                new RSAPublicKeySpec(new BigInteger(1, nBytes), new BigInteger(1, eBytes)));
+      } catch (Exception e) {
+        return null;
+      }
     }
   }
 

--- a/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
+++ b/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
@@ -17,6 +17,10 @@ public enum ErrorStatus {
 
   // Auth
   AUTH_OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "OAuth 인증에 실패했습니다."),
+  AUTH_APPLE_INVALID_TOKEN(
+      HttpStatus.UNAUTHORIZED, "AUTH_401_002", "Apple 인증 토큰이 유효하지 않습니다."),
+  AUTH_APPLE_KEY_UNAVAILABLE(
+      HttpStatus.BAD_GATEWAY, "AUTH_502_001", "Apple 공개키를 조회하지 못했습니다."),
   AUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_403_001", "접근 권한이 없습니다."),
 
   // User

--- a/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
+++ b/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
@@ -17,10 +17,8 @@ public enum ErrorStatus {
 
   // Auth
   AUTH_OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "OAuth 인증에 실패했습니다."),
-  AUTH_APPLE_INVALID_TOKEN(
-      HttpStatus.UNAUTHORIZED, "AUTH_401_002", "Apple 인증 토큰이 유효하지 않습니다."),
-  AUTH_APPLE_KEY_UNAVAILABLE(
-      HttpStatus.BAD_GATEWAY, "AUTH_502_001", "Apple 공개키를 조회하지 못했습니다."),
+  AUTH_APPLE_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_002", "Apple 인증 토큰이 유효하지 않습니다."),
+  AUTH_APPLE_KEY_UNAVAILABLE(HttpStatus.BAD_GATEWAY, "AUTH_502_001", "Apple 공개키를 조회하지 못했습니다."),
   AUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_403_001", "접근 권한이 없습니다."),
 
   // User

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,6 +22,8 @@ kakao:
 apple:
   bundle-id: com.minnnj.offmode
   keys-url: https://appleid.apple.com/auth/keys
+  issuer: https://appleid.apple.com
+  request-timeout-seconds: 5
 
 file:
   upload-dir: ${FILE_UPLOAD_DIR:./uploads}

--- a/backend/src/test/java/com/offmode/boundedcontext/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/auth/service/AuthServiceTest.java
@@ -348,7 +348,6 @@ class AuthServiceTest {
   private WebClient.Builder appleKeysErrorBuilder() {
     return WebClient.builder()
         .exchangeFunction(
-            request ->
-                Mono.just(ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).build()));
+            request -> Mono.just(ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).build()));
   }
 }

--- a/backend/src/test/java/com/offmode/boundedcontext/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/auth/service/AuthServiceTest.java
@@ -7,12 +7,28 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.offmode.boundedcontext.auth.dto.response.AuthResponse;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.jwt.JwtProvider;
+import com.offmode.global.status.ErrorStatus;
+import io.jsonwebtoken.Jwts;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,19 +43,38 @@ import reactor.core.publisher.Mono;
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
+  private static final String APPLE_ISSUER = "https://appleid.apple.com";
+  private static final String APPLE_AUDIENCE = "com.minnnj.offmode";
+  private static final String APPLE_KID = "test-kid";
+
+  private static KeyPair appleKeyPair;
+  private static Map<String, Object> appleJwk;
+
   @Mock private UserRepository userRepository;
   @Mock private JwtProvider jwtProvider;
 
   private AuthService authService;
+
+  @BeforeAll
+  static void generateAppleKey() throws Exception {
+    KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+    gen.initialize(2048);
+    appleKeyPair = gen.generateKeyPair();
+    appleJwk = jwkFor((RSAPublicKey) appleKeyPair.getPublic(), APPLE_KID);
+  }
 
   @BeforeEach
   void setUp() {
     authService = new AuthService(userRepository, jwtProvider, kakaoSuccessBuilder());
     ReflectionTestUtils.setField(authService, "kakaoUserInfoUrl", "https://kakao.test/me");
     ReflectionTestUtils.setField(authService, "kakaoRequestTimeoutSeconds", 5L);
-    ReflectionTestUtils.setField(authService, "appleBundleId", "com.minnnj.offmode");
+    ReflectionTestUtils.setField(authService, "appleBundleId", APPLE_AUDIENCE);
     ReflectionTestUtils.setField(authService, "appleKeysUrl", "https://apple.test/keys");
+    ReflectionTestUtils.setField(authService, "appleIssuer", APPLE_ISSUER);
+    ReflectionTestUtils.setField(authService, "appleRequestTimeoutSeconds", 5L);
   }
+
+  // ── Kakao ──────────────────────────────────────────────
 
   @Test
   void kakaoLoginCreatesUserAndReturnsJwt() {
@@ -74,15 +109,207 @@ class AuthServiceTest {
     verify(userRepository, never()).save(any());
   }
 
+  // ── Apple ──────────────────────────────────────────────
+
+  @Test
+  void appleLoginSucceedsWithValidToken() {
+    setAppleKeysBuilder(appleJwk);
+    String token = appleTokenBuilder().compact();
+
+    User saved =
+        User.builder()
+            .id(7L)
+            .provider("apple")
+            .providerId("apple-user-1")
+            .email("apple@example.com")
+            .name("Apple User")
+            .build();
+    when(userRepository.findByProviderAndProviderId("apple", "apple-user-1"))
+        .thenReturn(Optional.empty());
+    when(userRepository.save(any(User.class))).thenReturn(saved);
+    when(jwtProvider.generate(7L)).thenReturn("apple-jwt");
+
+    AuthResponse response = authService.appleLogin(token, "Apple User");
+
+    assertThat(response.getToken()).isEqualTo("apple-jwt");
+    assertThat(response.getUser()).isSameAs(saved);
+    assertThat(response.isNew()).isTrue();
+  }
+
   @Test
   void appleLoginRejectsMalformedIdentityToken() {
-    authService = new AuthService(userRepository, jwtProvider, appleKeysBuilder());
-    ReflectionTestUtils.setField(authService, "appleBundleId", "com.minnnj.offmode");
-    ReflectionTestUtils.setField(authService, "appleKeysUrl", "https://apple.test/keys");
+    setAppleKeysBuilder(appleJwk);
 
-    assertThatThrownBy(() -> authService.appleLogin("malformed-token", "Apple User"))
+    assertThatThrownBy(() -> authService.appleLogin("not-a-jwt", "Apple User"))
         .isInstanceOf(BusinessException.class)
-        .hasMessage("OAuth 인증에 실패했습니다.");
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+  }
+
+  @Test
+  void appleLoginRejectsBlankToken() {
+    assertThatThrownBy(() -> authService.appleLogin("   ", "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+  }
+
+  @Test
+  void appleLoginRejectsExpiredToken() {
+    setAppleKeysBuilder(appleJwk);
+    String expired =
+        appleTokenBuilder()
+            .issuedAt(Date.from(Instant.now().minus(Duration.ofHours(2))))
+            .expiration(Date.from(Instant.now().minus(Duration.ofHours(1))))
+            .compact();
+
+    assertThatThrownBy(() -> authService.appleLogin(expired, "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+  }
+
+  @Test
+  void appleLoginRejectsWrongIssuer() {
+    setAppleKeysBuilder(appleJwk);
+    String wrongIssuer = appleTokenBuilder().issuer("https://evil.example.com").compact();
+
+    assertThatThrownBy(() -> authService.appleLogin(wrongIssuer, "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+  }
+
+  @Test
+  void appleLoginRejectsWrongAudience() {
+    setAppleKeysBuilder(appleJwk);
+    String wrongAud =
+        appleTokenBuilder().audience().clear().add("com.someoneelse.app").and().compact();
+
+    assertThatThrownBy(() -> authService.appleLogin(wrongAud, "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+  }
+
+  @Test
+  void appleLoginRejectsUnknownKid() {
+    setAppleKeysBuilder(jwkFor((RSAPublicKey) appleKeyPair.getPublic(), "other-kid"));
+    String token = appleTokenBuilder().compact();
+
+    assertThatThrownBy(() -> authService.appleLogin(token, "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+  }
+
+  @Test
+  void appleLoginRejectsBlankSub() {
+    setAppleKeysBuilder(appleJwk);
+    String noSub = appleTokenBuilder().subject(null).compact();
+
+    assertThatThrownBy(() -> authService.appleLogin(noSub, "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_INVALID_TOKEN);
+  }
+
+  @Test
+  void appleLoginWrapsAppleKeysFetchFailure() {
+    authService = new AuthService(userRepository, jwtProvider, appleKeysErrorBuilder());
+    applyAppleConfig();
+    String token = appleTokenBuilder().compact();
+
+    assertThatThrownBy(() -> authService.appleLogin(token, "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_KEY_UNAVAILABLE);
+  }
+
+  @Test
+  void appleLoginRejectsEmptyKeysResponse() {
+    setAppleKeysBuilderWithBody("{ \"keys\": [] }");
+    String token = appleTokenBuilder().compact();
+
+    assertThatThrownBy(() -> authService.appleLogin(token, "Apple User"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.AUTH_APPLE_KEY_UNAVAILABLE);
+  }
+
+  // ── helpers ────────────────────────────────────────────
+
+  private io.jsonwebtoken.JwtBuilder appleTokenBuilder() {
+    PrivateKey privateKey = appleKeyPair.getPrivate();
+    return Jwts.builder()
+        .header()
+        .keyId(APPLE_KID)
+        .and()
+        .issuer(APPLE_ISSUER)
+        .audience()
+        .add(APPLE_AUDIENCE)
+        .and()
+        .subject("apple-user-1")
+        .issuedAt(Date.from(Instant.now()))
+        .expiration(Date.from(Instant.now().plus(Duration.ofMinutes(10))))
+        .claim("email", "apple@example.com")
+        .signWith(privateKey, Jwts.SIG.RS256);
+  }
+
+  private void setAppleKeysBuilder(Map<String, Object> jwk) {
+    String body;
+    try {
+      body = new ObjectMapper().writeValueAsString(Map.of("keys", List.of(jwk)));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    setAppleKeysBuilderWithBody(body);
+  }
+
+  private void setAppleKeysBuilderWithBody(String body) {
+    authService =
+        new AuthService(
+            userRepository,
+            jwtProvider,
+            WebClient.builder()
+                .exchangeFunction(
+                    request ->
+                        Mono.just(
+                            ClientResponse.create(HttpStatus.OK)
+                                .header("Content-Type", "application/json")
+                                .body(body)
+                                .build())));
+    applyAppleConfig();
+  }
+
+  private void applyAppleConfig() {
+    ReflectionTestUtils.setField(authService, "kakaoUserInfoUrl", "https://kakao.test/me");
+    ReflectionTestUtils.setField(authService, "kakaoRequestTimeoutSeconds", 5L);
+    ReflectionTestUtils.setField(authService, "appleBundleId", APPLE_AUDIENCE);
+    ReflectionTestUtils.setField(authService, "appleKeysUrl", "https://apple.test/keys");
+    ReflectionTestUtils.setField(authService, "appleIssuer", APPLE_ISSUER);
+    ReflectionTestUtils.setField(authService, "appleRequestTimeoutSeconds", 5L);
+  }
+
+  private static Map<String, Object> jwkFor(RSAPublicKey pub, String kid) {
+    Map<String, Object> jwk = new LinkedHashMap<>();
+    jwk.put("kty", "RSA");
+    jwk.put("alg", "RS256");
+    jwk.put("use", "sig");
+    jwk.put("kid", kid);
+    jwk.put("n", b64Url(pub.getModulus()));
+    jwk.put("e", b64Url(pub.getPublicExponent()));
+    return jwk;
+  }
+
+  private static String b64Url(BigInteger value) {
+    byte[] bytes = value.toByteArray();
+    if (bytes.length > 1 && bytes[0] == 0) {
+      byte[] tmp = new byte[bytes.length - 1];
+      System.arraycopy(bytes, 1, tmp, 0, tmp.length);
+      bytes = tmp;
+    }
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
   }
 
   private WebClient.Builder kakaoSuccessBuilder() {
@@ -118,17 +345,10 @@ class AuthServiceTest {
                         .build()));
   }
 
-  private WebClient.Builder appleKeysBuilder() {
+  private WebClient.Builder appleKeysErrorBuilder() {
     return WebClient.builder()
         .exchangeFunction(
             request ->
-                Mono.just(
-                    ClientResponse.create(HttpStatus.OK)
-                        .header("Content-Type", "application/json")
-                        .body(
-                            """
-                            { "keys": [] }
-                            """)
-                        .build()));
+                Mono.just(ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).build()));
   }
 }


### PR DESCRIPTION
## 🔗 Issue

- close #46

---

## 📌 Summary

- 정규식 기반 `kid` 파싱을 JJWT `LocatorAdapter`로 교체해 토큰 형식 변화·비정상 입력에 견고하게 변경
- `requireIssuer(https://appleid.apple.com)` / `requireAudience(appleBundleId)` / `sub` blank 검증을 명시화 (만료는 `parseSignedClaims`가 담당)
- 토큰 무효(`AUTH_APPLE_INVALID_TOKEN`, 401)와 Apple 공개키 조회 실패(`AUTH_APPLE_KEY_UNAVAILABLE`, 502) 에러 코드 분리
- `apple.issuer` / `apple.request-timeout-seconds` 설정 추가
- 만료·잘못된 iss/aud·알 수 없는 kid·빈 sub·공개키 조회 실패·빈 keys 응답 등 실패 케이스 테스트 추가 (RSA 키페어를 테스트 내에서 생성해 실제 서명/검증 경로 확인)

---

## ✅ Test

- [x] backend에서 ./gradlew test (AuthServiceTest 12개 포함 전체 통과)