### PR TITLE
[Fix] #126 프로필 통계·파츠·기록에 방 인증(RoomProof) 합산 누락 수정

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -147,11 +148,13 @@ public class MissionService {
   // 내 미션 기록 (최근 30개, 인증 사진 포함)
   // 레거시 개인 미션(UserMission)과 Rooms v2 방 인증(RoomProof)을 날짜순으로 병합한다.
   // (현재 실제 인증은 방 인증으로만 저장되므로 RoomProof 미포함 시 기록이 비어 보인다)
+  // 병합 정렬 키(assignedAt=방 미션 날짜)와 같은 키로 각 소스 상위 30건만 가져오므로
+  // 병합 후 상위 30건은 전체 조회와 동일하다.
   public List<UserMissionResponse> getHistory(Long userId) {
     Stream<UserMissionResponse> personal =
-        userMissionRepository.findHistoryWithPhoto(userId).stream();
+        userMissionRepository.findHistoryWithPhoto(userId).stream().limit(30);
     Stream<UserMissionResponse> rooms =
-        roomProofRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+        roomProofRepository.findHistoryByUser(userId, PageRequest.of(0, 30)).stream()
             .map(MissionService::toHistoryResponse);
     return Stream.concat(personal, rooms)
         .sorted(Comparator.comparing(UserMissionResponse::assignedAt).reversed())

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/service/MissionService.java
@@ -9,14 +9,20 @@ import com.offmode.boundedcontext.mission.repository.MissionRepository;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.room.entity.RoomMission;
+import com.offmode.boundedcontext.room.entity.RoomProof;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.types.ProofStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +35,7 @@ public class MissionService {
 
   private final MissionRepository missionRepository;
   private final UserMissionRepository userMissionRepository;
+  private final RoomProofRepository roomProofRepository;
   private final UserRepository userRepository;
   private final BadgeService badgeService;
 
@@ -138,8 +145,36 @@ public class MissionService {
   }
 
   // 내 미션 기록 (최근 30개, 인증 사진 포함)
+  // 레거시 개인 미션(UserMission)과 Rooms v2 방 인증(RoomProof)을 날짜순으로 병합한다.
+  // (현재 실제 인증은 방 인증으로만 저장되므로 RoomProof 미포함 시 기록이 비어 보인다)
   public List<UserMissionResponse> getHistory(Long userId) {
-    return userMissionRepository.findHistoryWithPhoto(userId).stream().limit(30).toList();
+    Stream<UserMissionResponse> personal =
+        userMissionRepository.findHistoryWithPhoto(userId).stream();
+    Stream<UserMissionResponse> rooms =
+        roomProofRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+            .map(MissionService::toHistoryResponse);
+    return Stream.concat(personal, rooms)
+        .sorted(Comparator.comparing(UserMissionResponse::assignedAt).reversed())
+        .limit(30)
+        .toList();
+  }
+
+  // 방 인증(RoomProof) → 미션 기록 DTO. 날짜는 방 미션 날짜 기준(업로드 시각 아님)으로 버킷팅.
+  private static UserMissionResponse toHistoryResponse(RoomProof proof) {
+    RoomMission rm = proof.getRoomMission();
+    boolean verified = proof.getStatus() == ProofStatus.VERIFIED;
+    String status = (verified ? MissionStatus.VERIFIED : MissionStatus.PENDING).value();
+    String category = rm.getCategory() == null ? null : rm.getCategory().value();
+    return new UserMissionResponse(
+        proof.getId(),
+        rm.getIcon(),
+        rm.getTitle(),
+        category,
+        status,
+        rm.getDate().atStartOfDay(),
+        verified ? proof.getCreatedAt() : null,
+        proof.getPhotoUrl(),
+        proof.getCaption());
   }
 
   // 미션 풀 전체 조회

--- a/backend/src/main/java/com/offmode/boundedcontext/part/service/PartService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/part/service/PartService.java
@@ -8,6 +8,8 @@ import com.offmode.boundedcontext.part.dto.response.PartResponse.PlacementRespon
 import com.offmode.boundedcontext.part.entity.UserPart;
 import com.offmode.boundedcontext.part.repository.UserPartRepository;
 import com.offmode.boundedcontext.part.types.PartDefinition;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.types.ProofStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import com.offmode.global.exception.BusinessException;
@@ -27,6 +29,7 @@ public class PartService {
 
   private final UserPartRepository userPartRepository;
   private final UserMissionRepository userMissionRepository;
+  private final RoomProofRepository roomProofRepository;
   private final UserRepository userRepository;
 
   /** 모든 파츠 정의 + 유저별 해금 상태 + 배치 정보(미배치면 null). */
@@ -95,8 +98,10 @@ public class PartService {
         .toList();
   }
 
+  // 누적 인증 수 = 레거시 개인 미션 + Rooms v2 방 인증(RoomProof). UserService 와 동일 기준.
   private long countVerified(Long userId) {
-    return userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED);
+    return userMissionRepository.countByUserIdAndStatus(userId, MissionStatus.VERIFIED)
+        + roomProofRepository.countByUserIdAndStatus(userId, ProofStatus.VERIFIED);
   }
 
   private User getUserRef(Long userId) {

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -29,6 +29,9 @@ public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
 
   long countByUserIdAndStatus(Long userId, ProofStatus status);
 
+  // 프로필 활동 기록용: 유저가 올린 방 인증 전체(최신순, 사진·상태·미션 포함)
+  List<RoomProof> findByUserIdOrderByCreatedAtDesc(Long userId);
+
   // 카테고리별 방 인증 수 (WALKER/BEAUTY_CURATOR/LOCAL_HIPSTER 배지 + 카테고리 통계용).
   // roomMission.category 가 null 인 인증은 어떤 카테고리에도 잡히지 않는다.
   long countByUserIdAndStatusAndRoomMissionCategory(

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,8 +30,17 @@ public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
 
   long countByUserIdAndStatus(Long userId, ProofStatus status);
 
-  // 프로필 활동 기록용: 유저가 올린 방 인증 전체(최신순, 사진·상태·미션 포함)
-  List<RoomProof> findByUserIdOrderByCreatedAtDesc(Long userId);
+  // 프로필 활동 기록용: 유저가 올린 방 인증(방 미션 날짜 최신순).
+  // roomMission 을 fetch join 으로 함께 로드해 건당 추가 쿼리(N+1) 없이 사용한다.
+  @Query(
+      """
+        SELECT p
+        FROM RoomProof p
+        JOIN FETCH p.roomMission rm
+        WHERE p.user.id = :userId
+        ORDER BY rm.date DESC, p.id DESC
+    """)
+  List<RoomProof> findHistoryByUser(@Param("userId") Long userId, Pageable pageable);
 
   // 카테고리별 방 인증 수 (WALKER/BEAUTY_CURATOR/LOCAL_HIPSTER 배지 + 카테고리 통계용).
   // roomMission.category 가 null 인 인증은 어떤 카테고리에도 잡히지 않는다.

--- a/backend/src/test/java/com/offmode/boundedcontext/mission/service/MissionServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/mission/service/MissionServiceTest.java
@@ -14,6 +14,7 @@ import com.offmode.boundedcontext.mission.repository.MissionRepository;
 import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import java.time.LocalDateTime;
@@ -30,13 +31,19 @@ class MissionServiceTest {
 
   @Mock private MissionRepository missionRepository;
   @Mock private UserMissionRepository userMissionRepository;
+  @Mock private RoomProofRepository roomProofRepository;
   @Mock private UserRepository userRepository;
   @Mock private BadgeService badgeService;
 
   @Test
   void setTodayMissionCreatesMissionWhenTodayMissionDoesNotExist() {
     MissionService service =
-        new MissionService(missionRepository, userMissionRepository, userRepository, badgeService);
+        new MissionService(
+            missionRepository,
+            userMissionRepository,
+            roomProofRepository,
+            userRepository,
+            badgeService);
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     when(userMissionRepository.findFirstByUserIdAndAssignedAtBetweenOrderByAssignedAtDesc(
             eq(1L), any(), any()))
@@ -56,7 +63,12 @@ class MissionServiceTest {
   @Test
   void setTodayMissionOverwritesPendingMission() {
     MissionService service =
-        new MissionService(missionRepository, userMissionRepository, userRepository, badgeService);
+        new MissionService(
+            missionRepository,
+            userMissionRepository,
+            roomProofRepository,
+            userRepository,
+            badgeService);
     UserMission existing =
         UserMission.builder()
             .id(10L)
@@ -84,7 +96,12 @@ class MissionServiceTest {
   @Test
   void setTodayMissionCreatesNewMissionWhenExistingMissionIsVerified() {
     MissionService service =
-        new MissionService(missionRepository, userMissionRepository, userRepository, badgeService);
+        new MissionService(
+            missionRepository,
+            userMissionRepository,
+            roomProofRepository,
+            userRepository,
+            badgeService);
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     UserMission existing =
         UserMission.builder()
@@ -111,7 +128,12 @@ class MissionServiceTest {
   @Test
   void weightedPoolReducesWeightForRecentlyAssignedMission() {
     MissionService service =
-        new MissionService(missionRepository, userMissionRepository, userRepository, badgeService);
+        new MissionService(
+            missionRepository,
+            userMissionRepository,
+            roomProofRepository,
+            userRepository,
+            badgeService);
     when(missionRepository.findAll())
         .thenReturn(
             List.of(

--- a/backend/src/test/java/com/offmode/boundedcontext/part/service/PartServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/part/service/PartServiceTest.java
@@ -14,6 +14,7 @@ import com.offmode.boundedcontext.part.dto.request.PlacementRequest;
 import com.offmode.boundedcontext.part.dto.response.PartResponse;
 import com.offmode.boundedcontext.part.entity.UserPart;
 import com.offmode.boundedcontext.part.repository.UserPartRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import com.offmode.global.exception.BusinessException;
@@ -30,10 +31,12 @@ class PartServiceTest {
 
   @Mock private UserPartRepository userPartRepository;
   @Mock private UserMissionRepository userMissionRepository;
+  @Mock private RoomProofRepository roomProofRepository;
   @Mock private UserRepository userRepository;
 
   private PartService service() {
-    return new PartService(userPartRepository, userMissionRepository, userRepository);
+    return new PartService(
+        userPartRepository, userMissionRepository, roomProofRepository, userRepository);
   }
 
   private PartResponse find(List<PartResponse> parts, String key) {


### PR DESCRIPTION
## 🔗 Issue

- close #126

---

## 📌 Summary

- 완주 모델이 레거시 UserMission / Rooms v2 RoomProof로 나뉜 상태에서 #121이 UserService(stats)에만 RoomProof를 합산해, 방 인증만 한 유저는 파츠가 해금되지 않고 미션 기록이 비어 보이던 문제 수정
- `PartService.countVerified`: RoomProof VERIFIED 합산 추가 (UserService와 동일 기준)
- `MissionService.getHistory`: RoomProof를 방 미션 날짜 기준으로 병합해 최근 30개 반환 (`RoomProofRepository.findByUserIdOrderByCreatedAtDesc` 추가)

---

## ✅ Test

- [x] `./gradlew spotlessCheck test` BUILD SUCCESSFUL (PartServiceTest·MissionServiceTest RoomProof 반영)
- [ ] 실기기: 방 인증만 있는 계정에서 파츠 해금·주간 활동·미션 기록 표시 확인