### PR TITLE
[Infra] #81 EC2 백엔드 자동 배포 워크플로 추가

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -2,11 +2,10 @@ name: Deploy Backend
 
 on:
   push:
-    branches: ["main"]
-  workflow_dispatch:
+    tags: ["v*.*.*"]
 
 concurrency:
-  group: deploy-backend-main
+  group: deploy-backend-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -19,11 +18,31 @@ jobs:
       EC2_USER: ${{ secrets.EC2_USER || 'ec2-user' }}
       DEPLOY_PATH: ${{ vars.EC2_DEPLOY_PATH || '/home/ec2-user/offmode' }}
       BACKEND_ENV_FILE: ${{ vars.EC2_BACKEND_ENV_FILE || '.env' }}
-      CONTAINER_NAME: offmode-backend
+      CONTAINER_NAME: offmode
       IMAGE_NAME: offmode-backend
+      IMAGE_TAG: ${{ github.ref_name }}
       HOST_PORT: "8080"
 
     steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Validate tag is included in main
+        run: |
+          git fetch origin main:refs/remotes/origin/main --tags
+          tag_commit="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+
+          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
+            echo "Tag $GITHUB_REF_NAME ($tag_commit) is not included in origin/main."
+            echo "Merge the release commit into main before pushing the version tag."
+            exit 1
+          fi
+
+          echo "Deploying $GITHUB_REF_NAME from main commit $tag_commit"
+
       - name: Validate deployment secrets
         run: |
           test -n "$EC2_HOST" || (echo "EC2_HOST secret is required" && exit 1)
@@ -42,7 +61,7 @@ jobs:
           printf -v env_file_q '%q' "$BACKEND_ENV_FILE"
           printf -v container_name_q '%q' "$CONTAINER_NAME"
           printf -v image_name_q '%q' "$IMAGE_NAME"
-          printf -v image_tag_q '%q' "${GITHUB_SHA}"
+          printf -v image_tag_q '%q' "$IMAGE_TAG"
           printf -v host_port_q '%q' "$HOST_PORT"
 
           ssh -i ~/.ssh/offmode-ec2.pem "$EC2_USER@$EC2_HOST" \
@@ -50,9 +69,15 @@ jobs:
           set -Eeuo pipefail
 
           cd "$DEPLOY_PATH"
