### PR TITLE
[Feat] #107 캐릭터 스티커 꾸미기 편집기 (파츠 자유 배치·제스처·저장)

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,5 +1,7 @@
+import 'react-native-gesture-handler';
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { View, StyleSheet, Animated, LogBox, Platform, PanResponder } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import * as SplashScreen from 'expo-splash-screen';
 import { SafeAreaProvider, SafeAreaView, initialWindowMetrics } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
@@ -506,9 +508,11 @@ function AppInner() {
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <AppInner />
-    </ThemeProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <ThemeProvider>
+        <AppInner />
+      </ThemeProvider>
+    </GestureHandlerRootView>
   );
 }
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,7 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    // react-native-reanimated/plugin 은 반드시 plugins 배열 맨 마지막에 위치해야 한다.
+    plugins: ['react-native-reanimated/plugin'],
   };
 };

--- a/backend/src/main/java/com/offmode/boundedcontext/part/api/v1/PartController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/api/v1/PartController.java
@@ -1,8 +1,9 @@
 package com.offmode.boundedcontext.part.api.v1;
 
-import com.offmode.boundedcontext.part.dto.request.PartEquipRequest;
+import com.offmode.boundedcontext.part.dto.request.PartLayoutRequest;
 import com.offmode.boundedcontext.part.dto.response.PartResponse;
 import com.offmode.boundedcontext.part.service.PartService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,16 +21,16 @@ public class PartController {
 
   private final PartService partService;
 
-  // GET /api/v1/parts/me — 전체 파츠 정의 + 해금/장착 상태
+  // GET /api/v1/parts/me — 전체 파츠 정의 + 해금 상태 + 배치 정보
   @GetMapping("/me")
   public ResponseEntity<List<PartResponse>> getMyParts(@AuthenticationPrincipal Long userId) {
     return ResponseEntity.ok(partService.getUserParts(userId));
   }
 
-  // PUT /api/v1/parts/equip — 파츠 장착/해제 (equippedKey == null 이면 해제)
-  @PutMapping("/equip")
-  public ResponseEntity<List<PartResponse>> equip(
-      @AuthenticationPrincipal Long userId, @RequestBody PartEquipRequest request) {
-    return ResponseEntity.ok(partService.equip(userId, request.getEquippedKey()));
+  // PUT /api/v1/parts/layout — 캐릭터 꾸미기 레이아웃 전체 교체 저장
+  @PutMapping("/layout")
+  public ResponseEntity<List<PartResponse>> saveLayout(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody PartLayoutRequest request) {
+    return ResponseEntity.ok(partService.saveLayout(userId, request.getPlacements()));
   }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/part/dto/request/PartEquipRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/dto/request/PartEquipRequest.java
@@ -1,9 +1,0 @@
-package com.offmode.boundedcontext.part.dto.request;
-
-import lombok.Getter;
-
-/** 장착 요청. equippedKey 가 null 이면 장착 해제. */
-@Getter
-public class PartEquipRequest {
-  private String equippedKey;
-}

--- a/backend/src/main/java/com/offmode/boundedcontext/part/dto/request/PartLayoutRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/dto/request/PartLayoutRequest.java
@@ -1,0 +1,13 @@
+package com.offmode.boundedcontext.part.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+
+/** 캐릭터 꾸미기 전체 레이아웃 저장 요청. placements 로 배치를 통째로 교체한다. */
+@Getter
+public class PartLayoutRequest {
+
+  @NotNull @Valid private List<PlacementRequest> placements;
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/part/dto/request/PlacementRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/dto/request/PlacementRequest.java
@@ -1,0 +1,28 @@
+package com.offmode.boundedcontext.part.dto.request;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+/** 캐릭터에 배치할 파츠 1개. x/y 는 0~1 정규화 좌표. */
+@Getter
+public class PlacementRequest {
+
+  @NotBlank private String key;
+
+  @DecimalMin("0.0")
+  @DecimalMax("1.0")
+  private double x;
+
+  @DecimalMin("0.0")
+  @DecimalMax("1.0")
+  private double y;
+
+  @Positive private double scale;
+
+  private double rotation;
+
+  private int z;
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/part/dto/response/PartResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/dto/response/PartResponse.java
@@ -1,9 +1,10 @@
 package com.offmode.boundedcontext.part.dto.response;
 
+import com.offmode.boundedcontext.part.entity.UserPart;
 import com.offmode.boundedcontext.part.types.PartDefinition;
 import lombok.Getter;
 
-/** 파츠 정의 + 유저별 해금/장착 상태. */
+/** 파츠 정의 + 유저별 해금 상태 + 캐릭터 위 배치 정보(미배치면 null). */
 @Getter
 public class PartResponse {
 
@@ -12,14 +13,22 @@ public class PartResponse {
   private final int order;
   private final Integer unlockThreshold; // 누적 인증 미션 수 기준, null 이면 Coming Soon
   private final boolean unlocked;
-  private final boolean equipped;
+  private final PlacementResponse placement; // 캐릭터에 배치돼 있으면 좌표/스케일 등, 미배치면 null
 
-  public PartResponse(PartDefinition def, boolean unlocked, boolean equipped) {
+  public PartResponse(PartDefinition def, boolean unlocked, PlacementResponse placement) {
     this.key = def.getKey();
     this.name = def.getName();
     this.order = def.order();
     this.unlockThreshold = def.getUnlockThreshold();
     this.unlocked = unlocked;
-    this.equipped = equipped;
+    this.placement = placement;
+  }
+
+  /** 캐릭터 위 파츠 배치 정보. x/y 는 0~1 정규화 좌표, z 는 렌더 순서. */
+  public record PlacementResponse(double x, double y, double scale, double rotation, int z) {
+    public static PlacementResponse from(UserPart part) {
+      return new PlacementResponse(
+          part.getPosX(), part.getPosY(), part.getScale(), part.getRotation(), part.getZIndex());
+    }
   }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/part/entity/UserPart.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/entity/UserPart.java
@@ -19,9 +19,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UpdateTimestamp;
 
-/** 유저별 장착 중인 파츠. 동시 장착은 1개만 허용하므로 유저당 한 행만 존재한다. */
+/** 유저별로 캐릭터에 자유 배치된 파츠 1개. 유저당 파츠 종류별로 최대 한 행씩 존재한다. */
 @Entity
-@Table(name = "user_parts", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id"}))
+@Table(
+    name = "user_parts",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "part_key"}))
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -37,13 +39,23 @@ public class UserPart {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
-  @Column(name = "equipped_key")
-  private String equippedKey; // null 이면 장착 해제 상태
+  @Column(name = "part_key", nullable = false)
+  private String partKey;
+
+  @Column(name = "pos_x", nullable = false)
+  private double posX; // 0~1 정규화 X 좌표
+
+  @Column(name = "pos_y", nullable = false)
+  private double posY; // 0~1 정규화 Y 좌표
+
+  @Column(name = "scale", nullable = false)
+  private double scale;
+
+  @Column(name = "rotation", nullable = false)
+  private double rotation; // 도(degree)
+
+  @Column(name = "z_index", nullable = false)
+  private int zIndex;
 
   @UpdateTimestamp private LocalDateTime updatedAt;
-
-  /** 장착 파츠 변경 (null 이면 해제). */
-  public void updateEquippedKey(String equippedKey) {
-    this.equippedKey = equippedKey;
-  }
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/part/repository/UserPartRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/repository/UserPartRepository.java
@@ -1,7 +1,7 @@
 package com.offmode.boundedcontext.part.repository;
 
 import com.offmode.boundedcontext.part.entity.UserPart;
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface UserPartRepository extends JpaRepository<UserPart, Long> {
 
-  Optional<UserPart> findByUserId(Long userId);
+  List<UserPart> findByUserId(Long userId);
 
   @Modifying
   @Query("DELETE FROM UserPart up WHERE up.user.id = :userId")

--- a/backend/src/main/java/com/offmode/boundedcontext/part/service/PartService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/service/PartService.java
@@ -2,7 +2,9 @@ package com.offmode.boundedcontext.part.service;
 
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.part.dto.request.PlacementRequest;
 import com.offmode.boundedcontext.part.dto.response.PartResponse;
+import com.offmode.boundedcontext.part.dto.response.PartResponse.PlacementResponse;
 import com.offmode.boundedcontext.part.entity.UserPart;
 import com.offmode.boundedcontext.part.repository.UserPartRepository;
 import com.offmode.boundedcontext.part.types.PartDefinition;
@@ -12,7 +14,9 @@ import com.offmode.global.exception.BusinessException;
 import com.offmode.global.status.ErrorStatus;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,49 +29,63 @@ public class PartService {
   private final UserMissionRepository userMissionRepository;
   private final UserRepository userRepository;
 
-  /** 모든 파츠 정의 + 유저별 해금/장착 상태. */
+  /** 모든 파츠 정의 + 유저별 해금 상태 + 배치 정보(미배치면 null). */
   public List<PartResponse> getUserParts(Long userId) {
     long verified = countVerified(userId);
-    String equippedKey =
-        userPartRepository.findByUserId(userId).map(UserPart::getEquippedKey).orElse(null);
-    return buildParts(verified, equippedKey);
+    Map<String, UserPart> placed =
+        userPartRepository.findByUserId(userId).stream()
+            .collect(Collectors.toMap(UserPart::getPartKey, Function.identity()));
+    return buildParts(verified, placed);
   }
 
-  /** 파츠 장착/해제 후 갱신된 전체 파츠 상태 반환. equippedKey 가 null 또는 빈 문자열이면 해제로 처리한다. */
+  /** 캐릭터 레이아웃 전체 교체 저장 후 갱신된 전체 파츠 상태 반환. 각 파츠는 존재하고 해금돼 있어야 한다. */
   @Transactional
-  public List<PartResponse> equip(Long userId, String equippedKey) {
+  public List<PartResponse> saveLayout(Long userId, List<PlacementRequest> placements) {
     long verified = countVerified(userId);
-    String targetKey = (equippedKey != null && !equippedKey.isBlank()) ? equippedKey : null;
 
-    if (targetKey != null) {
+    for (PlacementRequest p : placements) {
       PartDefinition def =
-          PartDefinition.fromKey(targetKey)
+          PartDefinition.fromKey(p.getKey())
               .orElseThrow(() -> new BusinessException(ErrorStatus.PART_NOT_FOUND));
       if (!def.isUnlockedBy(verified)) {
         throw new BusinessException(ErrorStatus.PART_NOT_UNLOCKED);
       }
     }
 
-    Optional<UserPart> existing = userPartRepository.findByUserId(userId);
+    userPartRepository.deleteByUserId(userId);
 
-    // 장착 이력이 없는데 해제 요청 → 불필요한 빈 행을 만들지 않고 현재 상태 그대로 반환
-    if (existing.isEmpty() && targetKey == null) {
-      return buildParts(verified, null);
+    User userRef = placements.isEmpty() ? null : getUserRef(userId);
+    List<UserPart> entities =
+        placements.stream()
+            .map(
+                p ->
+                    UserPart.builder()
+                        .user(userRef)
+                        .partKey(p.getKey())
+                        .posX(p.getX())
+                        .posY(p.getY())
+                        .scale(p.getScale())
+                        .rotation(p.getRotation())
+                        .zIndex(p.getZ())
+                        .build())
+            .toList();
+    if (!entities.isEmpty()) {
+      userPartRepository.saveAll(entities);
     }
 
-    UserPart userPart =
-        existing.orElseGet(() -> UserPart.builder().user(getUserRef(userId)).build());
-    userPart.updateEquippedKey(targetKey);
-    userPartRepository.save(userPart);
-
-    return buildParts(verified, targetKey);
+    Map<String, UserPart> placed =
+        entities.stream().collect(Collectors.toMap(UserPart::getPartKey, Function.identity()));
+    return buildParts(verified, placed);
   }
 
-  private List<PartResponse> buildParts(long verified, String equippedKey) {
+  private List<PartResponse> buildParts(long verified, Map<String, UserPart> placed) {
     return Arrays.stream(PartDefinition.values())
         .map(
-            def ->
-                new PartResponse(def, def.isUnlockedBy(verified), def.getKey().equals(equippedKey)))
+            def -> {
+              UserPart part = placed.get(def.getKey());
+              PlacementResponse placement = part == null ? null : PlacementResponse.from(part);
+              return new PartResponse(def, def.isUnlockedBy(verified), placement);
+            })
         .toList();
   }
 

--- a/backend/src/main/java/com/offmode/boundedcontext/part/service/PartService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/service/PartService.java
@@ -43,6 +43,12 @@ public class PartService {
   public List<PartResponse> saveLayout(Long userId, List<PlacementRequest> placements) {
     long verified = countVerified(userId);
 
+    // 같은 파츠 중복 배치 방어 — unique(user_id, part_key) 위반 500 대신 명시적 400
+    long distinctKeys = placements.stream().map(PlacementRequest::getKey).distinct().count();
+    if (distinctKeys != placements.size()) {
+      throw new BusinessException(ErrorStatus.PART_DUPLICATE);
+    }
+
     for (PlacementRequest p : placements) {
       PartDefinition def =
           PartDefinition.fromKey(p.getKey())

--- a/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
+++ b/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
@@ -38,6 +38,7 @@ public enum ErrorStatus {
   // Part
   PART_NOT_FOUND(HttpStatus.NOT_FOUND, "PART_404_001", "해당 파츠를 찾을 수 없습니다."),
   PART_NOT_UNLOCKED(HttpStatus.BAD_REQUEST, "PART_400_001", "아직 해금되지 않은 파츠입니다."),
+  PART_DUPLICATE(HttpStatus.BAD_REQUEST, "PART_400_002", "같은 파츠를 중복으로 배치할 수 없습니다."),
 
   // Room
   ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM_404_001", "방을 찾을 수 없습니다."),

--- a/backend/src/main/resources/db/migration/h2/V8__redesign_user_parts.sql
+++ b/backend/src/main/resources/db/migration/h2/V8__redesign_user_parts.sql
@@ -1,0 +1,36 @@
+-- user_parts 재설계: 유저당 1행(단일 장착) → 유저당 N행(자유 배치된 파츠).
+-- 각 행 = 배치된 파츠 1개.
+
+-- 1) 배치 정보 컬럼 추가 (우선 nullable 로 추가 후 이관 완료 시점에 NOT NULL 전환)
+ALTER TABLE user_parts ADD COLUMN part_key VARCHAR(255);
+ALTER TABLE user_parts ADD COLUMN pos_x DOUBLE;
+ALTER TABLE user_parts ADD COLUMN pos_y DOUBLE;
+ALTER TABLE user_parts ADD COLUMN scale DOUBLE;
+ALTER TABLE user_parts ADD COLUMN rotation DOUBLE;
+ALTER TABLE user_parts ADD COLUMN z_index INT;
+
+-- 2) 기존 장착 파츠를 중앙(0.5, 0.5) 기본 배치로 이관
+UPDATE user_parts
+SET part_key = equipped_key,
+    pos_x = 0.5,
+    pos_y = 0.5,
+    scale = 1,
+    rotation = 0,
+    z_index = 0
+WHERE equipped_key IS NOT NULL;
+
+-- 3) 장착 이력이 없던 빈 행 제거
+DELETE FROM user_parts WHERE equipped_key IS NULL;
+
+-- 4) 기존 유니크/컬럼 제거
+ALTER TABLE user_parts DROP CONSTRAINT uk_user_parts_user_id;
+ALTER TABLE user_parts DROP COLUMN equipped_key;
+
+-- 5) NOT NULL 전환 + 파츠당 1개 유니크 재설정
+ALTER TABLE user_parts ALTER COLUMN part_key SET NOT NULL;
+ALTER TABLE user_parts ALTER COLUMN pos_x SET NOT NULL;
+ALTER TABLE user_parts ALTER COLUMN pos_y SET NOT NULL;
+ALTER TABLE user_parts ALTER COLUMN scale SET NOT NULL;
+ALTER TABLE user_parts ALTER COLUMN rotation SET NOT NULL;
+ALTER TABLE user_parts ALTER COLUMN z_index SET NOT NULL;
+ALTER TABLE user_parts ADD CONSTRAINT uk_user_parts_user_part UNIQUE (user_id, part_key);

--- a/backend/src/main/resources/db/migration/mysql/V8__redesign_user_parts.sql
+++ b/backend/src/main/resources/db/migration/mysql/V8__redesign_user_parts.sql
@@ -1,0 +1,36 @@
+-- user_parts 재설계: 유저당 1행(단일 장착) → 유저당 N행(자유 배치된 파츠).
+-- 각 행 = 배치된 파츠 1개.
+
+-- 1) 배치 정보 컬럼 추가 (우선 nullable 로 추가 후 이관 완료 시점에 NOT NULL 전환)
+ALTER TABLE user_parts ADD COLUMN part_key VARCHAR(255);
+ALTER TABLE user_parts ADD COLUMN pos_x DOUBLE;
+ALTER TABLE user_parts ADD COLUMN pos_y DOUBLE;
+ALTER TABLE user_parts ADD COLUMN scale DOUBLE;
+ALTER TABLE user_parts ADD COLUMN rotation DOUBLE;
+ALTER TABLE user_parts ADD COLUMN z_index INT;
+
+-- 2) 기존 장착 파츠를 중앙(0.5, 0.5) 기본 배치로 이관
+UPDATE user_parts
+SET part_key = equipped_key,
+    pos_x = 0.5,
+    pos_y = 0.5,
+    scale = 1,
+    rotation = 0,
+    z_index = 0
+WHERE equipped_key IS NOT NULL;
+
+-- 3) 장착 이력이 없던 빈 행 제거
+DELETE FROM user_parts WHERE equipped_key IS NULL;
+
+-- 4) 기존 유니크/컬럼 제거
+ALTER TABLE user_parts DROP INDEX uk_user_parts_user_id;
+ALTER TABLE user_parts DROP COLUMN equipped_key;
+
+-- 5) NOT NULL 전환 + 파츠당 1개 유니크 재설정
+ALTER TABLE user_parts MODIFY COLUMN part_key VARCHAR(255) NOT NULL;
+ALTER TABLE user_parts MODIFY COLUMN pos_x DOUBLE NOT NULL;
+ALTER TABLE user_parts MODIFY COLUMN pos_y DOUBLE NOT NULL;
+ALTER TABLE user_parts MODIFY COLUMN scale DOUBLE NOT NULL;
+ALTER TABLE user_parts MODIFY COLUMN rotation DOUBLE NOT NULL;
+ALTER TABLE user_parts MODIFY COLUMN z_index INT NOT NULL;
+ALTER TABLE user_parts ADD CONSTRAINT uk_user_parts_user_part UNIQUE (user_id, part_key);

--- a/backend/src/test/java/com/offmode/boundedcontext/part/service/PartServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/part/service/PartServiceTest.java
@@ -134,6 +134,22 @@ class PartServiceTest {
   }
 
   @Test
+  void saveLayoutRejectsDuplicateKey() {
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(5L);
+
+    List<PlacementRequest> placements =
+        List.of(placement("leaf", 0.1, 0.2, 1.0, 0), placement("leaf", 0.5, 0.5, 1.0, 1));
+
+    assertThatThrownBy(() -> service().saveLayout(1L, placements))
+        .isInstanceOfSatisfying(
+            BusinessException.class,
+            e -> assertThat(e.getErrorStatus()).isEqualTo(ErrorStatus.PART_DUPLICATE));
+
+    verify(userPartRepository, never()).deleteByUserId(any());
+    verify(userPartRepository, never()).saveAll(anyList());
+  }
+
+  @Test
   void saveLayoutWithEmptyClearsWithoutTouchingUser() {
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(5L);
 

--- a/backend/src/test/java/com/offmode/boundedcontext/part/service/PartServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/part/service/PartServiceTest.java
@@ -3,12 +3,14 @@ package com.offmode.boundedcontext.part.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.part.dto.request.PlacementRequest;
 import com.offmode.boundedcontext.part.dto.response.PartResponse;
 import com.offmode.boundedcontext.part.entity.UserPart;
 import com.offmode.boundedcontext.part.repository.UserPartRepository;
@@ -17,11 +19,11 @@ import com.offmode.boundedcontext.user.repository.UserRepository;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.status.ErrorStatus;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class PartServiceTest {
@@ -38,11 +40,31 @@ class PartServiceTest {
     return parts.stream().filter(p -> p.getKey().equals(key)).findFirst().orElseThrow();
   }
 
+  private PlacementRequest placement(String key, double x, double y, double scale, int z) {
+    PlacementRequest req = new PlacementRequest();
+    ReflectionTestUtils.setField(req, "key", key);
+    ReflectionTestUtils.setField(req, "x", x);
+    ReflectionTestUtils.setField(req, "y", y);
+    ReflectionTestUtils.setField(req, "scale", scale);
+    ReflectionTestUtils.setField(req, "rotation", 0.0);
+    ReflectionTestUtils.setField(req, "z", z);
+    return req;
+  }
+
   @Test
-  void getUserPartsReflectsUnlockThresholdsAndEquippedKey() {
+  void getUserPartsReflectsUnlockThresholdsAndPlacements() {
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(7L);
     when(userPartRepository.findByUserId(1L))
-        .thenReturn(Optional.of(UserPart.builder().equippedKey("crown").build()));
+        .thenReturn(
+            List.of(
+                UserPart.builder()
+                    .partKey("crown")
+                    .posX(0.2)
+                    .posY(0.8)
+                    .scale(1.5)
+                    .rotation(30.0)
+                    .zIndex(2)
+                    .build()));
 
     List<PartResponse> parts = service().getUserParts(1L);
 
@@ -50,64 +72,76 @@ class PartServiceTest {
     assertThat(find(parts, "heart").isUnlocked()).isTrue(); // threshold 7
     assertThat(find(parts, "ribbon").isUnlocked()).isFalse(); // threshold 10
     assertThat(find(parts, "comingSoon14").isUnlocked()).isFalse(); // 항상 잠김
-    assertThat(find(parts, "crown").isEquipped()).isTrue();
-    assertThat(find(parts, "heart").isEquipped()).isFalse();
+
+    PartResponse crown = find(parts, "crown");
+    assertThat(crown.getPlacement()).isNotNull();
+    assertThat(crown.getPlacement().x()).isEqualTo(0.2);
+    assertThat(crown.getPlacement().y()).isEqualTo(0.8);
+    assertThat(crown.getPlacement().scale()).isEqualTo(1.5);
+    assertThat(crown.getPlacement().rotation()).isEqualTo(30.0);
+    assertThat(crown.getPlacement().z()).isEqualTo(2);
+    assertThat(find(parts, "heart").getPlacement()).isNull();
   }
 
   @Test
-  void equipUnlockedPartSavesAndReturnsUpdatedState() {
+  void saveLayoutReplacesAllPlacements() {
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
-    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(5L);
-    when(userPartRepository.findByUserId(1L)).thenReturn(Optional.empty());
-    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-    when(userPartRepository.save(any(UserPart.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(7L);
+    when(userRepository.findById(1L)).thenReturn(java.util.Optional.of(user));
+    when(userPartRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
 
-    List<PartResponse> parts = service().equip(1L, "twinkle");
+    List<PlacementRequest> placements =
+        List.of(placement("leaf", 0.1, 0.2, 1.0, 0), placement("crown", 0.5, 0.5, 1.2, 1));
 
-    assertThat(find(parts, "twinkle").isEquipped()).isTrue(); // threshold 5, unlocked
+    List<PartResponse> parts = service().saveLayout(1L, placements);
+
+    verify(userPartRepository).deleteByUserId(1L);
+    verify(userPartRepository).saveAll(anyList());
+    assertThat(find(parts, "leaf").getPlacement()).isNotNull();
+    assertThat(find(parts, "leaf").getPlacement().x()).isEqualTo(0.1);
+    assertThat(find(parts, "crown").getPlacement()).isNotNull();
+    assertThat(find(parts, "star").getPlacement()).isNull(); // 배치 안 함
   }
 
   @Test
-  void equipBlankKeyUnequipsInsteadOfRejecting() {
-    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(5L);
-    when(userPartRepository.findByUserId(1L))
-        .thenReturn(Optional.of(UserPart.builder().equippedKey("twinkle").build()));
-    when(userPartRepository.save(any(UserPart.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
-
-    List<PartResponse> parts = service().equip(1L, ""); // 빈 문자열 = 해제
-
-    assertThat(find(parts, "twinkle").isEquipped()).isFalse();
-  }
-
-  @Test
-  void unequipWithNoExistingRowDoesNotCreateRow() {
-    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(5L);
-    when(userPartRepository.findByUserId(1L)).thenReturn(Optional.empty());
-
-    List<PartResponse> parts = service().equip(1L, null);
-
-    assertThat(parts).hasSize(16);
-    assertThat(parts).noneMatch(PartResponse::isEquipped);
-    verify(userPartRepository, never()).save(any(UserPart.class));
-  }
-
-  @Test
-  void equipLockedPartThrows() {
+  void saveLayoutRejectsLockedPart() {
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(5L);
 
-    assertThatThrownBy(() -> service().equip(1L, "star")) // threshold 13
+    List<PlacementRequest> placements =
+        List.of(placement("star", 0.5, 0.5, 1.0, 0)); // threshold 13
+
+    assertThatThrownBy(() -> service().saveLayout(1L, placements))
         .isInstanceOfSatisfying(
             BusinessException.class,
             e -> assertThat(e.getErrorStatus()).isEqualTo(ErrorStatus.PART_NOT_UNLOCKED));
+
+    verify(userPartRepository, never()).deleteByUserId(any());
+    verify(userPartRepository, never()).saveAll(anyList());
   }
 
   @Test
-  void equipUnknownKeyThrows() {
-    assertThatThrownBy(() -> service().equip(1L, "nope"))
+  void saveLayoutRejectsUnknownKey() {
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(50L);
+
+    List<PlacementRequest> placements = List.of(placement("nope", 0.5, 0.5, 1.0, 0));
+
+    assertThatThrownBy(() -> service().saveLayout(1L, placements))
         .isInstanceOfSatisfying(
             BusinessException.class,
             e -> assertThat(e.getErrorStatus()).isEqualTo(ErrorStatus.PART_NOT_FOUND));
+
+    verify(userPartRepository, never()).deleteByUserId(any());
+  }
+
+  @Test
+  void saveLayoutWithEmptyClearsWithoutTouchingUser() {
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(5L);
+
+    List<PartResponse> parts = service().saveLayout(1L, List.of());
+
+    verify(userPartRepository).deleteByUserId(1L);
+    verify(userPartRepository, never()).saveAll(anyList());
+    assertThat(parts).hasSize(16);
+    assertThat(parts).allMatch(p -> p.getPlacement() == null);
   }
 }

--- a/components/CharacterDecor.jsx
+++ b/components/CharacterDecor.jsx
@@ -15,6 +15,11 @@ const PART_SIZE = 72;   // 배치 파츠 기본 렌더 크기(px, scale=1 기준
 const MIN_SCALE = 0.4;
 const MAX_SCALE = 3;
 
+/** 값을 [min, max] 범위로 제한 */
+function clamp(v, min, max) {
+  return Math.min(max, Math.max(min, v));
+}
+
 /** 서버 placement → 편집 상태(누락 필드 기본값 보정) */
 function normPlacement(pl) {
   return {
@@ -47,9 +52,10 @@ function PlacedPart({ item, cardW, cardH, image, selected, onSelect, onChange })
   }, [cardW, cardH, item.x, item.y, item.scale, item.rotation, posX, posY, scale, rot]);
 
   const commit = useCallback(() => {
+    // 카드 밖으로 드래그해도 서버 검증(0~1)과 어긋나지 않도록 clamp 후 저장
     onChange({
-      x: cardW ? posX.value / cardW : item.x,
-      y: cardH ? posY.value / cardH : item.y,
+      x: clamp(cardW ? posX.value / cardW : item.x, 0, 1),
+      y: clamp(cardH ? posY.value / cardH : item.y, 0, 1),
       scale: scale.value,
       rotation: rot.value,
     });
@@ -72,6 +78,7 @@ function PlacedPart({ item, cardW, cardH, image, selected, onSelect, onChange })
   const pinch = Gesture.Pinch()
     .onStart(() => {
       startScale.value = scale.value;
+      runOnJS(onSelect)();
     })
     .onUpdate((e) => {
       const next = startScale.value * e.scale;
@@ -84,6 +91,7 @@ function PlacedPart({ item, cardW, cardH, image, selected, onSelect, onChange })
   const rotation = Gesture.Rotation()
     .onStart(() => {
       startRot.value = rot.value;
+      runOnJS(onSelect)();
     })
     .onUpdate((e) => {
       rot.value = startRot.value + (e.rotation * 180) / Math.PI;

--- a/components/CharacterDecor.jsx
+++ b/components/CharacterDecor.jsx
@@ -1,61 +1,285 @@
-import React from 'react';
-import { View, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, Image, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  runOnJS,
+} from 'react-native-reanimated';
 import { W } from '../constants/warm';
-import { CHARACTER_BASE } from '../constants/parts';
+import { CHARACTER_BASE, PART_BY_KEY } from '../constants/parts';
+import * as H from '../utils/haptics';
 import WarmText from './WarmText';
 
+const PART_SIZE = 72;   // 배치 파츠 기본 렌더 크기(px, scale=1 기준)
+const MIN_SCALE = 0.4;
+const MAX_SCALE = 3;
+
+/** 서버 placement → 편집 상태(누락 필드 기본값 보정) */
+function normPlacement(pl) {
+  return {
+    x: pl?.x ?? 0.5,
+    y: pl?.y ?? 0.5,
+    scale: pl?.scale ?? 1,
+    rotation: pl?.rotation ?? 0,
+    z: pl?.z ?? 0,
+  };
+}
+
+/* ── 배치된 파츠 1개 (드래그·핀치·회전 제스처) ───────────────── */
+function PlacedPart({ item, cardW, cardH, image, selected, onSelect, onChange }) {
+  // 중심 좌표(px)와 변형값을 shared value로 관리
+  const posX = useSharedValue(item.x * cardW);
+  const posY = useSharedValue(item.y * cardH);
+  const scale = useSharedValue(item.scale);
+  const rot = useSharedValue(item.rotation);
+  const startX = useSharedValue(0);
+  const startY = useSharedValue(0);
+  const startScale = useSharedValue(1);
+  const startRot = useSharedValue(0);
+
+  // 카드 크기 확정/외부 변경 시 shared value 동기화
+  useEffect(() => {
+    posX.value = item.x * cardW;
+    posY.value = item.y * cardH;
+    scale.value = item.scale;
+    rot.value = item.rotation;
+  }, [cardW, cardH, item.x, item.y, item.scale, item.rotation, posX, posY, scale, rot]);
+
+  const commit = useCallback(() => {
+    onChange({
+      x: cardW ? posX.value / cardW : item.x,
+      y: cardH ? posY.value / cardH : item.y,
+      scale: scale.value,
+      rotation: rot.value,
+    });
+  }, [onChange, cardW, cardH, item.x, item.y, posX, posY, scale, rot]);
+
+  const pan = Gesture.Pan()
+    .onStart(() => {
+      startX.value = posX.value;
+      startY.value = posY.value;
+      runOnJS(onSelect)();
+    })
+    .onUpdate((e) => {
+      posX.value = startX.value + e.translationX;
+      posY.value = startY.value + e.translationY;
+    })
+    .onEnd(() => {
+      runOnJS(commit)();
+    });
+
+  const pinch = Gesture.Pinch()
+    .onStart(() => {
+      startScale.value = scale.value;
+    })
+    .onUpdate((e) => {
+      const next = startScale.value * e.scale;
+      scale.value = Math.min(MAX_SCALE, Math.max(MIN_SCALE, next));
+    })
+    .onEnd(() => {
+      runOnJS(commit)();
+    });
+
+  const rotation = Gesture.Rotation()
+    .onStart(() => {
+      startRot.value = rot.value;
+    })
+    .onUpdate((e) => {
+      rot.value = startRot.value + (e.rotation * 180) / Math.PI;
+    })
+    .onEnd(() => {
+      runOnJS(commit)();
+    });
+
+  const composed = Gesture.Simultaneous(pan, pinch, rotation);
+
+  const aStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: posX.value - PART_SIZE / 2 },
+      { translateY: posY.value - PART_SIZE / 2 },
+      { scale: scale.value },
+      { rotate: `${rot.value}deg` },
+    ],
+  }));
+
+  return (
+    <GestureDetector gesture={composed}>
+      <Animated.View style={[s.placed, aStyle]}>
+        {selected && <View style={s.selRing} pointerEvents="none" />}
+        <Image source={image} style={s.placedImg} resizeMode="contain" />
+      </Animated.View>
+    </GestureDetector>
+  );
+}
+
 /**
- * 캐릭터 꾸미기 섹션 (웜 크림 리디자인, Figma node 442:329).
- * 정적/프레젠테이셔널 컴포넌트 — 해금/장착 상태는 props로 받는다.
+ * 캐릭터 스티커 꾸미기 편집기 (#107).
+ * 해금된 파츠를 캐릭터 카드 위에 자유 배치 → 제스처로 위치·크기·각도 조정 → 저장.
  *
- * @param {Array}  parts        buildPartsState() 결과 (key·name·order·image·unlocked·equipped)
- * @param {object} [characterSource]  캐릭터 베이스 이미지 (기본: CHARACTER_BASE)
- * @param {function} [onPressPart] 파츠 탭 핸들러 (#107). 없으면 비활성(정적).
+ * @param {Array}    parts            병합된 파츠 배열 (key·name·image·unlockThreshold·unlocked·placement)
+ * @param {object}   [characterSource] 캐릭터 베이스 이미지
+ * @param {function} onSaveLayout     placements 배열을 서버에 저장하는 콜백
  */
-export default function CharacterDecor({ parts, characterSource = CHARACTER_BASE, onPressPart }) {
+export default function CharacterDecor({ parts, characterSource = CHARACTER_BASE, onSaveLayout }) {
+  const [placed, setPlaced] = useState([]);       // [{ key, x, y, scale, rotation, z }]
+  const [selectedKey, setSelectedKey] = useState(null);
+  const [card, setCard] = useState({ w: 0, h: 0 });
+
+  // 서버 placement → 편집 상태 초기화(로드/새로고침/저장 후)
+  useEffect(() => {
+    const init = parts
+      .filter((p) => p.placement)
+      .map((p) => ({ key: p.key, ...normPlacement(p.placement) }));
+    setPlaced(init);
+    setSelectedKey(null);
+  }, [parts]);
+
+  const onCardLayout = useCallback((e) => {
+    const { width, height } = e.nativeEvent.layout;
+    setCard({ w: width, h: height });
+  }, []);
+
+  const updatePlacement = useCallback((key, patch) => {
+    setPlaced((prev) => prev.map((p) => (p.key === key ? { ...p, ...patch } : p)));
+  }, []);
+
+  const topZ = () => placed.reduce((m, p) => Math.max(m, p.z ?? 0), 0);
+
+  // 그리드 파츠 탭 → 추가 / 이미 배치됐으면 제거(토글) / 잠김이면 안내
+  const handlePressPart = (part) => {
+    if (!part.unlocked) {
+      H.tap();
+      Alert.alert(
+        '아직 잠긴 파츠예요',
+        part.unlockThreshold != null
+          ? `누적 인증 ${part.unlockThreshold}회 달성 시 열려요`
+          : '준비 중이에요',
+      );
+      return;
+    }
+    H.tap();
+    const already = placed.some((p) => p.key === part.key);
+    if (already) {
+      setPlaced((prev) => prev.filter((p) => p.key !== part.key));
+      if (selectedKey === part.key) setSelectedKey(null);
+      return;
+    }
+    setPlaced((prev) => [
+      ...prev,
+      { key: part.key, x: 0.5, y: 0.5, scale: 1, rotation: 0, z: topZ() + 1 },
+    ]);
+    setSelectedKey(part.key);
+  };
+
+  const deleteSelected = () => {
+    if (!selectedKey) return;
+    H.tap();
+    setPlaced((prev) => prev.filter((p) => p.key !== selectedKey));
+    setSelectedKey(null);
+  };
+
+  const bringSelectedToFront = () => {
+    if (!selectedKey) return;
+    H.tap();
+    const nextZ = topZ() + 1;
+    setPlaced((prev) => prev.map((p) => (p.key === selectedKey ? { ...p, z: nextZ } : p)));
+  };
+
+  const handleSave = () => {
+    const placements = placed.map((p) => ({
+      key: p.key, x: p.x, y: p.y, scale: p.scale, rotation: p.rotation, z: p.z,
+    }));
+    onSaveLayout?.(placements);
+  };
+
+  const selectedPart = selectedKey ? PART_BY_KEY[selectedKey] : null;
+  const sortedPlaced = [...placed].sort((a, b) => (a.z ?? 0) - (b.z ?? 0));
+
   return (
     <View style={s.wrap}>
-      {/* 캐릭터 카드 */}
-      <View style={s.card}>
+      {/* 캐릭터 카드 (편집 캔버스) */}
+      <View style={s.card} onLayout={onCardLayout}>
         <Image source={characterSource} style={s.character} resizeMode="contain" />
+
+        {/* 빈 곳 탭 → 선택 해제 */}
+        <TouchableOpacity
+          style={StyleSheet.absoluteFill}
+          activeOpacity={1}
+          onPress={() => setSelectedKey(null)}
+        />
+
+        {/* 배치된 파츠 */}
+        {card.w > 0 && sortedPlaced.map((item) => {
+          const meta = PART_BY_KEY[item.key];
+          if (!meta) return null;
+          return (
+            <PlacedPart
+              key={item.key}
+              item={item}
+              cardW={card.w}
+              cardH={card.h}
+              image={meta.image}
+              selected={selectedKey === item.key}
+              onSelect={() => setSelectedKey(item.key)}
+              onChange={(patch) => updatePlacement(item.key, patch)}
+            />
+          );
+        })}
       </View>
 
-      {/* 안내 문구 */}
-      <View style={s.guide}>
-        <WarmText v="sub" style={s.guideLine}>
-          캐릭터를 자유롭게 꾸며 보세요
-        </WarmText>
-        <WarmText v="sub" style={s.guideLine}>
-          꾸준히 미션을 성공하면 새로운 파츠가 열려요
-        </WarmText>
-      </View>
+      {/* 선택된 파츠 툴바 */}
+      {selectedPart ? (
+        <View style={s.toolbar}>
+          <WarmText size={13} color={W.text} style={s.toolbarName}>{selectedPart.name}</WarmText>
+          <TouchableOpacity style={s.toolBtn} onPress={bringSelectedToFront} activeOpacity={0.7}>
+            <WarmText size={12} color={W.text}>맨 앞으로</WarmText>
+          </TouchableOpacity>
+          <TouchableOpacity style={[s.toolBtn, s.toolBtnDanger]} onPress={deleteSelected} activeOpacity={0.7}>
+            <WarmText size={12} color={W.coral}>삭제</WarmText>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <View style={s.guide}>
+          <WarmText v="sub" style={s.guideLine}>
+            아래 파츠를 눌러 캐릭터 위에 올려 보세요
+          </WarmText>
+          <WarmText v="sub" style={s.guideLine}>
+            드래그로 이동 · 두 손가락으로 크기·회전
+          </WarmText>
+        </View>
+      )}
 
       {/* 파츠 그리드 (4열) */}
       <View style={s.grid}>
         {parts.map((part) => {
+          const isPlaced = placed.some((p) => p.key === part.key);
           const cellStyle = [
             s.pill,
-            part.equipped ? s.pillEquipped : s.pillDefault,
+            isPlaced ? s.pillEquipped : s.pillDefault,
             !part.unlocked && s.pillLocked,
           ];
-          const content = (
-            <View style={cellStyle}>
-              <Image source={part.image} style={s.partImg} resizeMode="contain" />
-            </View>
-          );
           return (
             <View key={part.key} style={s.cellWrap}>
-              {onPressPart ? (
-                <TouchableOpacity activeOpacity={0.7} onPress={() => onPressPart(part)}>
-                  {content}
-                </TouchableOpacity>
-              ) : (
-                content
-              )}
+              <TouchableOpacity activeOpacity={0.7} onPress={() => handlePressPart(part)}>
+                <View style={cellStyle}>
+                  <Image source={part.image} style={s.partImg} resizeMode="contain" />
+                  {isPlaced && (
+                    <View style={s.placedBadge}>
+                      <WarmText size={9} color={W.white}>배치됨</WarmText>
+                    </View>
+                  )}
+                </View>
+              </TouchableOpacity>
             </View>
           );
         })}
       </View>
+
+      {/* 저장 버튼 (웜 톤) */}
+      <TouchableOpacity style={s.saveBtn} onPress={handleSave} activeOpacity={0.85}>
+        <WarmText v="btn" size={15} color={W.white}>꾸미기 저장</WarmText>
+      </TouchableOpacity>
 
       {/* 푸터 */}
       <WarmText v="caption" size={10} color={W.text} style={s.footer}>
@@ -79,8 +303,54 @@ const s = StyleSheet.create({
     overflow: 'hidden',
   },
   character: { width: 250, height: 250 },
+
+  /* 배치 파츠 */
+  placed: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: PART_SIZE,
+    height: PART_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placedImg: { width: PART_SIZE, height: PART_SIZE },
+  selRing: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: W.brown,
+    borderStyle: 'dashed',
+  },
+
+  /* 툴바 / 안내 */
+  toolbar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    gap: 8,
+    backgroundColor: W.neutralFaint,
+    borderWidth: 1,
+    borderColor: W.borderStrong,
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginTop: 2,
+  },
+  toolbarName: { flex: 1 },
+  toolBtn: {
+    backgroundColor: W.surface,
+    borderWidth: 1,
+    borderColor: W.borderStrong,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  toolBtnDanger: { borderColor: W.coralBorder, backgroundColor: W.coralFaint },
   guide: { alignItems: 'center', marginTop: 2 },
   guideLine: { textAlign: 'center', lineHeight: 18 },
+
+  /* 그리드 */
   grid: { flexDirection: 'row', flexWrap: 'wrap', alignSelf: 'stretch', rowGap: 10, marginTop: 4 },
   cellWrap: { width: '25%', alignItems: 'center' },
   pill: {
@@ -96,5 +366,24 @@ const s = StyleSheet.create({
   pillEquipped: { backgroundColor: W.neutralFaint, borderColor: W.brown },
   pillLocked: { opacity: 0.3 },
   partImg: { width: 48, height: 48 },
+  placedBadge: {
+    position: 'absolute',
+    bottom: 2,
+    right: 2,
+    backgroundColor: W.brown,
+    borderRadius: 6,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+  },
+
+  /* 저장 버튼 */
+  saveBtn: {
+    alignSelf: 'stretch',
+    backgroundColor: W.green,
+    borderRadius: 16,
+    paddingVertical: 15,
+    alignItems: 'center',
+    marginTop: 6,
+  },
   footer: { textAlign: 'center', marginTop: 6 },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "lottie-react-native": "7.1.0",
         "react": "18.3.1",
         "react-native": "0.76.9",
+        "react-native-gesture-handler": "~2.20.2",
+        "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.4.0",
         "react-native-svg": "15.8.0"
@@ -80,7 +82,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -505,6 +506,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
       "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/traverse": "^7.29.7"
@@ -521,6 +523,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
       "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -536,6 +539,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
       "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -551,6 +555,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
       "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
@@ -567,6 +572,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
       "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
@@ -584,6 +590,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
       "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/traverse": "^7.29.7"
@@ -684,6 +691,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       },
@@ -804,6 +812,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
       "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -990,6 +999,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -1055,6 +1065,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
       "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1101,6 +1112,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
       "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1169,6 +1181,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
       "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1185,6 +1198,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
       "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1200,6 +1214,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
       "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1216,6 +1231,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
       "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1231,6 +1247,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
       "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/plugin-transform-destructuring": "^7.29.7"
@@ -1247,6 +1264,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
       "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1326,6 +1344,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
       "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1371,6 +1390,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
       "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1386,6 +1406,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
       "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1418,6 +1439,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
       "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7",
@@ -1436,6 +1458,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
       "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1468,6 +1491,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
       "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1532,6 +1556,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
       "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-replace-supers": "^7.29.7"
@@ -1627,6 +1652,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
       "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1752,6 +1778,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
       "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1768,6 +1795,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
       "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1864,6 +1892,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
       "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1898,6 +1927,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
       "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1913,6 +1943,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
       "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1945,6 +1976,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
       "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1961,6 +1993,7 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
       "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.29.7",
         "@babel/helper-compilation-targets": "^7.29.7",
@@ -2046,6 +2079,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
       "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.8",
         "core-js-compat": "^3.48.0"
@@ -2076,6 +2110,7 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -2216,6 +2251,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -2223,7 +2270,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -2236,7 +2282,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4037,7 +4082,6 @@
       "integrity": "sha512-mIT9MiL/vMm4eirLcmw2h6h/Nm5FICtnYSdohq4vTLA2FF/6PNhByM7s8ffqoVfE5L0uAa6Xda1B7oddolUiGg==",
       "deprecated": "This version is no longer supported",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^6.4.17",
         "escape-string-regexp": "^4.0.0",
@@ -4268,7 +4312,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4520,6 +4563,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -4642,7 +4691,6 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -5276,7 +5324,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6030,7 +6077,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7483,7 +7529,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8177,7 +8222,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-52.0.49.tgz",
       "integrity": "sha512-ge3gUnuyGEePWWKzPY7TQ7FsvtFTdmsdYDHeBVUjMr9KIoQig/gf8A03oH26p3UtTL6sUJcyOIg9vwIHGNPSUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "0.22.28",
@@ -9344,6 +9388,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.23.1"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -12865,7 +12918,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12927,7 +12979,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.9.tgz",
       "integrity": "sha512-+LRwecWmTDco7OweGsrECIqJu0iyrREd6CTCgC/uLLYipiHvk+MH9nd6drFtCw/6Blz6eoKTcH9YTTJusNtrWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
         "@react-native/assets-registry": "0.76.9",
@@ -12984,12 +13035,51 @@
         }
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.2.tgz",
+      "integrity": "sha512-HqzFpFczV4qCnwKlvSAvpzEXisL+Z9fsR08YV5LfJDkzuArMhBu2sOoSPUF/K62PCoAb+ObGlTC83TKHfUd0vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "3.16.7",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.16.7.tgz",
+      "integrity": "sha512-qoUUQOwE1pHlmQ9cXTJ2MX9FQ9eHllopCLiWOkDkp6CER95ZWeXhJCP4cSm6AD4jigL5jHcZf/SkWrg8ttZUsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz",
       "integrity": "sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -13000,7 +13090,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.4.0.tgz",
       "integrity": "sha512-c7zc7Zwjty6/pGyuuvh9gK3YBYqHPOxrhXfG1lF4gHlojQSmIx2piNbNaV+Uykj+RDTmFXK0e/hA+fucw/Qozg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -13015,7 +13104,6 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.8.0.tgz",
       "integrity": "sha512-KHJzKpgOjwj1qeZzsBjxNdoIgv2zNCO9fVcoq2TEhTRsVV5DGTZ9JzUZwybd7q4giT/H3RdtqC3u44dWdO0Ffw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "lottie-react-native": "7.1.0",
     "react": "18.3.1",
     "react-native": "0.76.9",
+    "react-native-gesture-handler": "~2.20.2",
+    "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-svg": "15.8.0"

--- a/screens/ProfileScreen.jsx
+++ b/screens/ProfileScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import {
   View, StyleSheet, ScrollView, RefreshControl, TouchableOpacity,
-  Modal, TextInput, Keyboard, ActivityIndicator,
+  Modal, TextInput, Keyboard, ActivityIndicator, Alert,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useColors } from '../utils/useColors';
@@ -12,7 +12,27 @@ import { W } from '../constants/warm';
 import { AVATAR_IDS, getAvatarSource, getAvatarDefaultSource } from '../utils/avatars';
 import * as H from '../utils/haptics';
 import CharacterDecor from '../components/CharacterDecor';
-import { buildPartsState } from '../constants/parts';
+import { PARTS, isPartUnlocked } from '../constants/parts';
+
+/**
+ * GET /api/v1/parts/me 응답을 정적 카탈로그(PARTS)와 key로 병합.
+ * - image·이름·순서·임계값은 로컬 카탈로그에서, unlocked·placement 는 서버에서.
+ * - 서버 응답이 없으면(fallback) 누적 인증 수 기준으로 해금 여부만 계산.
+ */
+function mergePartsState(partsRes, verifiedCount) {
+  const byKey = {};
+  if (Array.isArray(partsRes)) {
+    for (const p of partsRes) if (p?.key) byKey[p.key] = p;
+  }
+  return PARTS.map((meta) => {
+    const remote = byKey[meta.key];
+    return {
+      ...meta,
+      unlocked: remote?.unlocked ?? isPartUnlocked(meta, verifiedCount),
+      placement: remote?.placement ?? null,
+    };
+  });
+}
 
 /* ── 날짜 유틸 ─────────────────────────────────────────── */
 function parseLocalDT(val) {
@@ -185,24 +205,37 @@ export default function ProfileScreen({ profile, onSaveProfile, currentMission }
   const [userProfile, setUserProfile] = useState(null);
   const [userStats, setUserStats] = useState(null);
   const [weekItems, setWeekItems] = useState([]);
+  const [parts, setParts] = useState([]);
   const [editVisible, setEditVisible] = useState(false);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
   const loadData = useCallback(async () => {
     try {
-      const [u, hist, stats] = await Promise.all([
+      const [u, hist, stats, partsRes] = await Promise.all([
         api.get('/api/v1/users/me'),
         api.get('/api/v1/missions/history'),
         api.get('/api/v1/users/me/stats'),
+        api.get('/api/v1/parts/me').catch(() => null),
       ]);
       setUserProfile(u);
       setWeekItems(hist.map(toWeekItem).filter(Boolean));
       setUserStats(stats);
+      setParts(mergePartsState(partsRes, stats?.totalVerified ?? 0));
     } catch (e) {
       console.warn('데이터 로딩 실패:', e);
     }
   }, []);
+
+  const handleSaveLayout = useCallback(async (placements) => {
+    try {
+      const updated = await api.put('/api/v1/parts/layout', { placements });
+      setParts(mergePartsState(updated, userStats?.totalVerified ?? 0));
+      H.success();
+    } catch (e) {
+      Alert.alert('저장 실패', e.message);
+    }
+  }, [userStats]);
 
   useEffect(() => {
     loadData().finally(() => setLoading(false));
@@ -226,7 +259,6 @@ export default function ProfileScreen({ profile, onSaveProfile, currentMission }
   const completionRate = totalMissions > 0 ? Math.round((verifiedCount / totalMissions) * 100) : 0;
 
   const weekData = useMemo(() => computeWeekData(weekItems, userProfile?.createdAt), [weekItems, userProfile]);
-  const decorParts = useMemo(() => buildPartsState(verifiedCount, null), [verifiedCount]);
 
   const avatarId = profile?.avatar ?? userProfile?.avatar ?? '01';
   const avatarSource = getAvatarSource(avatarId, currentMission?.status ?? null);
@@ -291,7 +323,7 @@ export default function ProfileScreen({ profile, onSaveProfile, currentMission }
         <WeeklyActivity weekData={weekData} />
 
         {/* 캐릭터 꾸미기 */}
-        <CharacterDecor parts={decorParts} />
+        <CharacterDecor parts={parts} onSaveLayout={handleSaveLayout} />
       </ScrollView>
 
       {profile && (


### PR DESCRIPTION
## 🔗 Issue

- close #107

---

## 📌 Summary

- 파츠 기능을 **고정 슬롯 단일 장착 → 스티커식 자유 꾸미기 편집기**로 재설계 (여러 파츠 배치 + 위치·크기·각도 조정 + 서버 저장)
- **백엔드**: `user_parts` 유저당 N행 재설계(`part_key` + transform `pos_x/pos_y/scale/rotation/z_index`, `unique(user_id, part_key)`) — 마이그레이션 **V8**(h2/mysql). `GET /parts/me` 응답에 `placement` 포함, `PUT /parts/equip` → **`PUT /parts/layout`**(전체 덮어쓰기, 잠긴/미존재 파츠 거부). `PartEquipRequest` 제거, `PartLayoutRequest`/`PlacementRequest` 신규
- **프론트**: `react-native-gesture-handler`·`react-native-reanimated` 도입, `CharacterDecor`를 스티커 편집기로 재작성(pan·pinch·rotation 제스처, 정규화 좌표 0~1), `ProfileScreen`에서 `GET /parts/me` 연동 + 저장(`PUT /parts/layout`)
- 좌표는 캐릭터 카드 기준 정규화(0~1)로 저장 → 기기 해상도 무관

---

## ✅ Test

- [x] 백엔드 `./gradlew spotlessCheck` / `test`(FlywayMigrationTest가 V8 H2 마이그레이션 실검증) / `build` — 전부 SUCCESSFUL
- [x] 프론트 `npm ci` + `npm run lint` — 0 errors
- [ ] 실기기: 네이티브 재빌드(`npm run ios`) 후 파츠 추가/드래그/핀치·회전/삭제, 저장 후 재진입 복원 확인 (작성자 직접)
