### PR TITLE
[Fix] #73 피드 이모지 리액션 개별 집계 수정

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/api/v1/FeedController.java
@@ -3,6 +3,7 @@ package com.offmode.boundedcontext.feed.api.v1;
 import com.offmode.boundedcontext.feed.dto.request.ReactRequest;
 import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
 import com.offmode.boundedcontext.feed.dto.response.FeedStatsResponse;
+import com.offmode.boundedcontext.feed.dto.response.ReactionSummaryResponse;
 import com.offmode.boundedcontext.feed.dto.response.VerificationResponse;
 import com.offmode.boundedcontext.feed.service.FeedService;
 import jakarta.validation.Valid;
@@ -41,12 +42,11 @@ public class FeedController {
 
   // POST /api/v1/feed/{id}/react - 리액션 토글  body: { "emoji": "🔥" }
   @PostMapping("/{id}/react")
-  public ResponseEntity<Void> react(
+  public ResponseEntity<List<ReactionSummaryResponse>> react(
       @AuthenticationPrincipal Long userId,
       @PathVariable Long id,
       @Valid @RequestBody ReactRequest request) {
-    feedService.react(userId, id, request.getEmoji());
-    return ResponseEntity.ok().build();
+    return ResponseEntity.ok(feedService.react(userId, id, request.getEmoji()));
   }
 
   // POST /api/v1/feed/{id}/confirm - 피어 인증 (다른 사람의 인증 확인)

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/repository/ReactionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/repository/ReactionRepository.java
@@ -11,9 +11,21 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
   List<Reaction> findByVerificationIdAndUserId(Long verificationId, Long userId);
 
-  List<Reaction> findByVerificationIdIn(List<Long> ids);
+  @Query(
+      """
+        SELECT r.verification.id, r.emoji, r.user.id
+        FROM Reaction r
+        WHERE r.verification.id IN :ids
+    """)
+  List<Object[]> findRowsByVerificationIdIn(@Param("ids") List<Long> ids);
 
-  List<Reaction> findByVerificationId(Long verificationId);
+  @Query(
+      """
+        SELECT r.verification.id, r.emoji, r.user.id
+        FROM Reaction r
+        WHERE r.verification.id = :verificationId
+    """)
+  List<Object[]> findRowsByVerificationId(@Param("verificationId") Long verificationId);
 
   // 유저가 남긴 reaction 삭제
   @Modifying

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/repository/ReactionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/repository/ReactionRepository.java
@@ -2,7 +2,6 @@ package com.offmode.boundedcontext.feed.repository;
 
 import com.offmode.boundedcontext.feed.entity.Reaction;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,21 +9,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
-  Optional<Reaction> findByVerificationIdAndUserIdAndEmoji(
-      Long verificationId, Long userId, String emoji);
+  List<Reaction> findByVerificationIdAndUserId(Long verificationId, Long userId);
 
-  // 여러 인증에 대한 리액션 요약 (emoji별 count + 내가 눌렀는지)
-  @Query(
-      """
-        SELECT r.verification.id, r.emoji,
-               COUNT(r),
-               SUM(CASE WHEN r.user.id = :userId THEN 1 ELSE 0 END)
-        FROM Reaction r
-        WHERE r.verification.id IN :ids
-        GROUP BY r.verification.id, r.emoji
-        ORDER BY r.verification.id, COUNT(r) DESC
-    """)
-  List<Object[]> findSummaries(@Param("ids") List<Long> ids, @Param("userId") Long userId);
+  List<Reaction> findByVerificationIdIn(List<Long> ids);
+
+  List<Reaction> findByVerificationId(Long verificationId);
 
   // 유저가 남긴 reaction 삭제
   @Modifying

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
@@ -141,7 +141,7 @@ public class FeedService {
       reactionRepository.save(Reaction.builder().verification(v).user(user).emoji(emoji).build());
     }
 
-    return toReactionSummaries(reactionRepository.findByVerificationId(verificationId), userId);
+    return toReactionSummaries(reactionRepository.findRowsByVerificationId(verificationId), userId);
   }
 
   @Transactional(readOnly = true)
@@ -171,7 +171,7 @@ public class FeedService {
     // DB collation에 따른 이모지 GROUP BY 병합을 피하기 위해 애플리케이션에서 정확히 집계한다.
     List<Long> ids = items.stream().map(FeedItemResponse::getId).toList();
     Map<Long, List<ReactionSummaryResponse>> reactionMap =
-        toReactionSummaryMap(reactionRepository.findByVerificationIdIn(ids), userId);
+        toReactionSummaryMap(reactionRepository.findRowsByVerificationIdIn(ids), userId);
 
     items.forEach(
         item -> item.setReactions(reactionMap.getOrDefault(item.getId(), java.util.List.of())));
@@ -179,14 +179,16 @@ public class FeedService {
   }
 
   private Map<Long, List<ReactionSummaryResponse>> toReactionSummaryMap(
-      List<Reaction> reactions, Long userId) {
+      List<Object[]> reactionRows, Long userId) {
     Map<Long, Map<String, ReactionAggregate>> grouped = new HashMap<>();
-    for (Reaction reaction : reactions) {
-      Long verificationId = reaction.getVerification().getId();
+    for (Object[] row : reactionRows) {
+      Long verificationId = ((Number) row[0]).longValue();
+      String emoji = (String) row[1];
+      Long reactorId = ((Number) row[2]).longValue();
       grouped
           .computeIfAbsent(verificationId, key -> new LinkedHashMap<>())
-          .computeIfAbsent(reaction.getEmoji(), key -> new ReactionAggregate())
-          .add(reaction, userId);
+          .computeIfAbsent(emoji, key -> new ReactionAggregate())
+          .add(reactorId, userId);
     }
 
     Map<Long, List<ReactionSummaryResponse>> result = new HashMap<>();
@@ -209,10 +211,12 @@ public class FeedService {
     return result;
   }
 
-  private List<ReactionSummaryResponse> toReactionSummaries(List<Reaction> reactions, Long userId) {
-    Map<Long, List<ReactionSummaryResponse>> reactionMap = toReactionSummaryMap(reactions, userId);
-    if (reactions.isEmpty()) return List.of();
-    Long verificationId = reactions.getFirst().getVerification().getId();
+  private List<ReactionSummaryResponse> toReactionSummaries(
+      List<Object[]> reactionRows, Long userId) {
+    Map<Long, List<ReactionSummaryResponse>> reactionMap =
+        toReactionSummaryMap(reactionRows, userId);
+    if (reactionRows.isEmpty()) return List.of();
+    Long verificationId = ((Number) reactionRows.getFirst()[0]).longValue();
     return reactionMap.getOrDefault(verificationId, List.of());
   }
 
@@ -220,9 +224,9 @@ public class FeedService {
     private long count;
     private boolean myReact;
 
-    void add(Reaction reaction, Long viewerId) {
+    void add(Long reactorId, Long viewerId) {
       count++;
-      if (reaction.getUser().getId().equals(viewerId)) {
+      if (reactorId.equals(viewerId)) {
         myReact = true;
       }
     }

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
@@ -21,6 +21,9 @@ import com.offmode.global.file.ImageUploadService;
 import com.offmode.global.status.ErrorStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -117,23 +120,31 @@ public class FeedService {
   }
 
   @Transactional
-  public void react(Long userId, Long verificationId, String emoji) {
+  public List<ReactionSummaryResponse> react(Long userId, Long verificationId, String emoji) {
     Verification v =
         verificationRepository
             .findById(verificationId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.VERIFICATION_NOT_FOUND));
 
-    reactionRepository
-        .findByVerificationIdAndUserIdAndEmoji(verificationId, userId, emoji)
-        .ifPresentOrElse(
-            reactionRepository::delete, // 이미 있으면 취소(토글)
-            () -> { // 없으면 추가
-              User user = userService.getById(userId);
-              reactionRepository.save(
-                  Reaction.builder().verification(v).user(user).emoji(emoji).build());
-            });
+    List<Reaction> userReactions =
+        reactionRepository.findByVerificationIdAndUserId(verificationId, userId);
+    Reaction existing =
+        userReactions.stream()
+            .filter(reaction -> reaction.getEmoji().equals(emoji))
+            .findFirst()
+            .orElse(null);
+
+    if (existing != null) {
+      reactionRepository.delete(existing);
+    } else {
+      User user = userService.getById(userId);
+      reactionRepository.save(Reaction.builder().verification(v).user(user).emoji(emoji).build());
+    }
+
+    return toReactionSummaries(reactionRepository.findByVerificationId(verificationId), userId);
   }
 
+  @Transactional(readOnly = true)
   public List<FeedItemResponse> getFeed(Long userId, int page, int size) {
     // 오늘 내 미션 텍스트 조회 — 없으면 빈 피드 반환
     LocalDateTime todayStart = LocalDate.now().atStartOfDay();
@@ -157,25 +168,72 @@ public class FeedService {
     log.info("[GET-FEED] 필터 missionText='{}' → 조회된 피드 {}건", missionText, items.size());
     if (items.isEmpty()) return items;
 
-    // 한 번의 쿼리로 전체 리액션 요약 조회
+    // DB collation에 따른 이모지 GROUP BY 병합을 피하기 위해 애플리케이션에서 정확히 집계한다.
     List<Long> ids = items.stream().map(FeedItemResponse::getId).toList();
-    List<Object[]> rows = reactionRepository.findSummaries(ids, userId);
-
-    // verificationId → List<ReactionSummaryResponse> 맵 구성
-    Map<Long, List<ReactionSummaryResponse>> reactionMap = new java.util.HashMap<>();
-    for (Object[] row : rows) {
-      Long vId = (Long) row[0];
-      String emoji = (String) row[1];
-      long count = ((Number) row[2]).longValue();
-      boolean myReact = ((Number) row[3]).longValue() > 0;
-      reactionMap
-          .computeIfAbsent(vId, k -> new java.util.ArrayList<>())
-          .add(new ReactionSummaryResponse(emoji, count, myReact));
-    }
+    Map<Long, List<ReactionSummaryResponse>> reactionMap =
+        toReactionSummaryMap(reactionRepository.findByVerificationIdIn(ids), userId);
 
     items.forEach(
         item -> item.setReactions(reactionMap.getOrDefault(item.getId(), java.util.List.of())));
     return items;
+  }
+
+  private Map<Long, List<ReactionSummaryResponse>> toReactionSummaryMap(
+      List<Reaction> reactions, Long userId) {
+    Map<Long, Map<String, ReactionAggregate>> grouped = new HashMap<>();
+    for (Reaction reaction : reactions) {
+      Long verificationId = reaction.getVerification().getId();
+      grouped
+          .computeIfAbsent(verificationId, key -> new LinkedHashMap<>())
+          .computeIfAbsent(reaction.getEmoji(), key -> new ReactionAggregate())
+          .add(reaction, userId);
+    }
+
+    Map<Long, List<ReactionSummaryResponse>> result = new HashMap<>();
+    grouped.forEach(
+        (verificationId, emojiMap) ->
+            result.put(
+                verificationId,
+                emojiMap.entrySet().stream()
+                    .map(
+                        entry ->
+                            new ReactionSummaryResponse(
+                                entry.getKey(),
+                                entry.getValue().count(),
+                                entry.getValue().myReact()))
+                    .sorted(
+                        Comparator.comparingLong(ReactionSummaryResponse::count)
+                            .reversed()
+                            .thenComparing(ReactionSummaryResponse::emoji))
+                    .toList()));
+    return result;
+  }
+
+  private List<ReactionSummaryResponse> toReactionSummaries(List<Reaction> reactions, Long userId) {
+    Map<Long, List<ReactionSummaryResponse>> reactionMap = toReactionSummaryMap(reactions, userId);
+    if (reactions.isEmpty()) return List.of();
+    Long verificationId = reactions.getFirst().getVerification().getId();
+    return reactionMap.getOrDefault(verificationId, List.of());
+  }
+
+  private static class ReactionAggregate {
+    private long count;
+    private boolean myReact;
+
+    void add(Reaction reaction, Long viewerId) {
+      count++;
+      if (reaction.getUser().getId().equals(viewerId)) {
+        myReact = true;
+      }
+    }
+
+    long count() {
+      return count;
+    }
+
+    boolean myReact() {
+      return myReact;
+    }
   }
 
   public FeedStatsResponse getStats(Long userId) {

--- a/backend/src/main/resources/db/migration/h2/V3__fix_reaction_emoji_collation.sql
+++ b/backend/src/main/resources/db/migration/h2/V3__fix_reaction_emoji_collation.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reactions
+  ALTER COLUMN emoji VARCHAR(10) NOT NULL;

--- a/backend/src/main/resources/db/migration/mysql/V3__fix_reaction_emoji_collation.sql
+++ b/backend/src/main/resources/db/migration/mysql/V3__fix_reaction_emoji_collation.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reactions
+  MODIFY emoji VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/repository/VerificationRepositoryTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/repository/VerificationRepositoryTest.java
@@ -52,9 +52,11 @@ class VerificationRepositoryTest {
     reactionRepository.save(
         Reaction.builder().verification(verification).user(reactor).emoji("👍").build());
 
-    List<Reaction> result = reactionRepository.findByVerificationId(verification.getId());
+    List<Object[]> result = reactionRepository.findRowsByVerificationId(verification.getId());
 
-    assertThat(result).extracting(Reaction::getEmoji).containsExactlyInAnyOrder("🔥", "🔥", "👍");
+    assertThat(result)
+        .extracting(row -> (String) row[1])
+        .containsExactlyInAnyOrder("🔥", "🔥", "👍");
   }
 
   private User saveUser(String providerId) {

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/repository/VerificationRepositoryTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/repository/VerificationRepositoryTest.java
@@ -3,6 +3,7 @@ package com.offmode.boundedcontext.feed.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
+import com.offmode.boundedcontext.feed.entity.Reaction;
 import com.offmode.boundedcontext.feed.entity.Verification;
 import com.offmode.boundedcontext.mission.entity.UserMission;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.PageRequest;
 class VerificationRepositoryTest {
 
   @Autowired private VerificationRepository verificationRepository;
+  @Autowired private ReactionRepository reactionRepository;
   @Autowired private UserMissionRepository userMissionRepository;
   @Autowired private UserRepository userRepository;
 
@@ -37,12 +39,30 @@ class VerificationRepositoryTest {
     assertThat(result).extracting(FeedItemResponse::getMissionText).containsExactly("물 마시기");
   }
 
+  @Test
+  void findByVerificationIdReturnsEachEmojiReactionSeparately() {
+    User owner = saveUser("owner");
+    User viewer = saveUser("viewer");
+    User reactor = saveUser("reactor");
+    Verification verification = saveVerification(owner, "물 마시기", "caption");
+    reactionRepository.save(
+        Reaction.builder().verification(verification).user(viewer).emoji("🔥").build());
+    reactionRepository.save(
+        Reaction.builder().verification(verification).user(reactor).emoji("🔥").build());
+    reactionRepository.save(
+        Reaction.builder().verification(verification).user(reactor).emoji("👍").build());
+
+    List<Reaction> result = reactionRepository.findByVerificationId(verification.getId());
+
+    assertThat(result).extracting(Reaction::getEmoji).containsExactlyInAnyOrder("🔥", "🔥", "👍");
+  }
+
   private User saveUser(String providerId) {
     return userRepository.save(
         User.builder().provider("kakao").providerId(providerId).name(providerId).build());
   }
 
-  private void saveVerification(User user, String missionText, String caption) {
+  private Verification saveVerification(User user, String missionText, String caption) {
     UserMission mission =
         userMissionRepository.save(
             UserMission.builder()
@@ -51,7 +71,7 @@ class VerificationRepositoryTest {
                 .missionText(missionText)
                 .missionCategory(MissionCategory.VITALITY)
                 .build());
-    verificationRepository.save(
+    return verificationRepository.save(
         Verification.builder().user(user).userMission(mission).caption(caption).build());
   }
 }

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
@@ -128,7 +128,7 @@ class FeedServiceTest {
         Reaction.builder().id(30L).verification(verification).user(user).emoji("🔥").build();
     when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
     when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of(reaction));
-    when(reactionRepository.findByVerificationId(20L)).thenReturn(List.of());
+    when(reactionRepository.findRowsByVerificationId(20L)).thenReturn(List.of());
 
     List<ReactionSummaryResponse> result = feedService.react(1L, 20L, "🔥");
 
@@ -144,12 +144,12 @@ class FeedServiceTest {
     when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
     when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of());
     when(userService.getById(1L)).thenReturn(viewer);
-    when(reactionRepository.findByVerificationId(20L))
+    when(reactionRepository.findRowsByVerificationId(20L))
         .thenReturn(
             List.of(
-                Reaction.builder().verification(verification).user(viewer).emoji("💜").build(),
-                Reaction.builder().verification(verification).user(reactor).emoji("🔥").build(),
-                Reaction.builder().verification(verification).user(reactor).emoji("👍").build()));
+                new Object[] {20L, "💜", 1L},
+                new Object[] {20L, "🔥", 2L},
+                new Object[] {20L, "👍", 2L}));
 
     List<ReactionSummaryResponse> result = feedService.react(1L, 20L, "💜");
 
@@ -172,11 +172,8 @@ class FeedServiceTest {
     when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
     when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of(heart));
     when(userService.getById(1L)).thenReturn(viewer);
-    when(reactionRepository.findByVerificationId(20L))
-        .thenReturn(
-            List.of(
-                heart,
-                Reaction.builder().verification(verification).user(viewer).emoji("👍").build()));
+    when(reactionRepository.findRowsByVerificationId(20L))
+        .thenReturn(List.of(new Object[] {20L, "💜", 1L}, new Object[] {20L, "👍", 1L}));
 
     List<ReactionSummaryResponse> result = feedService.react(1L, 20L, "👍");
 

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.offmode.boundedcontext.badge.service.BadgeService;
 import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
+import com.offmode.boundedcontext.feed.dto.response.ReactionSummaryResponse;
 import com.offmode.boundedcontext.feed.entity.Reaction;
 import com.offmode.boundedcontext.feed.entity.Verification;
 import com.offmode.boundedcontext.feed.repository.ReactionRepository;
@@ -126,12 +127,63 @@ class FeedServiceTest {
     Reaction reaction =
         Reaction.builder().id(30L).verification(verification).user(user).emoji("🔥").build();
     when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
-    when(reactionRepository.findByVerificationIdAndUserIdAndEmoji(20L, 1L, "🔥"))
-        .thenReturn(Optional.of(reaction));
+    when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of(reaction));
+    when(reactionRepository.findByVerificationId(20L)).thenReturn(List.of());
 
-    feedService.react(1L, 20L, "🔥");
+    List<ReactionSummaryResponse> result = feedService.react(1L, 20L, "🔥");
 
+    assertThat(result).isEmpty();
     verify(reactionRepository).delete(reaction);
+  }
+
+  @Test
+  void reactReturnsCountsGroupedByExactEmoji() {
+    User viewer = User.builder().id(1L).provider("kakao").providerId("viewer").build();
+    User reactor = User.builder().id(2L).provider("kakao").providerId("reactor").build();
+    Verification verification = Verification.builder().id(20L).build();
+    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of());
+    when(userService.getById(1L)).thenReturn(viewer);
+    when(reactionRepository.findByVerificationId(20L))
+        .thenReturn(
+            List.of(
+                Reaction.builder().verification(verification).user(viewer).emoji("💜").build(),
+                Reaction.builder().verification(verification).user(reactor).emoji("🔥").build(),
+                Reaction.builder().verification(verification).user(reactor).emoji("👍").build()));
+
+    List<ReactionSummaryResponse> result = feedService.react(1L, 20L, "💜");
+
+    assertThat(result)
+        .extracting(ReactionSummaryResponse::emoji)
+        .containsExactlyInAnyOrder("👍", "🔥", "💜");
+    assertThat(result).extracting(ReactionSummaryResponse::count).containsOnly(1L);
+    assertThat(result)
+        .filteredOn(reaction -> reaction.emoji().equals("💜"))
+        .extracting(ReactionSummaryResponse::myReact)
+        .containsExactly(true);
+  }
+
+  @Test
+  void reactDoesNotToggleDifferentEmojiFromSameUser() {
+    User viewer = User.builder().id(1L).provider("kakao").providerId("viewer").build();
+    Verification verification = Verification.builder().id(20L).build();
+    Reaction heart =
+        Reaction.builder().id(30L).verification(verification).user(viewer).emoji("💜").build();
+    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of(heart));
+    when(userService.getById(1L)).thenReturn(viewer);
+    when(reactionRepository.findByVerificationId(20L))
+        .thenReturn(
+            List.of(
+                heart,
+                Reaction.builder().verification(verification).user(viewer).emoji("👍").build()));
+
+    List<ReactionSummaryResponse> result = feedService.react(1L, 20L, "👍");
+
+    assertThat(result)
+        .extracting(ReactionSummaryResponse::emoji)
+        .containsExactlyInAnyOrder("💜", "👍");
+    assertThat(result).extracting(ReactionSummaryResponse::count).containsOnly(1L);
   }
 
   @Test

--- a/backend/src/test/java/com/offmode/global/config/FlywayMigrationTest.java
+++ b/backend/src/test/java/com/offmode/global/config/FlywayMigrationTest.java
@@ -39,6 +39,6 @@ class FlywayMigrationTest {
         Arrays.stream(flyway.info().applied()).filter(info -> info.getVersion() != null).count();
 
     assertThat(missionCount).isEqualTo(90);
-    assertThat(migrationCount).isEqualTo(2);
+    assertThat(migrationCount).isEqualTo(3);
   }
 }

--- a/screens/FeedScreen.jsx
+++ b/screens/FeedScreen.jsx
@@ -70,14 +70,14 @@ function normalizeEmojiKey(emoji) {
 function normalizeReactions(sourceReactions) {
   // 고정 3개는 항상 표시, 커스텀 이모지는 그 뒤에 추가
   const safeReactions = Array.isArray(sourceReactions) ? sourceReactions : [];
-  const reactionMap = {};
+  const reactionMap = new Map();
   safeReactions.forEach(r => {
     const emoji = normalizeEmojiKey(r.emoji);
-    if (emoji) reactionMap[emoji] = { ...r, emoji };
+    if (emoji) reactionMap.set(emoji, { ...r, emoji });
   });
   return [
-    ...FIXED_EMOJIS.map(e => reactionMap[e] ?? { emoji: e, count: 0, myReact: false }),
-    ...Object.values(reactionMap).filter(r => !FIXED_EMOJIS.includes(r.emoji)),
+    ...FIXED_EMOJIS.map(e => reactionMap.get(e) ?? { emoji: e, count: 0, myReact: false }),
+    ...Array.from(reactionMap.values()).filter(r => !FIXED_EMOJIS.includes(r.emoji)),
   ];
 }
 

--- a/screens/FeedScreen.jsx
+++ b/screens/FeedScreen.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import {
   View, Text, StyleSheet, ScrollView,
   TouchableOpacity, Dimensions, ActivityIndicator, Image,
   Modal, TextInput, KeyboardAvoidingView, Platform, Animated,
+  Alert, AppState, RefreshControl,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useColors } from '../utils/useColors';
@@ -60,17 +61,32 @@ const GRAD_PALETTE = [
   ['#ffd180','#e65100'], ['#90caf9','#1a3a6a'], ['#a5d6a7','#1b5e20'],
 ];
 
+const pad = n => String(n).padStart(2, '0');
+
+function normalizeEmojiKey(emoji) {
+  return String(emoji ?? '').trim().normalize('NFC');
+}
+
+function normalizeReactions(sourceReactions) {
+  // 고정 3개는 항상 표시, 커스텀 이모지는 그 뒤에 추가
+  const safeReactions = Array.isArray(sourceReactions) ? sourceReactions : [];
+  const reactionMap = {};
+  safeReactions.forEach(r => {
+    const emoji = normalizeEmojiKey(r.emoji);
+    if (emoji) reactionMap[emoji] = { ...r, emoji };
+  });
+  return [
+    ...FIXED_EMOJIS.map(e => reactionMap[e] ?? { emoji: e, count: 0, myReact: false }),
+    ...Object.values(reactionMap).filter(r => !FIXED_EMOJIS.includes(r.emoji)),
+  ];
+}
+
+function applyServerReactions(item, reactions) {
+  return { ...item, reactions: normalizeReactions(reactions) };
+}
+
 function apiItemToCard(item, idx) {
   const d = new Date(item.createdAt);
-  const pad = n => String(n).padStart(2, '0');
-  // 고정 3개는 항상 표시, 커스텀 이모지는 그 뒤에 추가
-  const backendReactions = item.reactions ?? [];
-  const reactionMap = {};
-  backendReactions.forEach(r => { reactionMap[r.emoji] = r; });
-  const reactions = [
-    ...FIXED_EMOJIS.map(e => reactionMap[e] ?? { emoji: e, count: 0, myReact: false }),
-    ...backendReactions.filter(r => !FIXED_EMOJIS.includes(r.emoji)),
-  ];
   return {
     id:           item.id,
     user:         item.userName    ?? '오프모더',
@@ -84,7 +100,7 @@ function apiItemToCard(item, idx) {
     label:        '미션 완료',
     status:       (item.verifyCount ?? 0) > 0 ? 'done' : 'pending',
     grad:         GRAD_PALETTE[idx % GRAD_PALETTE.length],
-    reactions,
+    reactions:     normalizeReactions(item.reactions),
     caption:      item.caption  ?? null,
     photoUrl:     item.photoUrl ? `${BASE_URL}${item.photoUrl}` : null,
     missionIcon:  item.missionIcon,
@@ -328,20 +344,52 @@ export default function FeedScreen() {
   const [items,        setItems]        = useState([]);
   const [filter,       setFilter]       = useState('전체');
   const [loading,      setLoading]      = useState(true);
+  const [refreshing,   setRefreshing]   = useState(false);
   const [todayMission, setTodayMission] = useState(null);
 
-  useEffect(() => {
-    api.get('/api/v1/missions/today')
-      .then(setTodayMission)
-      .catch(() => {});
-
-    api.get('/api/v1/feed')
-      .then(data => setItems(data.map(apiItemToCard)))
-      .catch(e => console.warn('피드 로딩 실패:', e))
-      .finally(() => setLoading(false));
+  const loadFeed = useCallback(async ({ showLoading = false, showError = false } = {}) => {
+    if (showLoading) setLoading(true);
+    try {
+      const [mission, feed] = await Promise.all([
+        api.get('/api/v1/missions/today').catch(() => null),
+        api.get('/api/v1/feed'),
+      ]);
+      setTodayMission(mission);
+      setItems(feed.map(apiItemToCard));
+    } catch (e) {
+      console.warn('피드 로딩 실패:', e);
+      if (showError) Alert.alert('피드를 새로고침하지 못했어요', e?.message || '잠시 후 다시 시도해주세요.');
+    } finally {
+      if (showLoading) setLoading(false);
+    }
   }, []);
 
-  const handleReact = (id, emoji) => {
+  useEffect(() => {
+    loadFeed({ showLoading: true, showError: true });
+
+    const intervalId = setInterval(() => {
+      loadFeed();
+    }, 15000);
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') loadFeed();
+    });
+
+    return () => {
+      clearInterval(intervalId);
+      subscription.remove();
+    };
+  }, [loadFeed]);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await loadFeed({ showError: true });
+    setRefreshing(false);
+  }, [loadFeed]);
+
+  const handleReact = async (id, emoji) => {
+    const emojiKey = normalizeEmojiKey(emoji);
+    if (!emojiKey) return;
+
     const toggle = (reactions, emoji, direction) => {
       const existing = reactions.find(r => r.emoji === emoji);
       if (existing) {
@@ -356,22 +404,31 @@ export default function FeedScreen() {
       return direction > 0 ? [...reactions, { emoji, count: 1, myReact: true }] : reactions;
     };
 
+    const previousReactions = items.find(item => item.id === id)?.reactions ?? null;
     // 낙관적 업데이트
     setItems(prev => prev.map(item => {
       if (item.id !== id) return item;
-      const already = item.reactions.find(r => r.emoji === emoji)?.myReact ?? false;
-      return { ...item, reactions: toggle(item.reactions, emoji, already ? -1 : 1) };
+      const already = item.reactions.find(r => r.emoji === emojiKey)?.myReact ?? false;
+      return { ...item, reactions: toggle(item.reactions, emojiKey, already ? -1 : 1) };
     }));
 
-    api.post(`/api/v1/feed/${id}/react`, { emoji }).catch(e => {
+    try {
+      const serverReactions = await api.post(`/api/v1/feed/${id}/react`, { emoji: emojiKey });
+      if (Array.isArray(serverReactions)) {
+        setItems(prev => prev.map(item => (
+          item.id === id ? applyServerReactions(item, serverReactions) : item
+        )));
+      } else {
+        loadFeed();
+      }
+    } catch (e) {
       console.warn('리액션 실패:', e);
-      // 롤백
+      Alert.alert('리액션을 반영하지 못했어요', e?.message || '잠시 후 다시 시도해주세요.');
       setItems(prev => prev.map(item => {
         if (item.id !== id) return item;
-        const wasActive = item.reactions.find(r => r.emoji === emoji)?.myReact ?? false;
-        return { ...item, reactions: toggle(item.reactions, emoji, wasActive ? -1 : 1) };
+        return previousReactions ? { ...item, reactions: previousReactions } : item;
       }));
-    });
+    }
   };
 
   const handleVerify = async (id) => {
@@ -412,7 +469,12 @@ export default function FeedScreen() {
         </View>
       </View>
       {loading ? <FeedSkeleton /> : (
-        <ScrollView showsVerticalScrollIndicator={false}>
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={C.green} />
+          }
+        >
           <View style={s.missionBar}>
             <View style={s.missionNameRow}>
               <Text style={s.missionIcon}>{todayMission?.missionIcon ?? featured?.missionIcon ?? '📋'}</Text>


### PR DESCRIPTION
## 🔗 Issue

- close #73

---

## 📌 Summary

- 피드 이모지 리액션 토글 API가 최신 이모지별 집계를 반환하도록 수정
- DB collation 영향으로 다른 이모지가 같은 값처럼 처리되는 문제를 피하도록 서버에서 정확한 문자열 기준으로 토글/집계
- 프론트에서 리액션 응답 동기화, 실패 롤백, 새로고침/앱 복귀 시 피드 재조회 처리 보강

---

## ✅ Test

- [x] `backend/.\gradlew.bat test`
- [x] `npm run lint`
- [x] `backend/.\gradlew.bat spotlessApply`