-          git fetch origin main
-          git switch main
-          git pull --ff-only origin main
+          git fetch origin main:refs/remotes/origin/main --tags
+          tag_commit="$(git rev-list -n 1 "$IMAGE_TAG")"
+
+          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
+            echo "Tag $IMAGE_TAG ($tag_commit) is not included in origin/main."
+            exit 1
+          fi
+
+          git checkout --detach "$tag_commit"
 
           cd backend
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,108 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend-main
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      EC2_HOST: ${{ secrets.EC2_HOST }}
+      EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+      EC2_USER: ${{ secrets.EC2_USER || 'ec2-user' }}
+      DEPLOY_PATH: ${{ vars.EC2_DEPLOY_PATH || '/home/ec2-user/offmode' }}
+      BACKEND_ENV_FILE: ${{ vars.EC2_BACKEND_ENV_FILE || '.env' }}
+      CONTAINER_NAME: offmode-backend
+      IMAGE_NAME: offmode-backend
+      HOST_PORT: "8080"
+
+    steps:
+      - name: Validate deployment secrets
+        run: |
+          test -n "$EC2_HOST" || (echo "EC2_HOST secret is required" && exit 1)
+          test -n "$EC2_SSH_KEY" || (echo "EC2_SSH_KEY secret is required" && exit 1)
+
+      - name: Configure SSH key
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$EC2_SSH_KEY" > ~/.ssh/offmode-ec2.pem
+          chmod 600 ~/.ssh/offmode-ec2.pem
+          ssh-keyscan -H "$EC2_HOST" >> ~/.ssh/known_hosts
+
+      - name: Deploy backend on EC2
+        run: |
+          printf -v deploy_path_q '%q' "$DEPLOY_PATH"
+          printf -v env_file_q '%q' "$BACKEND_ENV_FILE"
+          printf -v container_name_q '%q' "$CONTAINER_NAME"
+          printf -v image_name_q '%q' "$IMAGE_NAME"
+          printf -v image_tag_q '%q' "${GITHUB_SHA}"
+          printf -v host_port_q '%q' "$HOST_PORT"
+
+          ssh -i ~/.ssh/offmode-ec2.pem "$EC2_USER@$EC2_HOST" \
+            "DEPLOY_PATH=$deploy_path_q BACKEND_ENV_FILE=$env_file_q CONTAINER_NAME=$container_name_q IMAGE_NAME=$image_name_q IMAGE_TAG=$image_tag_q HOST_PORT=$host_port_q bash -s" <<'REMOTE_SCRIPT'
+          set -Eeuo pipefail
+
+          cd "$DEPLOY_PATH"
+          git fetch origin main
+          git switch main
+          git pull --ff-only origin main
+
+          cd backend
+
+          if [ ! -f "$BACKEND_ENV_FILE" ]; then
+            echo "Missing backend environment file: $(pwd)/$BACKEND_ENV_FILE"
+            exit 1
+          fi
+
+          previous_image="$(docker inspect --format='{{.Config.Image}}' "$CONTAINER_NAME" 2>/dev/null || true)"
+          next_image="$IMAGE_NAME:$IMAGE_TAG"
+          healthcheck_url="http://localhost:${HOST_PORT}/api/v1/health"
+
+          docker build -t "$next_image" -t "$IMAGE_NAME:latest" .
+
+          docker stop "$CONTAINER_NAME" 2>/dev/null || true
+          docker rm "$CONTAINER_NAME" 2>/dev/null || true
+
+          docker run -d \
+            --name "$CONTAINER_NAME" \
+            --env-file "$BACKEND_ENV_FILE" \
+            -e SPRING_PROFILES_ACTIVE=prod \
+            -p "${HOST_PORT}:8080" \
+            --restart unless-stopped \
+            "$next_image"
+
+          for attempt in $(seq 1 30); do
+            if curl -fsS "$healthcheck_url"; then
+              echo "Backend deployment succeeded"
+              docker logs --tail=100 "$CONTAINER_NAME"
+              exit 0
+            fi
+            echo "Waiting for backend healthcheck ($attempt/30)"
+            sleep 3
+          done
+
+          echo "Backend healthcheck failed. Recent container logs:"
+          docker logs --tail=200 "$CONTAINER_NAME" || true
+
+          if [ -n "$previous_image" ]; then
+            echo "Rolling back to previous image: $previous_image"
+            docker stop "$CONTAINER_NAME" 2>/dev/null || true
+            docker rm "$CONTAINER_NAME" 2>/dev/null || true
+            docker run -d \
+              --name "$CONTAINER_NAME" \
+              --env-file "$BACKEND_ENV_FILE" \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              -p "${HOST_PORT}:8080" \
+              --restart unless-stopped \
+              "$previous_image"
+          fi
+
+          exit 1
+          REMOTE_SCRIPT

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -90,18 +90,41 @@ jobs:
           next_image="$IMAGE_NAME:$IMAGE_TAG"
           healthcheck_url="http://localhost:${HOST_PORT}/api/v1/health"
 
+          rollback_to_previous_image() {
+            if [ -z "$previous_image" ]; then
+              echo "No previous image found. Rollback skipped."
+              return
+            fi
+
+            echo "Rolling back to previous image: $previous_image"
+            docker stop "$CONTAINER_NAME" 2>/dev/null || true
+            docker rm "$CONTAINER_NAME" 2>/dev/null || true
+            docker run -d \
+              --name "$CONTAINER_NAME" \
+              --env-file "$BACKEND_ENV_FILE" \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              -p "${HOST_PORT}:8080" \
+              --restart unless-stopped \
+              "$previous_image" || echo "Rollback container start failed."
+          }
+
           docker build -t "$next_image" -t "$IMAGE_NAME:latest" .
 
           docker stop "$CONTAINER_NAME" 2>/dev/null || true
           docker rm "$CONTAINER_NAME" 2>/dev/null || true
 
