### PR TITLE
[Feat] #122 방 인증을 진급 시스템(레벨·배지·카테고리)에 반영

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
@@ -7,6 +7,8 @@ import com.offmode.boundedcontext.badge.types.BadgeDefinition;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.types.ProofStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDate;
@@ -24,6 +26,7 @@ public class BadgeService {
   private final UserBadgeRepository userBadgeRepository;
   private final UserMissionRepository userMissionRepository;
   private final UserRepository userRepository;
+  private final RoomProofRepository roomProofRepository;
 
   /** 모든 배지 정의 + 획득 여부 반환 */
   public List<BadgeResponse> getUserBadges(Long userId) {
@@ -78,6 +81,8 @@ public class BadgeService {
       case OFFMODE_ENTRY -> userMissionRepository.existsByUserId(userId);
       case SKY_COLLECTOR ->
           userMissionRepository.countByStatusAndTextKeyword(userId, MissionStatus.VERIFIED, "하늘")
+                  + roomProofRepository.countByUserIdAndStatusAndRoomMissionTitleContaining(
+                      userId, ProofStatus.VERIFIED, "하늘")
               >= 10;
       case SPEEDRUNNER -> maxConsecutiveDays(userId) >= 7;
     };
@@ -86,17 +91,28 @@ public class BadgeService {
   // ── 공통 쿼리 헬퍼 ───────────────────────────────────────
 
   private long verifiedCount(Long userId) {
-    return userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED);
+    return userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED)
+        + roomProofRepository.countByUserIdAndStatus(userId, ProofStatus.VERIFIED);
   }
 
   private long verifiedByCategory(Long userId, MissionCategory category) {
     return userMissionRepository.countByUserIdAndStatusAndMissionCategory(
-        userId, MissionStatus.VERIFIED, category);
+            userId, MissionStatus.VERIFIED, category)
+        + roomProofRepository.countByUserIdAndStatusAndRoomMissionCategory(
+            userId, ProofStatus.VERIFIED, category);
   }
 
   private long verifiedByHour(Long userId, int fromHour, int toHour) {
-    return userMissionRepository.countByStatusAndHourRange(
-        userId, MissionStatus.VERIFIED, fromHour, toHour);
+    long legacy =
+        userMissionRepository.countByStatusAndHourRange(
+            userId, MissionStatus.VERIFIED, fromHour, toHour);
+    long room =
+        roomProofRepository.findCreatedAtByUserIdAndStatus(userId, ProofStatus.VERIFIED).stream()
+            .filter(java.util.Objects::nonNull)
+            .map(LocalDateTime::getHour)
+            .filter(hour -> hour >= fromHour && hour < toHour)
+            .count();
+    return legacy + room;
   }
 
   /** 최대 연속 미션 달성 일수 계산 */

--- a/backend/src/main/java/com/offmode/boundedcontext/room/entity/RoomMission.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/entity/RoomMission.java
@@ -1,5 +1,6 @@
 package com.offmode.boundedcontext.room.entity;
 
+import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.room.types.MissionSource;
 import jakarta.persistence.*;
 import java.time.LocalDate;
