### PR TITLE
[Feat] #76 Mission/Profile 화면 pull-to-refresh 추가

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -350,6 +350,7 @@ function AppInner() {
                 onOpenVerify={() => push('verify')}
                 hasMission={hasMission}
                 currentMission={currentMission}
+                onRefresh={loadTodayMission}
               />
             )}
             {tab === 'feed'     && <FeedScreen />}

--- a/screens/FeedScreen.jsx
+++ b/screens/FeedScreen.jsx
@@ -472,7 +472,7 @@ export default function FeedScreen() {
         <ScrollView
           showsVerticalScrollIndicator={false}
           refreshControl={
-            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={C.green} />
+            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={C.green} colors={[C.green]} />
           }
         >
           <View style={s.missionBar}>

--- a/screens/MissionScreen.jsx
+++ b/screens/MissionScreen.jsx
@@ -265,7 +265,7 @@ function MissionCard({ currentMission, userStats, mainBadge, earnedBadges, displ
       style={styles.screen}
       contentContainerStyle={styles.content}
       showsVerticalScrollIndicator={false}
-      refreshControl={onRefresh ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={C.green} /> : undefined}
+      refreshControl={onRefresh ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={C.green} colors={[C.green]} /> : undefined}
     >
       <View style={styles.cardWrapper}>
         <View style={[styles.card, { borderColor: catBorder }]}>
@@ -421,7 +421,7 @@ function EmptyMissionState({ missionTime, onOpenTimeSettings, onOpenRoulette, co
       style={styles.screen}
       contentContainerStyle={styles.content}
       showsVerticalScrollIndicator={false}
-      refreshControl={onRefresh ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={C.green} /> : undefined}
+      refreshControl={onRefresh ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={C.green} colors={[C.green]} /> : undefined}
     >
       <View style={empty.waitCard}>
         <HourglassAnimation size={88} />

--- a/screens/MissionScreen.jsx
+++ b/screens/MissionScreen.jsx
@@ -1,6 +1,6 @@
-import React, { useRef, useEffect, useState, useMemo } from 'react';
+import React, { useRef, useEffect, useState, useMemo, useCallback } from 'react';
 import {
-  View, Text, StyleSheet, ScrollView,
+  View, Text, StyleSheet, ScrollView, RefreshControl,
   TouchableOpacity, Animated, Easing, Image,
 } from 'react-native';
 import { BASE_URL } from '../utils/api';
@@ -254,14 +254,19 @@ function MissionIcon({ icon, styles, C }) {
   );
 }
 
-function MissionCard({ currentMission, userStats, mainBadge, earnedBadges, displayedText, onOpenVerify, styles, C }) {
+function MissionCard({ currentMission, userStats, mainBadge, earnedBadges, displayedText, onOpenVerify, styles, C, refreshing, onRefresh }) {
   const cat       = currentMission?.category;
   const catColor  = cat === 'Intellect' ? C.purple  : cat === 'Energy' ? C.blue   : C.green;
   const catFaint  = cat === 'Intellect' ? C.purpleFaint  : cat === 'Energy' ? C.blueFaint  : C.greenFaint;
   const catBorder = cat === 'Intellect' ? C.purpleBorder : cat === 'Energy' ? C.blueBorder : C.greenBorder;
 
   return (
-    <ScrollView style={styles.screen} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+      refreshControl={onRefresh ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={C.green} /> : undefined}
+    >
       <View style={styles.cardWrapper}>
         <View style={[styles.card, { borderColor: catBorder }]}>
           <LinearGradient
@@ -404,7 +409,7 @@ function useCountdown(missionTime) {
   return time;
 }
 
-function EmptyMissionState({ missionTime, onOpenTimeSettings, onOpenRoulette, communityStats, userStats, missionPool }) {
+function EmptyMissionState({ missionTime, onOpenTimeSettings, onOpenRoulette, communityStats, userStats, missionPool, refreshing, onRefresh }) {
   const C = useColors();
   const { styles, empty } = useMemo(() => makeAllStyles(C), [C]);
   const pad = (n) => String(n).padStart(2, '0');
@@ -412,7 +417,12 @@ function EmptyMissionState({ missionTime, onOpenTimeSettings, onOpenRoulette, co
   const timeLabel = missionTime ? `${pad(missionTime.hour)}:${pad(missionTime.minute)}` : '08:00';
 
   return (
-    <ScrollView style={styles.screen} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+      refreshControl={onRefresh ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={C.green} /> : undefined}
+    >
       <View style={empty.waitCard}>
         <HourglassAnimation size={88} />
         <WaitingTitle />
@@ -487,7 +497,7 @@ function EmptyMissionState({ missionTime, onOpenTimeSettings, onOpenRoulette, co
   );
 }
 
-export default function MissionScreen({ missionTime, onOpenTimeSettings, onOpenRoulette, onOpenVerify, hasMission = false, currentMission }) {
+export default function MissionScreen({ missionTime, onOpenTimeSettings, onOpenRoulette, onOpenVerify, hasMission = false, currentMission, onRefresh }) {
   const C = useColors();
   const { styles } = useMemo(() => makeAllStyles(C), [C]);
   const pad = (n) => String(n).padStart(2, '0');
@@ -498,14 +508,27 @@ export default function MissionScreen({ missionTime, onOpenTimeSettings, onOpenR
   const [userStats,      setUserStats]      = useState(null);
   const [badges,         setBadges]         = useState([]);
   const [missionPool,    setMissionPool]    = useState([]);
+  const [refreshing,     setRefreshing]     = useState(false);
   const fullText = "미션 수행 중...";
 
-  useEffect(() => {
-    api.get('/api/v1/feed/stats').then(setCommunityStats).catch(e => console.warn('커뮤니티 통계 로딩 실패:', e));
-    api.get('/api/v1/users/me/stats').then(setUserStats).catch(e => console.warn('유저 통계 로딩 실패:', e));
-    api.get('/api/v1/badges/me').then(setBadges).catch(e => console.warn('배지 로딩 실패:', e));
-    api.get('/api/v1/missions/pool').then(setMissionPool).catch(e => console.warn('미션 풀 로딩 실패:', e));
+  const loadData = useCallback(async () => {
+    await Promise.all([
+      api.get('/api/v1/feed/stats').then(setCommunityStats).catch(e => console.warn('커뮤니티 통계 로딩 실패:', e)),
+      api.get('/api/v1/users/me/stats').then(setUserStats).catch(e => console.warn('유저 통계 로딩 실패:', e)),
+      api.get('/api/v1/badges/me').then(setBadges).catch(e => console.warn('배지 로딩 실패:', e)),
+      api.get('/api/v1/missions/pool').then(setMissionPool).catch(e => console.warn('미션 풀 로딩 실패:', e)),
+    ]);
   }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await Promise.all([loadData(), onRefresh?.()]);
+    setRefreshing(false);
+  }, [loadData, onRefresh]);
 
   const mainBadge    = badges.find(b => b.earned) ?? null;
   const earnedBadges = badges.filter(b => b.earned).slice(0, 3);
@@ -560,6 +583,8 @@ export default function MissionScreen({ missionTime, onOpenTimeSettings, onOpenR
           onOpenVerify={onOpenVerify}
           styles={styles}
           C={C}
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
         />
       ) : (
         <EmptyMissionState
@@ -569,6 +594,8 @@ export default function MissionScreen({ missionTime, onOpenTimeSettings, onOpenR
           communityStats={communityStats}
           userStats={userStats}
           missionPool={missionPool}
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
         />
       )}
     </View>

--- a/screens/ProfileScreen.jsx
+++ b/screens/ProfileScreen.jsx
@@ -587,7 +587,7 @@ export default function ProfileScreen({ profile, onSaveProfile, currentMission }
     <ScrollView
       showsVerticalScrollIndicator={false}
       contentContainerStyle={{ paddingBottom: 100 }}
-      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={C.green} />}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={C.green} colors={[C.green]} />}
     >
       <LinearGradient colors={headerGrad} style={s.profileHeader}>
         <View style={s.avatarSection}>

--- a/screens/ProfileScreen.jsx
+++ b/screens/ProfileScreen.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import {
-  View, Text, StyleSheet, ScrollView,
+  View, Text, StyleSheet, ScrollView, RefreshControl,
   TouchableOpacity, Dimensions, Image, Modal, TextInput, Keyboard, Animated,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -529,21 +529,34 @@ export default function ProfileScreen({ profile, onSaveProfile, currentMission }
   const [userStats, setUserStats] = useState(null);
   const [editVisible, setEditVisible] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
 
-  useEffect(() => {
-    Promise.all([
-      api.get('/api/v1/badges/me'),
-      api.get('/api/v1/users/me'),
-      api.get('/api/v1/missions/history'),
-      api.get('/api/v1/users/me/stats'),
-    ]).then(([b, u, hist, stats]) => {
+  const loadData = useCallback(async () => {
+    try {
+      const [b, u, hist, stats] = await Promise.all([
+        api.get('/api/v1/badges/me'),
+        api.get('/api/v1/users/me'),
+        api.get('/api/v1/missions/history'),
+        api.get('/api/v1/users/me/stats'),
+      ]);
       setBadges(b);
       setUserProfile(u);
       setHistoryItems(hist.map(toHistoryItem).filter(Boolean));
       setUserStats(stats);
-    }).catch(e => console.warn('데이터 로딩 실패:', e))
-      .finally(() => setLoading(false));
+    } catch (e) {
+      console.warn('데이터 로딩 실패:', e);
+    }
   }, []);
+
+  useEffect(() => {
+    loadData().finally(() => setLoading(false));
+  }, [loadData]);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await loadData();
+    setRefreshing(false);
+  }, [loadData]);
 
   const handleSaveProfile = (updated) => {
     onSaveProfile?.(updated);
@@ -571,7 +584,11 @@ export default function ProfileScreen({ profile, onSaveProfile, currentMission }
 
   return (
     <View style={s.screen}>
-    <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 100 }}>
+    <ScrollView
+      showsVerticalScrollIndicator={false}
+      contentContainerStyle={{ paddingBottom: 100 }}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={C.green} />}
+    >
       <LinearGradient colors={headerGrad} style={s.profileHeader}>
         <View style={s.avatarSection}>
           <View style={s.avatarWrap}>


### PR DESCRIPTION
## 🔗 Issue

- close #76

---

## 📌 Summary

- **MissionScreen**: 본체에 `refreshing` state + `handleRefresh` 추가. 미션 카드/빈 상태 두 sub-component(`MissionCard`, `EmptyMissionState`) 각각의 `ScrollView`에 `refreshControl` prop으로 전달. 현재 미션은 부모(App.jsx)가 관리하므로 `onRefresh` prop으로 `loadTodayMission`도 함께 호출
- **ProfileScreen**: `useEffect` 데이터 로딩을 `loadData` useCallback으로 추출 → `refreshing` state + `handleRefresh` + 최상위 `ScrollView`에 `refreshControl` 부착
- **App.jsx**: `MissionScreen`에 `onRefresh={loadTodayMission}` prop 추가
- **FeedScreen은 이미 RefreshControl 적용돼 있어 변경 없음**
- `tintColor`는 일관성 위해 모두 `C.green`

---

## ✅ Test

- [ ] Mission 화면(미션 있을 때/없을 때 모두)에서 아래로 당기면 새로고침 인디케이터가 표시되고 데이터가 갱신됨
- [ ] Profile 화면에서 아래로 당기면 새로고침 인디케이터가 표시되고 배지/통계/히스토리가 갱신됨
- [ ] Feed 화면 기존 새로고침 동작 회귀 없음
- [ ] 새로고침 중 다른 사용자 상호작용(리액션, 인증) 정상 동작