-          docker run -d \
+          if ! docker run -d \
             --name "$CONTAINER_NAME" \
             --env-file "$BACKEND_ENV_FILE" \
             -e SPRING_PROFILES_ACTIVE=prod \
             -p "${HOST_PORT}:8080" \
             --restart unless-stopped \
-            "$next_image"
+            "$next_image"; then
+            echo "Backend container start failed."
+            docker ps -a --filter "name=$CONTAINER_NAME"
+            rollback_to_previous_image
+            exit 1
+          fi
 
           for attempt in $(seq 1 30); do
             if curl -fsS "$healthcheck_url"; then
@@ -116,18 +139,7 @@ jobs:
           echo "Backend healthcheck failed. Recent container logs:"
           docker logs --tail=200 "$CONTAINER_NAME" || true
 
-          if [ -n "$previous_image" ]; then
-            echo "Rolling back to previous image: $previous_image"
-            docker stop "$CONTAINER_NAME" 2>/dev/null || true
-            docker rm "$CONTAINER_NAME" 2>/dev/null || true
-            docker run -d \
-              --name "$CONTAINER_NAME" \
-              --env-file "$BACKEND_ENV_FILE" \
-              -e SPRING_PROFILES_ACTIVE=prod \
-              -p "${HOST_PORT}:8080" \
-              --restart unless-stopped \
-              "$previous_image"
-          fi
+          rollback_to_previous_image
 
           exit 1
           REMOTE_SCRIPT