@@ -38,6 +39,11 @@ public class RoomMission {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private MissionSource source;
+
+  // 진급 시스템(레벨/배지/카테고리 통계) 반영용 카테고리. 자유입력(DIRECT) 미션은 미분류(null).
+  @Enumerated(EnumType.STRING)
+  @Column(length = 20)
+  private MissionCategory category;
 
   @CreationTimestamp private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -1,8 +1,10 @@
 package com.offmode.boundedcontext.room.repository;
 
+import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.room.entity.RoomProof;
 import com.offmode.boundedcontext.room.types.ProofStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -26,6 +28,20 @@ public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
   long countByUserId(Long userId);
 
   long countByUserIdAndStatus(Long userId, ProofStatus status);
+
+  // 카테고리별 방 인증 수 (WALKER/BEAUTY_CURATOR/LOCAL_HIPSTER 배지 + 카테고리 통계용).
+  // roomMission.category 가 null 인 인증은 어떤 카테고리에도 잡히지 않는다.
+  long countByUserIdAndStatusAndRoomMissionCategory(
+      Long userId, ProofStatus status, MissionCategory category);
+
+  // 키워드 배지(예: "하늘")용 — 방 미션 제목에 키워드가 포함된 인증 수
+  long countByUserIdAndStatusAndRoomMissionTitleContaining(
+      Long userId, ProofStatus status, String keyword);
+
+  // 시간대 배지용 — VERIFIED 방 인증의 생성 시각 목록(시(hour) 필터는 Java에서 수행)
+  @Query("SELECT p.createdAt FROM RoomProof p WHERE p.user.id = :userId AND p.status = :status")
+  List<LocalDateTime> findCreatedAtByUserIdAndStatus(
+      @Param("userId") Long userId, @Param("status") ProofStatus status);
 
   // 유저 연속 달성 일수 계산용: 유저가 VERIFIED 한 방 미션의 날짜들
   @Query(

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomMissionService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomMissionService.java
@@ -2,6 +2,7 @@ package com.offmode.boundedcontext.room.service;
 
 import com.offmode.boundedcontext.mission.entity.Mission;
 import com.offmode.boundedcontext.mission.repository.MissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.room.dto.request.SetRoomMissionRequest;
 import com.offmode.boundedcontext.room.dto.response.MissionCandidateResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomMissionResponse;
@@ -48,10 +49,12 @@ public class RoomMissionService {
 
     String icon;
     String title;
+    MissionCategory category;
     if (request.getSource() == MissionSource.RANDOM) {
       Mission picked = pickRandomMission();
       icon = picked.getIcon();
       title = picked.getText();
+      category = picked.getCategory();
     } else if (request.getMissionId() != null) {
       Mission picked =
           masterMissionRepository
@@ -59,12 +62,15 @@ public class RoomMissionService {
               .orElseThrow(() -> new BusinessException(ErrorStatus.MISSION_NOT_FOUND));
       icon = picked.getIcon();
       title = picked.getText();
+      category = picked.getCategory();
     } else {
       if (request.getTitle() == null || request.getTitle().isBlank()) {
         throw new BusinessException(ErrorStatus.BAD_REQUEST);
       }
       title = request.getTitle();
       icon = request.getIcon() == null || request.getIcon().isBlank() ? "🎯" : request.getIcon();
+      // 자유입력 미션은 미분류 → 카테고리 레벨/배지에 반영하지 않는다.
+      category = null;
     }
 
     RoomMission saved =
@@ -75,6 +81,7 @@ public class RoomMissionService {
                 .icon(icon)
                 .title(title)
                 .source(request.getSource())
+                .category(category)
                 .build());
 
     return RoomMissionResponse.from(saved);

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofService.java
@@ -1,5 +1,6 @@
 package com.offmode.boundedcontext.room.service;
 
+import com.offmode.boundedcontext.badge.service.BadgeService;
 import com.offmode.boundedcontext.room.dto.response.ConfirmResponse;
 import com.offmode.boundedcontext.room.dto.response.HistoryProofResponse;
 import com.offmode.boundedcontext.room.dto.response.MiniMissionResponse;
@@ -53,6 +54,7 @@ public class RoomProofService {
   private final RoomService roomService;
   private final RoomProofAssembler proofAssembler;
   private final UserService userService;
+  private final BadgeService badgeService;
   private final ImageUploadService imageUploadService;
 
   // ===== 사진 인증 =====
@@ -92,6 +94,11 @@ public class RoomProofService {
                 .caption(caption)
                 .status(status)
                 .build());
+
+    // 업로드 즉시 인증 완료된 경우(requiredConfirm<=0) 업로더 본인에게 진급 처리
+    if (status == ProofStatus.VERIFIED) {
+      applyVerifiedProgress(userId);
+    }
 
     return proofAssembler.build(proof, requiredConfirm, userId);
   }
@@ -161,6 +168,8 @@ public class RoomProofService {
     if (confirmCount >= requiredConfirm && proof.getStatus() != ProofStatus.VERIFIED) {
       proof.setStatus(ProofStatus.VERIFIED);
       proofRepository.save(proof);
+      // VERIFIED 전환 순간 인증 주인(업로더)에게 진급 처리
+      applyVerifiedProgress(proof.getUser().getId());
     }
 
     return new ConfirmResponse(confirmCount, requiredConfirm, proof.getStatus());
@@ -241,6 +250,12 @@ public class RoomProofService {
                 .build());
 
     return new ProofReportResponse(saved.getId());
+  }
+
+  // 방 인증이 VERIFIED 로 확정되면 인증 주인에게 레벨업 + 배지 획득 체크
+  private void applyVerifiedProgress(Long ownerId) {
+    userService.applyVerifiedProgress(ownerId);
+    badgeService.checkAndAward(ownerId);
   }
 
   private RoomProof getProofInRoomOrThrow(Long proofId, Long roomId) {

--- a/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
@@ -70,25 +70,42 @@ public class UserService {
     }
   }
 
+  // 인증(개인 미션 또는 방 인증)이 VERIFIED 로 확정될 때 호출 — 합산 누적 인증 수로 레벨업 반영
+  @Transactional
+  public void applyVerifiedProgress(Long userId) {
+    levelUp(userId, (int) totalVerifiedCount(userId));
+  }
+
+  // 합산 누적 VERIFIED 인증 수 (개인 미션 + 방 인증) — getStats·applyVerifiedProgress 공유
+  private long totalVerifiedCount(Long userId) {
+    return userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED)
+        + roomProofRepository.countByUserIdAndStatus(userId, ProofStatus.VERIFIED);
+  }
+
   public UserStatsResponse getStats(Long userId) {
     // 누적 통계는 레거시 개인 미션(UserMission)과 Rooms v2 방 인증(RoomProof)을 합산한다.
     // (현재 실제 인증은 방 인증으로만 저장되므로 RoomProof 미합산 시 누적이 오르지 않음)
     long totalMissions =
         userMissionRepository.findByUserIdOrderByAssignedAtDesc(userId).size()
             + roomProofRepository.countByUserId(userId);
-    long totalVerified =
-        userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED)
-            + roomProofRepository.countByUserIdAndStatus(userId, ProofStatus.VERIFIED);
+    long totalVerified = totalVerifiedCount(userId);
 
+    // 카테고리 통계도 개인 미션 + 방 인증(해당 category)을 합산한다.
     long energy =
         userMissionRepository.countByUserIdAndStatusAndMissionCategory(
-            userId, MissionStatus.VERIFIED, MissionCategory.ENERGY);
+                userId, MissionStatus.VERIFIED, MissionCategory.ENERGY)
+            + roomProofRepository.countByUserIdAndStatusAndRoomMissionCategory(
+                userId, ProofStatus.VERIFIED, MissionCategory.ENERGY);
     long intellect =
         userMissionRepository.countByUserIdAndStatusAndMissionCategory(
-            userId, MissionStatus.VERIFIED, MissionCategory.INTELLECT);
+                userId, MissionStatus.VERIFIED, MissionCategory.INTELLECT)
+            + roomProofRepository.countByUserIdAndStatusAndRoomMissionCategory(
+                userId, ProofStatus.VERIFIED, MissionCategory.INTELLECT);
     long vitality =
         userMissionRepository.countByUserIdAndStatusAndMissionCategory(
-            userId, MissionStatus.VERIFIED, MissionCategory.VITALITY);
+                userId, MissionStatus.VERIFIED, MissionCategory.VITALITY)
+            + roomProofRepository.countByUserIdAndStatusAndRoomMissionCategory(
+                userId, ProofStatus.VERIFIED, MissionCategory.VITALITY);
 
     // 연속 달성 일수: 개인 미션 인증 날짜 + 방 인증 날짜를 합쳐서 계산
     Set<LocalDate> verifiedDates =

