### PR TITLE
[Fix] #110 누적 인증 통계에 방 인증(RoomProof) 합산

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -22,6 +22,21 @@ public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
   // 방의 오늘 미션에 대해 VERIFIED 한 멤버(유저) 수
   long countByRoomMissionIdAndStatus(Long roomMissionId, ProofStatus status);
 
+  // 유저 누적 통계용: 유저가 올린 방 인증 총 개수 / 그중 VERIFIED 개수
+  long countByUserId(Long userId);
+
+  long countByUserIdAndStatus(Long userId, ProofStatus status);
+
+  // 유저 연속 달성 일수 계산용: 유저가 VERIFIED 한 방 미션의 날짜들
+  @Query(
+      """
+        SELECT DISTINCT p.roomMission.date
+        FROM RoomProof p
+        WHERE p.user.id = :userId AND p.status = :status
+    """)
+  List<LocalDate> findVerifiedDatesByUser(
+      @Param("userId") Long userId, @Param("status") ProofStatus status);
+
   // 연속 달성 일수 계산용: 1건 이상 VERIFIED 가 존재하는 날짜들 (최신순)
   @Query(
       """

--- a/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
@@ -8,6 +8,8 @@ import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.part.repository.UserPartRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.types.ProofStatus;
 import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
@@ -15,7 +17,7 @@ import com.offmode.global.exception.BusinessException;
 import com.offmode.global.status.ErrorStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,7 @@ public class UserService {
   private final VerificationRepository verificationRepository;
   private final UserBadgeRepository userBadgeRepository;
   private final UserPartRepository userPartRepository;
+  private final RoomProofRepository roomProofRepository;
 
   public User getById(Long id) {
     return userRepository
@@ -68,9 +71,14 @@ public class UserService {
   }
 
   public UserStatsResponse getStats(Long userId) {
-    long totalMissions = userMissionRepository.findByUserIdOrderByAssignedAtDesc(userId).size();
+    // 누적 통계는 레거시 개인 미션(UserMission)과 Rooms v2 방 인증(RoomProof)을 합산한다.
+    // (현재 실제 인증은 방 인증으로만 저장되므로 RoomProof 미합산 시 누적이 오르지 않음)
+    long totalMissions =
+        userMissionRepository.findByUserIdOrderByAssignedAtDesc(userId).size()
+            + roomProofRepository.countByUserId(userId);
     long totalVerified =
-        userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED);
+        userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED)
+            + roomProofRepository.countByUserIdAndStatus(userId, ProofStatus.VERIFIED);
 
     long energy =
         userMissionRepository.countByUserIdAndStatusAndMissionCategory(
@@ -82,9 +90,13 @@ public class UserService {
         userMissionRepository.countByUserIdAndStatusAndMissionCategory(
             userId, MissionStatus.VERIFIED, MissionCategory.VITALITY);
 
-    List<LocalDateTime> verifiedTimes =
-        userMissionRepository.findVerifiedDateTimes(userId, MissionStatus.VERIFIED);
-    int streak = calcStreak(verifiedTimes);
+    // 연속 달성 일수: 개인 미션 인증 날짜 + 방 인증 날짜를 합쳐서 계산
+    Set<LocalDate> verifiedDates =
+        userMissionRepository.findVerifiedDateTimes(userId, MissionStatus.VERIFIED).stream()
+            .map(LocalDateTime::toLocalDate)
+            .collect(Collectors.toCollection(HashSet::new));
+    verifiedDates.addAll(roomProofRepository.findVerifiedDatesByUser(userId, ProofStatus.VERIFIED));
+    int streak = calcStreak(verifiedDates);
 
     return new UserStatsResponse(
         totalMissions,
@@ -99,10 +111,8 @@ public class UserService {
   }
 
   // 연속 달성 일수 계산 (오늘부터 역순으로 확인)
-  private int calcStreak(List<LocalDateTime> times) {
-    if (times.isEmpty()) return 0;
-    Set<LocalDate> dates =
-        times.stream().map(LocalDateTime::toLocalDate).collect(Collectors.toSet());
+  private int calcStreak(Set<LocalDate> dates) {
+    if (dates.isEmpty()) return 0;
 
     LocalDate check = LocalDate.now();
     int streak = 0;

--- a/backend/src/test/java/com/offmode/boundedcontext/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/user/service/UserServiceTest.java
@@ -1,0 +1,74 @@
+package com.offmode.boundedcontext.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.types.ProofStatus;
+import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @Mock private UserMissionRepository userMissionRepository;
+  @Mock private RoomProofRepository roomProofRepository;
+
+  // getStats는 개인 미션·방 인증 레포만 사용하므로 나머지 의존성은 null 로 주입한다.
+  private UserService service() {
+    return new UserService(
+        null, userMissionRepository, null, null, null, null, null, roomProofRepository);
+  }
+
+  private void stubCategoryCounts() {
+    when(userMissionRepository.countByUserIdAndStatusAndMissionCategory(
+            eq(1L), eq(MissionStatus.VERIFIED), any()))
+        .thenReturn(0L);
+  }
+
+  @Test
+  void getStats_방인증을_누적_통계에_합산한다() {
+    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L))
+        .thenReturn(List.of()); // 레거시 0
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(2L);
+    stubCategoryCounts();
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(List.of());
+    when(roomProofRepository.countByUserId(1L)).thenReturn(5L);
+    when(roomProofRepository.countByUserIdAndStatus(1L, ProofStatus.VERIFIED)).thenReturn(3L);
+    when(roomProofRepository.findVerifiedDatesByUser(1L, ProofStatus.VERIFIED))
+        .thenReturn(List.of());
+
+    UserStatsResponse res = service().getStats(1L);
+
+    assertThat(res.getTotalVerified()).isEqualTo(5L); // 레거시 2 + 방 3
+    assertThat(res.getTotalMissions()).isEqualTo(5L); // 레거시 0 + 방 5
+  }
+
+  @Test
+  void getStats_연속달성은_방인증_날짜도_포함한다() {
+    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
+    stubCategoryCounts();
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(List.of()); // 개인 미션 인증 없음
+    when(roomProofRepository.countByUserId(1L)).thenReturn(2L);
+    when(roomProofRepository.countByUserIdAndStatus(1L, ProofStatus.VERIFIED)).thenReturn(2L);
+    // 오늘 + 어제 방 인증 → 연속 2일
+    when(roomProofRepository.findVerifiedDatesByUser(1L, ProofStatus.VERIFIED))
+        .thenReturn(List.of(LocalDate.now(), LocalDate.now().minusDays(1)));
+
+    UserStatsResponse res = service().getStats(1L);
+
+    assertThat(res.getStreak()).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
## 🔗 Issue

- close #110

---

## 📌 Summary

- **버그**: 프로필 누적 인증 횟수가 오르지 않음. `UserService.getStats()`가 레거시 개인 미션(`UserMission`)만 세는데, Rooms v2에서 실제 인증은 전부 `RoomProof`로 저장되어 누적에 반영되지 않았음 (레거시 `VerifyScreen`은 더 이상 호출되지 않음)
- **수정**: `getStats`가 방 인증을 합산
  - `totalVerified` = 개인 VERIFIED + 방 VERIFIED
  - `totalMissions` = 개인 미션 + 방 인증 (완료율 100% 초과 방지)
  - `streak` = 개인 인증 날짜 ∪ 방 인증 날짜
- `RoomProofRepository`에 `countByUserId` / `countByUserIdAndStatus` / `findVerifiedDatesByUser` 추가
- `UserServiceTest` 신규 (누적 합산·streak 합산 검증)

## 📝 비고
- 솔로 방은 업로드 즉시 VERIFIED → 바로 누적. 그룹 방은 피어 인증 전까지 PENDING이라 verified엔 미포함(total에만) — 의도된 동작
- 카테고리 레벨(에너지/지성/활력)은 `RoomMission`에 카테고리 필드가 없어 이번 범위에서 제외

---

## ✅ Test

- [ ] 백엔드 `spotlessCheck` + `test` BUILD SUCCESSFUL (UserServiceTest 2건 포함)
- [ ] 방 인증 후 프로필 재진입 시 누적 인증 횟수 증가
- [ ] 연속 인증 시 streak 증가