--- a/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/offmode/global/config/SecurityConfig.java
@@ -74,7 +74,8 @@ public class SecurityConfig {
   }
 
   private String[] getPublicEndpoints() {
-    List<String> endpoints = new ArrayList<>(List.of("/api/v1/auth/**", "/health", "/uploads/**"));
+    List<String> endpoints =
+        new ArrayList<>(List.of("/api/v1/auth/**", "/api/v1/health", "/uploads/**"));
     if (isDevProfile()) {
       endpoints.add("/h2-console/**");
     }

--- a/backend/src/main/java/com/offmode/global/health/HealthController.java
+++ b/backend/src/main/java/com/offmode/global/health/HealthController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HealthController {
 
-  @GetMapping("/health")
+  @GetMapping({"/api/v1/health"})
   public Map<String, String> health() {
     return Map.of("status", "UP");
   }

--- a/backend/src/main/java/com/offmode/global/health/HealthController.java
+++ b/backend/src/main/java/com/offmode/global/health/HealthController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HealthController {
 
-  @GetMapping({"/api/v1/health"})
+  @GetMapping("/api/v1/health")
   public Map<String, String> health() {
     return Map.of("status", "UP");
   }

--- a/backend/src/test/java/com/offmode/global/health/HealthControllerTest.java
+++ b/backend/src/test/java/com/offmode/global/health/HealthControllerTest.java
@@ -23,9 +23,9 @@ class HealthControllerTest {
   @MockitoBean private JwtProvider jwtProvider;
 
   @Test
-  void healthReturnsUpWithoutAuthentication() throws Exception {
+  void apiV1HealthReturnsUpWithoutAuthentication() throws Exception {
     mockMvc
-        .perform(get("/health"))
+        .perform(get("/api/v1/health"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("UP"));
   }

--- a/docs/backend-ec2-deploy.md
+++ b/docs/backend-ec2-deploy.md
@@ -1,15 +1,31 @@
 # 백엔드 EC2 자동 배포
 
-`main` 브랜치에 push 또는 PR merge가 발생하면 `.github/workflows/deploy-backend.yml` 워크플로가 EC2에 SSH로 접속해 백엔드 컨테이너를 재배포합니다.
+`main` 브랜치에 PR을 머지한 뒤 `main`에 포함된 커밋에 `v1.0.0` 같은 버전 태그를 push하면 `.github/workflows/deploy-backend.yml` 워크플로가 EC2에 SSH로 접속해 백엔드 컨테이너를 재배포합니다.
 
 ## 배포 방식
 
 1. GitHub Actions가 EC2에 SSH 접속합니다.
-2. EC2의 기존 저장소에서 `main` 브랜치를 최신 상태로 갱신합니다.
-3. `backend` 디렉터리에서 Docker 이미지를 EC2 내부에서 빌드합니다.
-4. 기존 `offmode-backend` 컨테이너를 중지/삭제하고 새 컨테이너를 실행합니다.
-5. `http://localhost:8080/api/v1/health` 헬스체크가 성공하면 배포를 완료합니다.
-6. 헬스체크 실패 시 GitHub Actions 로그에 최근 컨테이너 로그를 남기고, 이전 이미지가 있으면 이전 이미지로 컨테이너를 다시 실행합니다.
+2. GitHub Actions와 EC2에서 배포 대상 태그가 `origin/main`에 포함된 커밋인지 확인합니다.
+3. EC2의 기존 저장소에서 Git 태그를 갱신한 뒤 배포 대상 버전 태그 커밋을 checkout합니다.
+4. `backend` 디렉터리에서 Docker 이미지를 EC2 내부에서 `offmode-backend:v1.0.0` 형식으로 빌드합니다.
+5. 기존 `offmode` 컨테이너를 중지/삭제하고 새 컨테이너를 실행합니다.
+6. `http://localhost:8080/api/v1/health` 헬스체크가 성공하면 배포를 완료합니다.
+7. 헬스체크 실패 시 GitHub Actions 로그에 최근 컨테이너 로그를 남기고, 이전 이미지가 있으면 이전 이미지로 컨테이너를 다시 실행합니다.
+
+## 배포 실행
+
+`develop`에서 검증된 변경사항을 `main`으로 머지한 뒤 버전 태그를 생성해 push합니다.
+
+```bash
+git switch main
+git pull origin main
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+태그 이름은 `v*.*.*` 패턴이어야 자동 배포가 실행됩니다. 예: `v1.0.0`, `v1.0.1`, `v1.1.0`
+
+태그가 `main`에 포함되지 않은 커밋을 가리키면 워크플로가 배포 전에 실패합니다.
 
 ## GitHub 설정
 
@@ -28,22 +44,14 @@ Repository Variables:
 | `EC2_DEPLOY_PATH` | `/home/ec2-user/offmode` | EC2 안의 offmode 저장소 경로 |
 | `EC2_BACKEND_ENV_FILE` | `.env` | `backend` 디렉터리 기준 운영 환경변수 파일 경로 |
 
+워크플로는 EC2의 현재 운영 상태에 맞춰 컨테이너 이름은 `offmode`, 이미지 이름은 `offmode-backend`를 사용합니다.
+
 ## EC2 사전 준비
-
-EC2에는 Docker, Git, curl이 설치되어 있어야 하며 `ec2-user`가 Docker 명령을 실행할 수 있어야 합니다.
-
-```bash
-cd /home/ec2-user
-git clone git@github.com:OffmodePub/offmode.git
-cd offmode
-git switch main
-```
 
 운영 환경변수는 EC2 안의 `backend/.env`에 둡니다. 이 파일은 저장소에 커밋하지 않습니다.
 
 ```bash
 cd /home/ec2-user/offmode/backend
-cp .env.example .env
 vi .env
 ```
 
@@ -55,17 +63,6 @@ vi .env
 - `JWT_SECRET`
 - `CORS_ALLOWED_ORIGINS`
 
-## 수동 검증
-
-자동 배포 전 EC2에서 한 번 수동으로 검증합니다.
-
-```bash
-cd /home/ec2-user/offmode/backend
-docker build -t offmode-backend:manual .
-docker run -d --name offmode-backend --env-file .env -p 8080:8080 offmode-backend:manual
-curl -fsS http://localhost:8080/api/v1/health
-docker logs --tail=100 offmode-backend
-```
 
 ## Flyway 배포 주의사항
 

--- a/docs/backend-ec2-deploy.md
+++ b/docs/backend-ec2-deploy.md
@@ -1,0 +1,74 @@
+# 백엔드 EC2 자동 배포
+
+`main` 브랜치에 push 또는 PR merge가 발생하면 `.github/workflows/deploy-backend.yml` 워크플로가 EC2에 SSH로 접속해 백엔드 컨테이너를 재배포합니다.
+
+## 배포 방식
+
+1. GitHub Actions가 EC2에 SSH 접속합니다.
+2. EC2의 기존 저장소에서 `main` 브랜치를 최신 상태로 갱신합니다.
+3. `backend` 디렉터리에서 Docker 이미지를 EC2 내부에서 빌드합니다.
+4. 기존 `offmode-backend` 컨테이너를 중지/삭제하고 새 컨테이너를 실행합니다.
+5. `http://localhost:8080/api/v1/health` 헬스체크가 성공하면 배포를 완료합니다.
+6. 헬스체크 실패 시 GitHub Actions 로그에 최근 컨테이너 로그를 남기고, 이전 이미지가 있으면 이전 이미지로 컨테이너를 다시 실행합니다.
+
+## GitHub 설정
+
+Repository Secrets:
+
+| 이름 | 설명 |
+| --- | --- |
+| `EC2_HOST` | EC2 public IP 또는 도메인 |
+| `EC2_SSH_KEY` | `ec2-user`로 접속 가능한 private key 전문 |
+| `EC2_USER` | 선택값. 생략 시 `ec2-user` |
+
+Repository Variables:
+
+| 이름 | 기본값 | 설명 |
+| --- | --- | --- |
+| `EC2_DEPLOY_PATH` | `/home/ec2-user/offmode` | EC2 안의 offmode 저장소 경로 |
+| `EC2_BACKEND_ENV_FILE` | `.env` | `backend` 디렉터리 기준 운영 환경변수 파일 경로 |
+
+## EC2 사전 준비
+
+EC2에는 Docker, Git, curl이 설치되어 있어야 하며 `ec2-user`가 Docker 명령을 실행할 수 있어야 합니다.
+
+```bash
+cd /home/ec2-user
+git clone git@github.com:OffmodePub/offmode.git
+cd offmode
+git switch main
+```
+
+운영 환경변수는 EC2 안의 `backend/.env`에 둡니다. 이 파일은 저장소에 커밋하지 않습니다.
+
+```bash
+cd /home/ec2-user/offmode/backend
+cp .env.example .env
+vi .env
+```
+
+필수 값:
+
+- `SPRING_PROFILES_ACTIVE=prod`
+- `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD`
+- `R2_ACCESS_KEY`, `R2_SECRET_KEY`, `R2_ENDPOINT`, `R2_BUCKET`, `R2_PUBLIC_URL`
+- `JWT_SECRET`
+- `CORS_ALLOWED_ORIGINS`
+
+## 수동 검증
+
+자동 배포 전 EC2에서 한 번 수동으로 검증합니다.
+
+```bash
+cd /home/ec2-user/offmode/backend
+docker build -t offmode-backend:manual .
+docker run -d --name offmode-backend --env-file .env -p 8080:8080 offmode-backend:manual
+curl -fsS http://localhost:8080/api/v1/health
+docker logs --tail=100 offmode-backend
+```
+
+## Flyway 배포 주의사항
+
+`prod` 프로필은 Flyway를 사용하고 Hibernate `ddl-auto`는 `validate`입니다. 스키마 변경이 포함된 배포 전에는 RDS 스냅샷 또는 백업을 먼저 생성하고, `backend/src/main/resources/db/migration/mysql`의 새 마이그레이션이 운영 DB에 적용 가능한지 확인합니다.
+
+운영 DB에 Flyway를 처음 적용하는 경우에는 기존 스키마와 `V1__init_schema.sql`을 비교한 뒤 baseline 전략을 먼저 정합니다. 자세한 정책은 `docs/db-migration.md`를 참고합니다.


### PR DESCRIPTION
## 🔗 Issue

- close #81

---

## 📌 Summary

- main 브랜치 push 시 EC2에 SSH 접속해 백엔드 Docker 이미지를 재빌드하고 컨테이너를 교체하는 GitHub Actions 워크플로를 추가했습니다.
- 배포 후 `/api/v1/health` 헬스체크와 실패 시 로그 출력/이전 이미지 롤백 흐름을 구성했습니다.
- EC2 사전 준비, GitHub Secrets/Variables, Flyway 배포 주의사항을 문서화했습니다.

---

## ✅ Test

- [x] `./gradlew.bat test`
- [x] `./gradlew.bat spotlessCheck`