### PR TITLE
[Fix] #77 기본 테마를 시스템 무관 라이트 모드로 고정

### DIFF
--- a/utils/ThemeContext.js
+++ b/utils/ThemeContext.js
@@ -1,14 +1,14 @@
 import React, { createContext, useContext, useState } from 'react';
-import { useColorScheme } from 'react-native';
 import { dark, light } from '../constants/colors';
 
 const Ctx = createContext(null);
 
 export function ThemeProvider({ children }) {
-  const system = useColorScheme();          // 'dark' | 'light' | null
-  const [override, setOverride] = useState(null);  // null = follow system
+  // 기본은 항상 라이트. 시스템 다크모드와 무관하게 동작하며,
+  // 사용자가 Settings에서 명시적으로 dark를 선택할 때만 override 적용.
+  const [override, setOverride] = useState(null);
 
-  const scheme = override ?? (system ?? 'light');
+  const scheme = override ?? 'light';
   const colors = scheme === 'dark' ? dark : light;
 
   return (


### PR DESCRIPTION
## 🔗 Issue

- close #77

---

## 📌 Summary

- `utils/ThemeContext.js`에서 `useColorScheme()` 의존성 제거
- 기본값을 `'light'`로 고정 (`scheme = override ?? 'light'`)
- 사용자가 Settings 화면에서 명시적으로 dark를 선택할 때만 override 적용

---

## ✅ Test

- [ ] 시스템(iOS/Android) 다크모드 ON 상태에서 앱 첫 실행 시 라이트 모드로 표시되는지 확인
- [ ] Settings에서 다크모드 토글 시 정상적으로 다크 적용되는지 확인
- [ ] 다크 토글 후 라이트로 다시 변경 시 정상 복귀되는지 확인
- [ ] StatusBar 색상이 테마 변경에 맞게 갱신되는지 확인 (라이트=어두운 텍스트, 다크=밝은 텍스트)