### PR TITLE
[Infra] #129 배포 워크플로 EC2 fetch를 GITHUB_TOKEN 인증으로 전환

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -8,6 +8,9 @@ concurrency:
   group: deploy-backend-${{ github.ref_name }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -22,6 +25,8 @@ jobs:
       IMAGE_NAME: offmode-backend
       IMAGE_TAG: ${{ github.ref_name }}
       HOST_PORT: "8080"
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Checkout release tag
@@ -63,13 +68,16 @@ jobs:
           printf -v image_name_q '%q' "$IMAGE_NAME"
           printf -v image_tag_q '%q' "$IMAGE_TAG"
           printf -v host_port_q '%q' "$HOST_PORT"
+          printf -v gh_token_q '%q' "$GH_TOKEN"
+          printf -v repo_q '%q' "$REPO"
 
           ssh -i ~/.ssh/offmode-ec2.pem "$EC2_USER@$EC2_HOST" \
-            "DEPLOY_PATH=$deploy_path_q BACKEND_ENV_FILE=$env_file_q CONTAINER_NAME=$container_name_q IMAGE_NAME=$image_name_q IMAGE_TAG=$image_tag_q HOST_PORT=$host_port_q bash -s" <<'REMOTE_SCRIPT'
+            "DEPLOY_PATH=$deploy_path_q BACKEND_ENV_FILE=$env_file_q CONTAINER_NAME=$container_name_q IMAGE_NAME=$image_name_q IMAGE_TAG=$image_tag_q HOST_PORT=$host_port_q GH_TOKEN=$gh_token_q REPO=$repo_q bash -s" <<'REMOTE_SCRIPT'
           set -Eeuo pipefail
 
           cd "$DEPLOY_PATH"
-          git fetch origin main:refs/remotes/origin/main --tags
+          # 프라이빗 레포: EC2에 자격증명을 두지 않고 워크플로의 임시 GITHUB_TOKEN으로만 fetch
+          GIT_TERMINAL_PROMPT=0 git fetch "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" main:refs/remotes/origin/main --tags
           tag_commit="$(git rev-list -n 1 "$IMAGE_TAG")"
 
           if ! git merge-base --is-ancestor "$tag_commit" origin/main; then


### PR DESCRIPTION
## 🔗 Issue

- close #129

---


## 📌 Summary

- 레포 프라이빗 전환 후 EC2의 `git fetch origin`(HTTPS)이 인증 실패로 배포 워크플로가 죽는 문제 수정 (v0.2.0 배포 실패 run 28595710022)
- 조직 정책상 deploy key 비활성화 → 워크플로의 임시 `GITHUB_TOKEN`을 SSH 원격 스크립트에 전달해 fetch URL에 `x-access-token` 방식으로 주입
  - EC2에 영구 자격증명 저장 없음 (토큰은 잡 종료 시 자동 만료)
  - `permissions: contents: read` 명시
- 도커 빌드/헬스체크/롤백 로직은 변경 없음

---

## ✅ Test

- YAML 문법 검증 통과 (js-yaml)
- 실제 동작은 머지 후 v0.2.0 재태깅 배포로 확인 예정