--- a/backend/src/main/resources/db/migration/h2/V10__add_room_mission_category.sql
+++ b/backend/src/main/resources/db/migration/h2/V10__add_room_mission_category.sql
@@ -1,0 +1,1 @@
+ALTER TABLE room_missions ADD COLUMN category VARCHAR(20);

--- a/backend/src/main/resources/db/migration/mysql/V10__add_room_mission_category.sql
+++ b/backend/src/main/resources/db/migration/mysql/V10__add_room_mission_category.sql
@@ -1,0 +1,1 @@
+ALTER TABLE room_missions ADD COLUMN category VARCHAR(20) NULL;

--- a/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
@@ -10,6 +10,8 @@ import com.offmode.boundedcontext.badge.types.BadgeDefinition;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.types.ProofStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDateTime;
@@ -27,11 +29,13 @@ class BadgeServiceTest {
   @Mock private UserBadgeRepository userBadgeRepository;
   @Mock private UserMissionRepository userMissionRepository;
   @Mock private UserRepository userRepository;
+  @Mock private RoomProofRepository roomProofRepository;
 
   @Test
   void checkAndAwardAwardsFirstMissionAcceptedBadge() {
     BadgeService service =
-        new BadgeService(userBadgeRepository, userMissionRepository, userRepository);
+        new BadgeService(
+            userBadgeRepository, userMissionRepository, userRepository, roomProofRepository);
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
     when(userMissionRepository.existsByUserId(1L)).thenReturn(true);
@@ -49,7 +53,8 @@ class BadgeServiceTest {
   @Test
   void checkAndAwardAwardsVerifiedCountAndCategoryBadges() {
     BadgeService service =
-        new BadgeService(userBadgeRepository, userMissionRepository, userRepository);
+        new BadgeService(
+            userBadgeRepository, userMissionRepository, userRepository, roomProofRepository);
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(10L);
@@ -72,7 +77,8 @@ class BadgeServiceTest {
   @Test
   void checkAndAwardAwardsSevenDayStreakBadge() {
     BadgeService service =
-        new BadgeService(userBadgeRepository, userMissionRepository, userRepository);
+        new BadgeService(
+            userBadgeRepository, userMissionRepository, userRepository, roomProofRepository);
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     LocalDateTime start = LocalDateTime.now().minusDays(6);
     when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
@@ -85,5 +91,26 @@ class BadgeServiceTest {
     List<BadgeDefinition> awarded = service.checkAndAward(1L);
 
     assertThat(awarded).contains(BadgeDefinition.SPEEDRUNNER);
+  }
+
+  @Test
+  void checkAndAwardCountsRoomProofsForExplorerBadge() {
+    BadgeService service =
+        new BadgeService(
+            userBadgeRepository, userMissionRepository, userRepository, roomProofRepository);
+    User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
+    when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
+    // 개인 미션 인증 0, 방 인증 1 → verifiedCount 1 → EXPLORER 획득
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
+    when(roomProofRepository.countByUserIdAndStatus(1L, ProofStatus.VERIFIED)).thenReturn(1L);
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(Collections.emptyList());
+    when(userRepository.getReferenceById(1L)).thenReturn(user);
+    when(userBadgeRepository.save(any(UserBadge.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    List<BadgeDefinition> awarded = service.checkAndAward(1L);
+
+    assertThat(awarded).contains(BadgeDefinition.EXPLORER_LV01);
   }
 }

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomMissionServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomMissionServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.offmode.boundedcontext.mission.entity.Mission;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -68,6 +70,11 @@ class RoomMissionServiceTest {
     assertThat(response.title()).isEqualTo("산책하기");
     assertThat(response.icon()).isEqualTo("🚶");
     assertThat(response.source()).isEqualTo(MissionSource.RANDOM);
+
+    // 랜덤 미션은 master 미션의 카테고리를 그대로 저장한다.
+    ArgumentCaptor<RoomMission> captor = ArgumentCaptor.forClass(RoomMission.class);
+    verify(missionRepository).save(captor.capture());
+    assertThat(captor.getValue().getCategory()).isEqualTo(MissionCategory.VITALITY);
   }
 
   @Test
@@ -85,6 +92,11 @@ class RoomMissionServiceTest {
     assertThat(response.title()).isEqualTo("노래 들으며 산책");
     assertThat(response.icon()).isEqualTo("🎵");
     assertThat(response.source()).isEqualTo(MissionSource.DIRECT);
+
+    // 자유입력 미션은 카테고리 미분류(null).
+    ArgumentCaptor<RoomMission> captor = ArgumentCaptor.forClass(RoomMission.class);
+    verify(missionRepository).save(captor.capture());
+    assertThat(captor.getValue().getCategory()).isNull();
   }
 
   private SetRoomMissionRequest request(

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceTest.java
@@ -3,11 +3,13 @@ package com.offmode.boundedcontext.room.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.offmode.boundedcontext.badge.service.BadgeService;
 import com.offmode.boundedcontext.room.dto.response.ConfirmResponse;
 import com.offmode.boundedcontext.room.dto.response.ProofReportResponse;
 import com.offmode.boundedcontext.room.entity.Room;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class RoomProofServiceTest {
@@ -44,6 +47,7 @@ class RoomProofServiceTest {
   @Mock private RoomService roomService;
   @Mock private RoomProofAssembler proofAssembler;
   @Mock private UserService userService;
+  @Mock private BadgeService badgeService;
   @Mock private ImageUploadService imageUploadService;
 
   private RoomProofService service() {
@@ -56,6 +60,7 @@ class RoomProofServiceTest {
         roomService,
         proofAssembler,
         userService,
+        badgeService,
         imageUploadService);
   }
 
@@ -100,6 +105,9 @@ class RoomProofServiceTest {
     assertThat(response.requiredConfirm()).isEqualTo(3);
     assertThat(proof.getStatus()).isEqualTo(ProofStatus.VERIFIED);
     verify(proofRepository).save(proof);
+    // VERIFIED 전환 시 인증 주인(9L)에게 진급 처리
+    verify(userService).applyVerifiedProgress(9L);
+    verify(badgeService).checkAndAward(9L);
   }
 
   @Test
@@ -118,6 +126,32 @@ class RoomProofServiceTest {
 
     assertThat(response.status()).isEqualTo(ProofStatus.PENDING);
     verify(confirmRepository, never()).save(any());
+    verify(userService, never()).applyVerifiedProgress(anyLong());
+    verify(badgeService, never()).checkAndAward(anyLong());
+  }
+
+  @Test
+  void createProofImmediatelyVerifiedTriggersProgressForUploader() {
+    Room room = Room.builder().id(2L).type(RoomType.SOLO).build();
+    RoomMission mission = RoomMission.builder().id(10L).room(room).build();
+    User uploader = User.builder().id(1L).provider("kakao").providerId("u").build();
+    when(roomService.getRoomOrThrow(2L)).thenReturn(room);
+    when(roomService.getMembershipOrThrow(2L, 1L)).thenReturn(new RoomMember());
+    when(missionRepository.findByRoomIdAndDate(eq(2L), any())).thenReturn(Optional.of(mission));
+    when(proofRepository.existsByRoomMissionIdAndUserId(10L, 1L)).thenReturn(false);
+    when(imageUploadService.uploadVerificationImage(any())).thenReturn("/uploads/a.jpg");
+    when(roomService.getMemberCount(2L)).thenReturn(1L);
+    when(roomService.requiredConfirm(RoomType.SOLO, 1)).thenReturn(0);
+    when(userService.getById(1L)).thenReturn(uploader);
+    when(proofRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    MockMultipartFile photo =
+        new MockMultipartFile("photo", "a.jpg", "image/jpeg", new byte[] {1, 2, 3});
+    service().createProof(1L, 2L, photo, "caption");
+
+    // 업로드 즉시 VERIFIED → 업로더 본인(1L)에게 진급 처리
+    verify(userService).applyVerifiedProgress(1L);
+    verify(badgeService).checkAndAward(1L);
   }
 
   @Test

--- a/backend/src/test/java/com/offmode/boundedcontext/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/user/service/UserServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.room.repository.RoomProofRepository;
 import com.offmode.boundedcontext.room.types.ProofStatus;
@@ -70,5 +71,33 @@ class UserServiceTest {
     UserStatsResponse res = service().getStats(1L);
 
     assertThat(res.getStreak()).isEqualTo(2);
+  }
+
+  @Test
+  void getStats_카테고리_통계에_방인증을_합산한다() {
+    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
+    stubCategoryCounts(); // 레거시 카테고리 0
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(List.of());
+    when(roomProofRepository.countByUserId(1L)).thenReturn(0L);
+    when(roomProofRepository.countByUserIdAndStatus(1L, ProofStatus.VERIFIED)).thenReturn(0L);
+    when(roomProofRepository.findVerifiedDatesByUser(1L, ProofStatus.VERIFIED))
+        .thenReturn(List.of());
+    when(roomProofRepository.countByUserIdAndStatusAndRoomMissionCategory(
+            1L, ProofStatus.VERIFIED, MissionCategory.ENERGY))
+        .thenReturn(0L);
+    when(roomProofRepository.countByUserIdAndStatusAndRoomMissionCategory(
+            1L, ProofStatus.VERIFIED, MissionCategory.INTELLECT))
+        .thenReturn(0L);
+    // 방 인증 VITALITY 5건 → vitality level 1 / fill 50
+    when(roomProofRepository.countByUserIdAndStatusAndRoomMissionCategory(
+            1L, ProofStatus.VERIFIED, MissionCategory.VITALITY))
+        .thenReturn(5L);
+
+    UserStatsResponse res = service().getStats(1L);
+
+    assertThat(res.getVitalityFill()).isEqualTo(50);
+    assertThat(res.getVitalityLevel()).isEqualTo(1);
   }
 }


### PR DESCRIPTION
## 🔗 Issue

- close #122

---

## 📌 Summary

- **`RoomMission.category` 추가** (Flyway V10) — 랜덤·추천 미션은 마스터 풀에서 카테고리 획득, 자유입력은 미분류(null)
- **RoomProof VERIFIED 확정 시 진급 훅** — 솔로(업로드 즉시)·그룹(피어 confirm 완료) 전환점에서 인증 주인 기준 `levelUp` + `badgeService.checkAndAward`
- **누적 카운트 공유 헬퍼** — `UserService.applyVerifiedProgress` + `totalVerifiedCount`(getStats와 공유), getStats 카테고리 통계에 방 인증 합산
- **BadgeService 전면 반영** — 수량(1/10/100)·카테고리·시간대·키워드(SKY) 배지 모두 방 인증 포함
- `RoomProofRepository` 파생 쿼리 3종(category/title/createdAt) 추가

## 📝 비고
- 자유입력 방 미션은 카테고리 미분류라 카테고리 레벨/배지엔 미반영(누적·수량 배지엔 반영)
- 소셜 배지(리액션)는 범위 밖
- 관련: #110(누적/연속 선반영)

---

## ✅ Test

- [ ] 백엔드 `spotlessCheck` + `test` BUILD SUCCESSFUL (RoomProofService/User/Badge/RoomMission 테스트 갱신, 컨텍스트 로드로 Flyway V10 검증)
- [ ] 방 인증 완료 시 레벨/배지/카테고리 통계 반영