### PR TITLE
[Chore] #74 햅틱 피드백과 효과음 임시 비활성화

### DIFF
--- a/screens/SettingsScreen.jsx
+++ b/screens/SettingsScreen.jsx
@@ -123,8 +123,9 @@ export default function SettingsScreen({
     ? `${pad(missionTime.hour)}:${pad(missionTime.minute)}`
     : '08:00';
 
-  const [haptic,    setHaptic]    = useState(H.isEnabled());
-  const [sound,     setSound]     = useState(false);
+  // TODO: 햅틱/효과음 정식 도입 시 설정 상태와 화면 노출을 복구한다.
+  // const [haptic,    setHaptic]    = useState(H.isEnabled());
+  // const [sound,     setSound]     = useState(false);
   const [pushNotif, setPushNotif] = useState(false);
   const [reminder,  setReminder]  = useState(false);
 
@@ -137,11 +138,12 @@ export default function SettingsScreen({
     })();
   }, []);
 
-  const handleHapticToggle = (v) => {
-    H.setEnabled(v);
-    setHaptic(v);
-    if (v) H.tap();
-  };
+  // TODO: 햅틱 정식 도입 시 복구한다.
+  // const handleHapticToggle = (v) => {
+  //   H.setEnabled(v);
+  //   setHaptic(v);
+  //   if (v) H.tap();
+  // };
 
   const handlePushNotif = async (v) => {
     if (v) {
@@ -261,7 +263,10 @@ export default function SettingsScreen({
                 onValueChange={(v) => setScheme(v ? 'dark' : 'light')}
               />
             }
+            last
           />
+          {/* TODO: 햅틱/효과음 정식 도입 시 설정 항목을 복구한다. */}
+          {/*
           <SettingRow
             icon="📳"
             label="햅틱 피드백"
@@ -273,6 +278,7 @@ export default function SettingsScreen({
             right={<OffSwitch value={sound} onValueChange={setSound} />}
             last
           />
+          */}
         </Section>
 
         {/* 정보 */}

--- a/utils/haptics.js
+++ b/utils/haptics.js
@@ -1,8 +1,8 @@
 /**
  * Haptics utility — 앱 전체에서 햅틱 피드백을 일관되게 사용하기 위한 모듈.
  *
- * 설정 화면의 토글과 연동되어 있음.
- * setEnabled(false) 하면 모든 햅틱이 무음 처리됨.
+ * TODO: 햅틱 정식 도입 전까지 실제 네이티브 호출은 비활성화한다.
+ * 재도입 시 아래 expo-haptics import와 각 함수의 원래 호출부를 복구한다.
  *
  * 사용법:
  *   import * as H from '../utils/haptics';
@@ -10,22 +10,22 @@
  *   H.medium();    // 중간 강도
  *   H.success();   // 완료 피드백
  */
-import * as Haptics from 'expo-haptics';
+// import * as Haptics from 'expo-haptics';
 
-let _enabled = true;
+let _enabled = false;
 
 export const setEnabled = (v) => { _enabled = v; };
 export const isEnabled  = ()  => _enabled;
 
 export const tap = () => {
-  if (_enabled) Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  // TODO: if (_enabled) Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
 };
 export const medium = () => {
-  if (_enabled) Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+  // TODO: if (_enabled) Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 };
 export const success = () => {
-  if (_enabled) Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  // TODO: if (_enabled) Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 };
 export const error = () => {
-  if (_enabled) Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+  // TODO: if (_enabled) Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
 };

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -4,7 +4,8 @@ import { Platform } from 'react-native';
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldShowAlert: true,
-    shouldPlaySound: true,
+    // TODO: 효과음 정식 도입 시 true로 복구한다.
+    shouldPlaySound: false,
     shouldSetBadge: false,
   }),
 });
@@ -28,7 +29,8 @@ export async function scheduleMissionNotification(hour, minute) {
     content: {
       title: '🎯 오늘의 미션 도착!',
       body: '지금 바로 확인하고 갓생을 시작해봐요 🔥',
-      sound: true,
+      // TODO: 효과음 정식 도입 시 true로 복구한다.
+      sound: false,
     },
     trigger: {
       type: Notifications.SchedulableTriggerInputTypes.DAILY,
@@ -51,7 +53,8 @@ export async function scheduleReminderNotification() {
     content: {
       title: '⏰ 오늘 미션 아직 완료 안 했어요!',
       body: '지금 완료하고 오늘 하루 마무리해요 🌙',
-      sound: true,
+      // TODO: 효과음 정식 도입 시 true로 복구한다.
+      sound: false,
     },
     trigger: {
       type: Notifications.SchedulableTriggerInputTypes.DAILY,

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -1,6 +1,8 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 
+const SILENT_NOTIFICATION_CHANNEL_ID = 'offmode-silent-notifications';
+
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldShowAlert: true,
@@ -17,12 +19,23 @@ export async function requestNotificationPermission() {
   return status === 'granted';
 }
 
+async function ensureSilentNotificationChannel() {
+  if (Platform.OS !== 'android') return;
+
+  await Notifications.setNotificationChannelAsync(SILENT_NOTIFICATION_CHANNEL_ID, {
+    name: 'Offmode notifications',
+    importance: Notifications.AndroidImportance.DEFAULT,
+    sound: null,
+  });
+}
+
 // 매일 설정한 시간에 반복 알림 예약 (기존 미션 알림 교체)
 export async function scheduleMissionNotification(hour, minute) {
   await cancelMissionNotification();
 
   const granted = await requestNotificationPermission();
   if (!granted) return;
+  await ensureSilentNotificationChannel();
 
   await Notifications.scheduleNotificationAsync({
     identifier: 'daily-mission',
@@ -36,6 +49,7 @@ export async function scheduleMissionNotification(hour, minute) {
       type: Notifications.SchedulableTriggerInputTypes.DAILY,
       hour,
       minute,
+      channelId: SILENT_NOTIFICATION_CHANNEL_ID,
     },
   });
 }
@@ -48,6 +62,7 @@ export async function scheduleReminderNotification() {
   await cancelReminderNotification();
   const granted = await requestNotificationPermission();
   if (!granted) return;
+  await ensureSilentNotificationChannel();
   await Notifications.scheduleNotificationAsync({
     identifier: 'daily-reminder',
     content: {
@@ -60,6 +75,7 @@ export async function scheduleReminderNotification() {
       type: Notifications.SchedulableTriggerInputTypes.DAILY,
       hour: 21,
       minute: 0,
+      channelId: SILENT_NOTIFICATION_CHANNEL_ID,
     },
   });
 }


### PR DESCRIPTION
## 🔗 Issue

- close #74

---

## 📌 Summary

- 설정 화면에서 햅틱 피드백과 효과음 토글 항목을 주석 처리해 노출되지 않도록 변경
- `utils/haptics.js`의 `expo-haptics` import와 실제 햅틱 호출을 임시 비활성화하고 재도입 TODO 추가
- 알림 핸들러와 예약 알림의 사운드 설정을 `false`로 변경해 효과음이 실행되지 않도록 처리

---

## ✅ Test

- [x] `npm run lint`
- [x] 설정 화면에서 햅틱 피드백/효과음 항목 미노출 확인


<img width="40%" alt="image" src="https://github.com/user-attachments/assets/62916519-f31f-4fa2-b335-8e4447f17540" />
 