### PR TITLE
[Infra] #84 v0.2.0 배포 (V8 마이그레이션 수정 포함)

### DIFF
--- a/backend/src/main/resources/db/migration/mysql/V8__redesign_user_parts.sql
+++ b/backend/src/main/resources/db/migration/mysql/V8__redesign_user_parts.sql
@@ -22,11 +22,7 @@ WHERE equipped_key IS NOT NULL;
 -- 3) 장착 이력이 없던 빈 행 제거
 DELETE FROM user_parts WHERE equipped_key IS NULL;
 
--- 4) 기존 유니크/컬럼 제거
-ALTER TABLE user_parts DROP INDEX uk_user_parts_user_id;
-ALTER TABLE user_parts DROP COLUMN equipped_key;
-
--- 5) NOT NULL 전환 + 파츠당 1개 유니크 재설정
+-- 4) NOT NULL 전환 + 파츠당 1개 유니크 추가
 ALTER TABLE user_parts MODIFY COLUMN part_key VARCHAR(255) NOT NULL;
 ALTER TABLE user_parts MODIFY COLUMN pos_x DOUBLE NOT NULL;
 ALTER TABLE user_parts MODIFY COLUMN pos_y DOUBLE NOT NULL;
@@ -34,3 +30,9 @@ ALTER TABLE user_parts MODIFY COLUMN scale DOUBLE NOT NULL;
 ALTER TABLE user_parts MODIFY COLUMN rotation DOUBLE NOT NULL;
 ALTER TABLE user_parts MODIFY COLUMN z_index INT NOT NULL;
 ALTER TABLE user_parts ADD CONSTRAINT uk_user_parts_user_part UNIQUE (user_id, part_key);
+
+-- 5) 기존 유니크/컬럼 제거
+-- fk_user_parts_user(user_id)가 user_id 선두 인덱스를 요구하므로,
+-- uk_user_parts_user_part(user_id, part_key)를 먼저 추가한 뒤에야 기존 인덱스를 삭제할 수 있다 (MySQL errno 1553)
+ALTER TABLE user_parts DROP INDEX uk_user_parts_user_id;
+ALTER TABLE user_parts DROP COLUMN equipped_key;


### PR DESCRIPTION
## 🔗 Issue

- Ref #84 

---


## 📌 Summary

- V8 마이그레이션이 운영 MySQL에서 실패(FK 요구 인덱스 삭제 순서, #132)해 수정(#133)을 포함한 재배포
- 운영 DB의 V8 부분 적용 상태는 수동 정리 완료 (빈 테이블 컬럼 제거 + flyway 실패 이력 삭제)
- 머지 후 v0.2.0 태그 재지정으로 배포 트리거

<!--
---

## ✅ Test

- 로컬 MySQL 8.0 도커에서 V1~V10 전체 마이그레이션 순차 실행 통과
-->