### PR TITLE
[Fix] #132 V8 마이그레이션 MySQL 인덱스 삭제 순서 수정

### DIFF
--- a/backend/src/main/resources/db/migration/mysql/V8__redesign_user_parts.sql
+++ b/backend/src/main/resources/db/migration/mysql/V8__redesign_user_parts.sql
@@ -22,11 +22,7 @@ WHERE equipped_key IS NOT NULL;
 -- 3) 장착 이력이 없던 빈 행 제거
 DELETE FROM user_parts WHERE equipped_key IS NULL;
 
--- 4) 기존 유니크/컬럼 제거
-ALTER TABLE user_parts DROP INDEX uk_user_parts_user_id;
-ALTER TABLE user_parts DROP COLUMN equipped_key;
-
--- 5) NOT NULL 전환 + 파츠당 1개 유니크 재설정
+-- 4) NOT NULL 전환 + 파츠당 1개 유니크 추가
 ALTER TABLE user_parts MODIFY COLUMN part_key VARCHAR(255) NOT NULL;
 ALTER TABLE user_parts MODIFY COLUMN pos_x DOUBLE NOT NULL;
 ALTER TABLE user_parts MODIFY COLUMN pos_y DOUBLE NOT NULL;
@@ -34,3 +30,9 @@ ALTER TABLE user_parts MODIFY COLUMN scale DOUBLE NOT NULL;
 ALTER TABLE user_parts MODIFY COLUMN rotation DOUBLE NOT NULL;
 ALTER TABLE user_parts MODIFY COLUMN z_index INT NOT NULL;
 ALTER TABLE user_parts ADD CONSTRAINT uk_user_parts_user_part UNIQUE (user_id, part_key);
+
+-- 5) 기존 유니크/컬럼 제거
+-- fk_user_parts_user(user_id)가 user_id 선두 인덱스를 요구하므로,
+-- uk_user_parts_user_part(user_id, part_key)를 먼저 추가한 뒤에야 기존 인덱스를 삭제할 수 있다 (MySQL errno 1553)
+ALTER TABLE user_parts DROP INDEX uk_user_parts_user_id;
+ALTER TABLE user_parts DROP COLUMN equipped_key;


### PR DESCRIPTION
## 🔗 Issue

- close #132

---


## 📌 Summary

- v0.2.0 배포에서 Flyway V8(`redesign_user_parts`)이 운영 MySQL에서 실패한 문제 수정
- 원인: `DROP INDEX uk_user_parts_user_id`가 `fk_user_parts_user` 외래키의 유일한 user_id 인덱스라 MySQL이 삭제 거부 (errno 1553). H2는 이 제약이 없어 dev에서만 통과했음
- 수정: 새 유니크 `uk_user_parts_user_part(user_id, part_key)`를 먼저 추가한 뒤 기존 인덱스를 삭제하도록 순서 변경 (mysql 버전만 수정, h2는 변경 없음 — 기존 dev DB 체크섬 유지)

---

## ✅ Test

- 로컬 MySQL 8.0 도커에서 V1~V10 전체 마이그레이션 순차 실행 → 전부 통과
- 운영 DB의 부분 적용 상태(컬럼 6개)는 별도 수동 정리 후 재배포 예정 (#132 참고)