### PR TITLE
[Fix] #98 룰렛/시간 픽커 페이드 회색 띠 제거

### DIFF
--- a/screens/MissionRouletteScreen.jsx
+++ b/screens/MissionRouletteScreen.jsx
@@ -74,8 +74,8 @@ function SlotMachine({ onDone, autoSpin = true, missions }) {
 
   return (
     <View style={slot.root}>
-      <LinearGradient colors={[C.bg, 'transparent']} style={[slot.fade, { top: 0 }]}    pointerEvents="none" />
-      <LinearGradient colors={['transparent', C.bg]} style={[slot.fade, { bottom: 0 }]} pointerEvents="none" />
+      <LinearGradient colors={[C.surface, C.surface + '00']} style={[slot.fade, { top: 0 }]}    pointerEvents="none" />
+      <LinearGradient colors={[C.surface + '00', C.surface]} style={[slot.fade, { bottom: 0 }]} pointerEvents="none" />
       <View style={slot.highlight} pointerEvents="none" />
       <View style={slot.window}>
         <Animated.View style={{ transform: [{ translateY }] }}>
@@ -84,7 +84,13 @@ function SlotMachine({ onDone, autoSpin = true, missions }) {
             return (
               <View key={i} style={slot.item}>
                 <Text style={slot.itemIcon}>{m.icon}</Text>
-                <T v="sub" size={15} style={[{ flex: 1, lineHeight: 22 }, isSelected && { color: getCategoryColor(m.category, C) }]} numberOfLines={2}>
+                <T
+                  v="sub"
+                  size={15}
+                  color={!isSelected && !C.isDark ? C.green : undefined}
+                  style={[{ flex: 1, lineHeight: 22 }, isSelected && { color: getCategoryColor(m.category, C) }]}
+                  numberOfLines={2}
+                >
                   {m.text}
                 </T>
               </View>

--- a/screens/MissionTimeScreen.jsx
+++ b/screens/MissionTimeScreen.jsx
@@ -69,8 +69,8 @@ function WheelPicker({ items, selectedIndex, onChange }) {
   return (
     <View style={wheel.wrap}>
       <View style={wheel.highlight} pointerEvents="none" />
-      <LinearGradient colors={[C.surface, 'transparent']} style={[wheel.fade, { top: 0 }]}    pointerEvents="none" />
-      <LinearGradient colors={['transparent', C.surface]} style={[wheel.fade, { bottom: 0 }]} pointerEvents="none" />
+      <LinearGradient colors={[C.surface, C.surface + '00']} style={[wheel.fade, { top: 0 }]}    pointerEvents="none" />
+      <LinearGradient colors={[C.surface + '00', C.surface]} style={[wheel.fade, { bottom: 0 }]} pointerEvents="none" />
       <ScrollView
         ref={scrollRef}
         style={{ height: PICKER_H, width: '100%' }}
@@ -92,7 +92,7 @@ function WheelPicker({ items, selectedIndex, onChange }) {
             <T
               v="sub"
               size={i === selectedIndex ? 34 : 28}
-              color={i === selectedIndex ? C.text : C.textSub}
+              color={i === selectedIndex ? C.text : (C.isDark ? C.textSub : C.green)}
               style={{ opacity: i === selectedIndex ? 1 : 0.4 }}
             >
               {pad(val)}

--- a/screens/SignupScreen.jsx
+++ b/screens/SignupScreen.jsx
@@ -76,8 +76,8 @@ function WheelPicker({ items, selectedIndex, onChange }) {
         borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.greenBorder,
         backgroundColor: C.greenFaint, zIndex: 1, borderRadius: 8,
       }} pointerEvents="none" />
-      <LinearGradient colors={[C.surface, 'transparent']} style={{ position: 'absolute', left: 0, right: 0, top: 0, height: ITEM_H * 1.0, zIndex: 2 }} pointerEvents="none" />
-      <LinearGradient colors={['transparent', C.surface]} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: ITEM_H * 1.0, zIndex: 2 }} pointerEvents="none" />
+      <LinearGradient colors={[C.surface, C.surface + '00']} style={{ position: 'absolute', left: 0, right: 0, top: 0, height: ITEM_H * 1.0, zIndex: 2 }} pointerEvents="none" />
+      <LinearGradient colors={[C.surface + '00', C.surface]} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: ITEM_H * 1.0, zIndex: 2 }} pointerEvents="none" />
       <ScrollView
         ref={scrollRef}
         style={{ height: PICKER_H }}
@@ -99,7 +99,7 @@ function WheelPicker({ items, selectedIndex, onChange }) {
             <T
               v="sub"
               size={i === selectedIndex ? 30 : 24}
-              color={i === selectedIndex ? C.text : C.textSub}
+              color={i === selectedIndex ? C.text : (C.isDark ? C.textSub : C.green)}
               style={{ opacity: i === selectedIndex ? 1 : 0.4 }}
             >
               {pad(val)}


### PR DESCRIPTION
## 🔗 Issue

- close #98

---

## 📌 Summary

- LinearGradient의 `'transparent'`는 `rgba(0,0,0,0)`이라 흰색에서 transparent로 페이드하면 RGB가 흰→검정 보간되며 **중간이 회색**으로 보이는 문제
- `'transparent'` → `C.surface + '00'` (같은 표면색의 알파 0) 으로 교체해 RGB 그대로 두고 알파만 감소시켜 회색 없이 자연스럽게 사라지도록 수정
- 비선택 항목 색상도 라이트 모드 한정으로 `C.textSub` → `C.green` (0.4 opacity)으로 변경해 회색 톤 완전 제거
- 영향 화면: 미션 룰렛, 시간 픽커, 회원가입 시간 픽커 (동일 휠 UI 3종)

> 원래 이슈는 룰렛 한정이었으나, 같은 페이드 패턴을 쓰는 다른 두 화면에서도 동일 결함이 있어 함께 수정.

---

## ✅ Test

- [x] 라이트 모드 미션 룰렛에서 위/아래 회색 띠 사라짐
- [x] 라이트 모드 시간 픽커(시/분)에서 위/아래 회색 페이드 사라짐, 비선택 숫자가 연한 그린으로 표시
- [x] 라이트 모드 회원가입 시간 픽커도 동일하게 그린 톤
- [x] 다크 모드는 기존과 동일하게 자연스러운 페이드 유지
- [x] 룰렛 자동/수동 스핀 모두 정상 동작