### PR TITLE
[Feat] #112 웜크림 리디자인 일괄 적용 + 하단 인셋 인프라·RoomDetail 재설계·프로필 탭 순서

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -66,8 +66,8 @@ import { scheduleMissionNotification, cancelMissionNotification } from './utils/
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
-// 최상위 3페이지 좌우 스와이프 순서 (Profile 가운데). Feed 탭은 RoomDetail로 흡수되어 제거됨.
-const PAGES = ['mission', 'profile', 'settings'];
+// 최상위 3페이지 좌우 스와이프 순서 (Mission 가운데). Feed 탭은 RoomDetail로 흡수되어 제거됨.
+const PAGES = ['profile', 'mission', 'settings'];
 
 function AppInner() {
   const { colors: C, scheme } = useTheme();
@@ -474,7 +474,7 @@ function AppInner() {
             </View>
           )}
 
-          {/* ── 최상위 3페이지 (좌우 스와이프: Mission | Profile | Settings) ── */}
+          {/* ── 최상위 3페이지 (좌우 스와이프: Profile | Mission | Settings) ── */}
           <View
             style={[styles.screenWrap, currentStack && { opacity: 0 }]}
             pointerEvents={currentStack ? 'none' : 'auto'}

--- a/App.jsx
+++ b/App.jsx
@@ -7,6 +7,7 @@ import { SafeAreaProvider, SafeAreaView, initialWindowMetrics } from 'react-nati
 import { StatusBar } from 'expo-status-bar';
 import { useFonts } from 'expo-font';
 import PageIndicator from './components/PageIndicator';
+import useBottomInset from './utils/useBottomInset';
 import { W } from './constants/warm';
 import * as H from './utils/haptics';
 import RoomListScreen from './screens/RoomListScreen';
@@ -68,6 +69,13 @@ SplashScreen.preventAutoHideAsync().catch(() => {});
 
 // 최상위 3페이지 좌우 스와이프 순서 (Mission 가운데). Feed 탭은 RoomDetail로 흡수되어 제거됨.
 const PAGES = ['profile', 'mission', 'settings'];
+
+// 최상위 페이저 하단 여백 (홈 인디케이터 있으면 그 높이, 없으면 24px — useBottomInset).
+// SafeAreaProvider 하위에서 렌더돼야 훅이 동작하므로 별도 컴포넌트로 분리.
+function PagerBottomInset() {
+  const height = useBottomInset();
+  return <View style={{ height, backgroundColor: 'transparent' }} />;
+}
 
 function AppInner() {
   const { colors: C, scheme } = useTheme();
@@ -284,7 +292,11 @@ function AppInner() {
     [tab],
   );
 
-  const statusStyle = scheme === 'dark' ? 'light' : 'dark';
+  // 회원가입·인증 후 메인 탭은 웜 크림 팔레트를 쓰므로 최상위 크롬(상태바·상단 세이프에어리어)도 크림으로 맞춘다.
+  const warmChrome =
+    authStatus === 'signingUp' || (authStatus === 'authenticated' && !showRoulette);
+  const chromeBg = warmChrome ? W.bg : C.bg;
+  const statusStyle = warmChrome ? 'dark' : scheme === 'dark' ? 'light' : 'dark';
 
   if (!fontsLoaded || authStatus === 'loading') return null;
 
@@ -312,8 +324,8 @@ function AppInner() {
   return (
     <Animated.View style={{ flex: 1, opacity: fadeAnim }}>
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-      <StatusBar style={statusStyle} backgroundColor={C.bg} />
-      <SafeAreaView style={{ flex: 1, backgroundColor: C.bg }} edges={['top']}>
+      <StatusBar style={statusStyle} backgroundColor={chromeBg} />
+      <SafeAreaView style={{ flex: 1, backgroundColor: chromeBg }} edges={['top']}>
 
       {/* ── 로그인 화면 ── */}
       {authStatus === 'unauthenticated' && (
@@ -344,7 +356,7 @@ function AppInner() {
 
       {/* ── 메인 탭 UI ── */}
       {authStatus === 'authenticated' && !showRoulette && (
-        <View style={{ flex: 1, backgroundColor: C.bg }}>
+        <View style={{ flex: 1, backgroundColor: W.bg }}>
 
           {/* ── 스택 화면 (오버레이) ── */}
           {currentStack === 'missionTime' && (
@@ -513,8 +525,12 @@ function AppInner() {
               )}
             </View>
 
-            {/* 페이지 인디케이터 (3페이지 공통) — 3페이지 모두 웜 크림 */}
-            <PageIndicator count={PAGES.length} active={PAGES.indexOf(tab)} bg={W.bg} />
+            {/* 플로팅 바텀: 인디케이터 + 하단 인셋을 화면 위에 투명 오버레이로 띄움
+                → 스크롤 컨텐츠가 그 뒤로 비치는 엣지-투-엣지 룩 */}
+            <View style={styles.pagerBottomOverlay} pointerEvents="none">
+              <PageIndicator count={PAGES.length} active={PAGES.indexOf(tab)} bg="transparent" />
+              <PagerBottomInset />
+            </View>
           </View>
         </View>
       )}
@@ -544,4 +560,5 @@ export default function App() {
 
 const styles = StyleSheet.create({
   screenWrap: { flex: 1 },
+  pagerBottomOverlay: { position: 'absolute', left: 0, right: 0, bottom: 0, backgroundColor: 'transparent' },
 });

--- a/components/CharacterDecor.jsx
+++ b/components/CharacterDecor.jsx
@@ -305,7 +305,7 @@ const s = StyleSheet.create({
     borderRadius: 40,
     borderWidth: 1,
     borderColor: W.borderStrong,
-    backgroundColor: W.neutralFaint,
+    backgroundColor: W.neutralSoft,
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'hidden',
@@ -363,7 +363,7 @@ const s = StyleSheet.create({
   cellWrap: { width: '25%', alignItems: 'center' },
   pill: {
     width: 80,
-    height: 44,
+    height: 40,
     borderRadius: 20,
     borderWidth: 1,
     alignItems: 'center',
@@ -371,7 +371,7 @@ const s = StyleSheet.create({
     overflow: 'hidden',
   },
   pillDefault: { backgroundColor: W.surface, borderColor: W.borderStrong },
-  pillEquipped: { backgroundColor: W.neutralFaint, borderColor: W.brown },
+  pillEquipped: { backgroundColor: 'rgba(168,149,138,0.3)', borderColor: W.brown }, // Figma 장착 상태 30% 틴트
   pillLocked: { opacity: 0.3 },
   partImg: { width: 48, height: 48 },
   placedBadge: {

--- a/components/PageIndicator.jsx
+++ b/components/PageIndicator.jsx
@@ -1,13 +1,26 @@
 import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { W } from '../constants/warm';
+import useBottomInset from '../utils/useBottomInset';
+
+/** 페이지 인디케이터 바 높이 (Figma 356:231). */
+export const PAGE_INDICATOR_HEIGHT = 33;
+
+/**
+ * 엣지-투-엣지 페이저에서 컨텐츠가 확보해야 할 하단 여백.
+ * = 인디케이터 높이 + 하단 인셋(useBottomInset)
+ * SafeAreaProvider 하위에서만 호출할 것.
+ */
+export function usePagerBottomBarHeight() {
+  return PAGE_INDICATOR_HEIGHT + useBottomInset();
+}
 
 /**
  * 최상위 3페이지(Mission · Profile · Settings) 스와이프 페이지 인디케이터.
  * Figma 356:231 — 비활성 8x8 점(웜 border), 활성 20x8 그린 pill.
- * bg는 활성 페이지에 맞춰 호출부에서 전달(웜 페이지=웜 크림, 설정=테마 배경).
+ * 엣지-투-엣지 플로팅 오버레이용으로 bg 기본값은 transparent.
  */
-export default function PageIndicator({ count = 3, active = 0, bg = W.bg }) {
+export default function PageIndicator({ count = 3, active = 0, bg = 'transparent' }) {
   const s = useMemo(() => makeStyles(bg), [bg]);
   return (
     <View style={s.bar}>
@@ -20,7 +33,7 @@ export default function PageIndicator({ count = 3, active = 0, bg = W.bg }) {
 
 function makeStyles(bg) {
   return StyleSheet.create({
-    bar: { height: 33, flexDirection: 'row', justifyContent: 'center', alignItems: 'center', gap: 8, backgroundColor: bg },
+    bar: { height: PAGE_INDICATOR_HEIGHT, flexDirection: 'row', justifyContent: 'center', alignItems: 'center', gap: 8, backgroundColor: bg },
     dot: { width: 8, height: 8, borderRadius: 4, backgroundColor: W.border },
     dotActive: { width: 20, backgroundColor: W.green },
   });

--- a/components/RoomBits.jsx
+++ b/components/RoomBits.jsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from 'react';
 import {
   View, Image, StyleSheet, TouchableOpacity, Modal, ScrollView,
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import { W } from '../constants/warm';
 import WarmText from './WarmText';
@@ -11,17 +10,17 @@ import { roomIconEmoji, DEFAULT_REACTIONS, EMOJI_PALETTE } from '../constants/ro
 import { getAvatarDefaultSource } from '../utils/avatars';
 
 /* ── 상단 헤더 (뒤로/제목/우측액션) ─────────────────────── */
-export function RoomTopBar({ title, subtitle, onBack, rightIcon, onRight }) {
+export function RoomTopBar({ title, subtitle, onBack, rightIcon, onRight, titleSize = 18, subtitleColor }) {
   const C = W;
   const s = useMemo(() => makeBarStyles(C), [C]);
   return (
     <View style={s.bar}>
       <TouchableOpacity onPress={onBack} hitSlop={12} style={s.side} activeOpacity={0.7}>
-        <Ionicons name="chevron-back" size={24} color={C.text} />
+        <Ionicons name="chevron-back" size={20} color={C.text} />
       </TouchableOpacity>
       <View style={s.center}>
-        <WarmText v="title" size={18} numberOfLines={1}>{title}</WarmText>
-        {subtitle ? <WarmText v="caption" color={C.green} style={{ marginTop: 2 }}>{subtitle}</WarmText> : null}
+        <WarmText v="title" size={titleSize} numberOfLines={1}>{title}</WarmText>
+        {subtitle ? <WarmText v="caption" color={subtitleColor ?? C.green} style={{ marginTop: 2 }}>{subtitle}</WarmText> : null}
       </View>
       {rightIcon ? (
         <TouchableOpacity onPress={onRight} hitSlop={12} style={s.side} activeOpacity={0.7}>
@@ -36,20 +35,20 @@ export function RoomTopBar({ title, subtitle, onBack, rightIcon, onRight }) {
 
 function makeBarStyles(C) {
   return StyleSheet.create({
-    bar:    { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 12, paddingTop: 16, paddingBottom: 10 },
+    bar:    { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingTop: 16, paddingBottom: 10 },
     side:   { width: 36, height: 36, alignItems: 'center', justifyContent: 'center' },
     center: { flex: 1, alignItems: 'center' },
   });
 }
 
 /* ── 멤버 아바타 (얼굴 이미지) ──────────────────────────── */
-export function MemberAvatar({ avatarId, size = 32 }) {
+export function MemberAvatar({ avatarId, size = 32, borderColor }) {
   const C = W;
   const src = getAvatarDefaultSource(avatarId);
   return (
     <View style={{
       width: size, height: size, borderRadius: size / 2, overflow: 'hidden',
-      borderWidth: 1, borderColor: C.border, backgroundColor: C.surface2,
+      borderWidth: 1, borderColor: borderColor ?? C.borderStrong, backgroundColor: C.surface2,
       alignItems: 'center', justifyContent: 'center',
     }}>
       {src ? <Image source={src} style={{ width: size, height: size }} resizeMode="contain" /> : null}
@@ -100,45 +99,44 @@ export function RoomIcon({ iconKey, size = 44, accent = false }) {
 export function SourceBadge({ source }) {
   const C = W;
   const isRandom = source === 'RANDOM';
+  const tone = isRandom
+    ? { bg: C.brownFaint, border: C.brownBorder, text: C.brown }
+    : { bg: C.greenFaint, border: C.green, text: C.green };
   return (
     <View style={{
       flexDirection: 'row', alignItems: 'center', gap: 3,
       borderWidth: 1, borderRadius: 8, paddingHorizontal: 7, paddingVertical: 2,
-      borderColor: C.border, backgroundColor: C.surface2,
+      borderColor: tone.border, backgroundColor: tone.bg,
     }}>
       <WarmText size={11}>{isRandom ? '🎲' : '✍️'}</WarmText>
-      <WarmText v="caption" size={11}>{isRandom ? '랜덤' : '직접'}</WarmText>
+      <WarmText v="caption" size={11} color={tone.text}>{isRandom ? '랜덤' : '직접'}</WarmText>
     </View>
   );
 }
 
 /* ── 진행률 바 ──────────────────────────────────────────── */
-export function ProgressBar({ value = 0, total = 0, showLabel = true }) {
+export function ProgressBar({ value = 0, total = 0, showLabel = true, height = 6 }) {
   const C = W;
   const pct = total > 0 ? Math.min(100, (value / total) * 100) : 0;
   return (
     <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-      <View style={{ flex: 1, height: 6, borderRadius: 3, backgroundColor: C.surface2, overflow: 'hidden' }}>
-        <View style={{ height: '100%', width: `${pct}%`, borderRadius: 3, backgroundColor: C.green }} />
+      <View style={{ flex: 1, height, borderRadius: height / 2, backgroundColor: C.greenSoft, overflow: 'hidden' }}>
+        <View style={{ height: '100%', width: `${pct}%`, borderRadius: height / 2, backgroundColor: C.green }} />
       </View>
-      {showLabel && <WarmText v="caption" size={11}>{value}/{total} 인증</WarmText>}
+      {showLabel && <WarmText v="caption" size={11} color={C.text}>{value}/{total} 인증</WarmText>}
     </View>
   );
 }
 
 /* ── 그린 버튼 / 아웃라인 버튼 ──────────────────────────── */
-export function GreenButton({ label, onPress, disabled, style, ionicon }) {
+export function GreenButton({ label, onPress, disabled, style, ionicon, radius }) {
   const C = W;
   return (
     <TouchableOpacity activeOpacity={0.85} onPress={onPress} disabled={disabled} style={style}>
-      <LinearGradient
-        colors={disabled ? [C.surface2, C.surface2] : ['#26d67a', '#1ab065']}
-        start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
-        style={btnStyles.green}
-      >
-        {ionicon ? <Ionicons name={ionicon} size={17} color={disabled ? C.textSub : '#000'} style={{ marginRight: 7 }} /> : null}
-        <WarmText v="btn" style={disabled ? { color: C.textSub } : undefined}>{label}</WarmText>
-      </LinearGradient>
+      <View style={[btnStyles.green, disabled ? btnStyles.greenDisabled : { backgroundColor: C.green }, radius != null && { borderRadius: radius }]}>
+        {ionicon ? <Ionicons name={ionicon} size={17} color={disabled ? C.text : '#fff9f3'} style={{ marginRight: 7 }} /> : null}
+        <WarmText v="btn" style={disabled ? { color: C.text } : undefined}>{label}</WarmText>
+      </View>
     </TouchableOpacity>
   );
 }
@@ -155,6 +153,7 @@ export function OutlineButton({ label, onPress, style, ionicon }) {
 
 const btnStyles = StyleSheet.create({
   green:   { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', borderRadius: 16, paddingVertical: 16 },
+  greenDisabled: { backgroundColor: W.neutralStrong, borderWidth: 1, borderColor: W.text },
   outline: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', borderRadius: 16, paddingVertical: 15, borderWidth: 1.5 },
 });
 
@@ -176,19 +175,19 @@ export function ReactionBar({ reactions = [], onToggle }) {
           key={r.emoji}
           activeOpacity={0.7}
           onPress={() => { H.tap(); onToggle?.(r.emoji); }}
-          style={[reactStyles.chip, { borderColor: C.border, backgroundColor: C.surface },
-            r.mine && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
+          style={[reactStyles.chip, { borderColor: C.brown, backgroundColor: C.neutralStrong },
+            r.mine && { borderColor: C.coral, backgroundColor: C.coralSoft }]}
         >
           <WarmText size={13}>{r.emoji}</WarmText>
-          {r.count > 0 && <WarmText v="caption" size={11} color={r.mine ? C.green : C.textSub}>{r.count}</WarmText>}
+          {r.count > 0 && <WarmText v="caption" size={12} color={C.text}>{r.count}</WarmText>}
         </TouchableOpacity>
       ))}
       <TouchableOpacity
         activeOpacity={0.7}
         onPress={() => { H.tap(); setPickerOpen(true); }}
-        style={[reactStyles.chip, { borderColor: C.border, backgroundColor: C.surface }]}
+        style={[reactStyles.chip, { borderColor: C.brown, backgroundColor: C.neutralStrong }]}
       >
-        <Ionicons name="add" size={14} color={C.textSub} />
+        <Ionicons name="add" size={14} color={C.text} />
       </TouchableOpacity>
 
       <EmojiPickerModal
@@ -248,10 +247,10 @@ export function NudgeChip({ nudged, onPress }) {
       activeOpacity={0.8}
       disabled={nudged}
       onPress={() => { H.tap(); onPress?.(); }}
-      style={[nudgeStyles.chip, { borderColor: C.border, backgroundColor: C.surface },
+      style={[nudgeStyles.chip, { borderColor: C.borderStrong, backgroundColor: C.surface },
         nudged && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
     >
-      <WarmText v="caption" size={12} color={nudged ? C.green : C.textSub}>
+      <WarmText v="caption" size={11} color={nudged ? C.green : C.brown}>
         {nudged ? '✓ 콕 찔렀어요' : '👉 콕 찌르기'}
       </WarmText>
     </TouchableOpacity>
@@ -269,12 +268,11 @@ export function ProofStatusBadge({ status }) {
   return (
     <View style={{
       flexDirection: 'row', alignItems: 'center', gap: 4,
-      borderWidth: 1, borderRadius: 10, paddingHorizontal: 8, paddingVertical: 3,
-      borderColor: verified ? C.greenBorder : C.border,
+      borderRadius: 999, paddingHorizontal: 8, paddingVertical: 3,
       backgroundColor: verified ? C.greenFaint : C.surface2,
     }}>
       <WarmText v="caption" size={11} color={verified ? C.green : C.textSub}>
-        {verified ? '✓ 인증완료' : '· 대기'}
+        {verified ? '인증 완료' : '대기 중'}
       </WarmText>
     </View>
   );

--- a/components/WarmText.jsx
+++ b/components/WarmText.jsx
@@ -17,10 +17,10 @@ const VARIANTS = {
   section: { fontFamily: GM, fontSize: 15, color: W.text },
   body: { fontFamily: GL, fontSize: 14, color: W.text },
   sub: { fontFamily: GL, fontSize: 13, color: W.textSub, lineHeight: 19 },
-  label: { fontFamily: GM, fontSize: 12, color: W.textSub, letterSpacing: 1 },
+  label: { fontFamily: GM, fontSize: 12, color: W.text, letterSpacing: 1 },
   caption: { fontFamily: GL, fontSize: 11, color: W.textSub },
   mission: { fontFamily: GL, fontSize: 24, color: W.text, textAlign: 'center', lineHeight: 32 },
-  btn: { fontFamily: GM, fontSize: 16, color: W.white },
+  btn: { fontFamily: GM, fontSize: 16, color: '#fff9f3' },
 };
 
 export default function WarmText({ v = 'body', size, color, style, children, ...rest }) {

--- a/constants/warm.js
+++ b/constants/warm.js
@@ -14,13 +14,17 @@ export const W = {
   textSub:   '#a8958a', // text sub
   border:    '#e3d6c6', // 부드러운 구분선
   borderStrong: '#a8958a', // 카드 아웃라인(1.5px)
-  neutral:      'rgba(168,149,138,0.5)',  // 뉴트럴 버튼/칩 채움
-  neutralFaint: 'rgba(168,149,138,0.22)',
+  neutral:       'rgba(168,149,138,0.5)',  // 뉴트럴 버튼/칩 채움
+  neutralStrong: 'rgba(168,149,138,0.4)',  // 비활성 버튼/미션 정보 카드
+  neutralSoft:   'rgba(168,149,138,0.2)',  // 카드·입력 배경 (Figma 뉴트럴 탠)
+  neutralFaint:  'rgba(168,149,138,0.12)', // 파스텔 틴트·비활성 칩
 
   // 브랜드 / Energy
-  green:       '#2e7d52',
-  greenFaint:  'rgba(46,125,82,0.12)',
-  greenBorder: 'rgba(46,125,82,0.35)',
+  green:             '#2e7d52',
+  greenFaint:        'rgba(46,125,82,0.12)',
+  greenSoft:         'rgba(46,125,82,0.2)',  // 진행률 트랙
+  greenBorder:       'rgba(46,125,82,0.35)',
+  greenBorderStrong: 'rgba(46,125,82,0.5)',  // 선택 상태 테두리
   // Vitality
   brown:       '#7a5c4f',
   brownFaint:  'rgba(122,92,79,0.12)',
@@ -28,6 +32,7 @@ export const W = {
   // Intellect
   coral:       '#e8513a',
   coralFaint:  'rgba(232,81,58,0.12)',
+  coralSoft:   'rgba(232,81,58,0.4)',   // 활성 리액션 칩
   coralBorder: 'rgba(232,81,58,0.35)',
 
   white: '#ffffff',

--- a/ios/offmode.xcodeproj/project.pbxproj
+++ b/ios/offmode.xcodeproj/project.pbxproj
@@ -360,7 +360,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = offmode/offmode.entitlements;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = SX5KZM28U5;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -374,7 +374,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -403,7 +403,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = offmode/offmode.entitlements;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = SX5KZM28U5;
 				INFOPLIST_FILE = offmode/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
@@ -412,7 +412,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -489,10 +489,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -549,10 +546,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/ios/offmode/Info.plist
+++ b/ios/offmode/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -42,7 +42,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>KAKAO_APP_KEY</key>
 	<string>62ae912ced27c2b48181b0a6d1c84353</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/screens/CreateRoomScreen.jsx
+++ b/screens/CreateRoomScreen.jsx
@@ -6,12 +6,24 @@ import { W } from '../constants/warm';
 import { api } from '../utils/api';
 import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
+import useBottomInset from '../utils/useBottomInset';
 import { RoomTopBar, GreenButton } from '../components/RoomBits';
 import { ROOM_ICON_KEYS, roomIconEmoji } from '../constants/rooms';
+
+// 아이콘별 파스텔 틴트 배경 (Figma 313:120 iconRow)
+const ICON_TINTS = {
+  FIRE:    W.coralFaint,
+  MOON:    W.brownFaint,
+  COFFEE:  W.brownFaint,
+  RUN:     W.greenFaint,
+  BOOKS:   W.coralFaint,
+  SPARKLE: W.greenFaint,
+};
 
 export default function CreateRoomScreen({ onBack, onCreated }) {
   const C = W;
   const s = useMemo(() => makeStyles(C), [C]);
+  const bottomInset = useBottomInset();
 
   const [name, setName] = useState('');
   const [iconKey, setIconKey] = useState('FIRE');
@@ -47,14 +59,14 @@ export default function CreateRoomScreen({ onBack, onCreated }) {
             value={name}
             onChangeText={setName}
             placeholder="예) 우리 동네 갓생러"
-            placeholderTextColor={C.textSub}
+            placeholderTextColor={C.brown}
             maxLength={16}
             style={s.input}
           />
         </View>
 
         <View style={s.field}>
-          <WarmText v="label" style={s.label}>방 아이콘</WarmText>
+          <WarmText v="label" size={14} style={s.label}>방 아이콘</WarmText>
           <View style={s.iconGrid}>
             {ROOM_ICON_KEYS.map(key => {
               const active = iconKey === key;
@@ -63,9 +75,13 @@ export default function CreateRoomScreen({ onBack, onCreated }) {
                   key={key}
                   activeOpacity={0.8}
                   onPress={() => { H.tap(); setIconKey(key); }}
-                  style={[s.iconCell, active && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
+                  style={[
+                    s.iconCell,
+                    { backgroundColor: ICON_TINTS[key] ?? C.neutralFaint },
+                    active && { borderColor: C.coral, backgroundColor: C.coralFaint },
+                  ]}
                 >
-                  <WarmText size={24}>{roomIconEmoji(key)}</WarmText>
+                  <WarmText size={22}>{roomIconEmoji(key)}</WarmText>
                 </TouchableOpacity>
               );
             })}
@@ -85,11 +101,11 @@ export default function CreateRoomScreen({ onBack, onCreated }) {
                   key={opt.value}
                   activeOpacity={0.8}
                   onPress={() => { H.tap(); setType(opt.value); }}
-                  style={[s.segItem, active && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
+                  style={[s.segItem, active && { borderColor: C.greenBorderStrong, backgroundColor: C.greenFaint }]}
                 >
                   <WarmText size={20} style={{ marginBottom: 4 }}>{opt.emoji}</WarmText>
                   <WarmText v="body" size={14} color={active ? C.green : C.text}>{opt.label}</WarmText>
-                  <WarmText v="caption" size={11} style={{ marginTop: 2 }}>{opt.desc}</WarmText>
+                  <WarmText v="caption" size={11} color={active ? C.textSub : C.brown} style={{ marginTop: 2 }}>{opt.desc}</WarmText>
                 </TouchableOpacity>
               );
             })}
@@ -99,14 +115,14 @@ export default function CreateRoomScreen({ onBack, onCreated }) {
         {type === 'GROUP' ? (
           <View style={s.inviteCard}>
             <WarmText v="section" size={14} style={{ marginBottom: 4 }}>🔗 친구 초대</WarmText>
-            <WarmText v="sub" size={13}>방을 만든 뒤 초대코드를 공유하면 친구가 참여할 수 있어요.</WarmText>
+            <WarmText v="sub" size={13} color={C.brown}>방을 만든 뒤 초대코드를 공유하면 친구가 참여할 수 있어요.</WarmText>
           </View>
         ) : null}
 
         {error ? <WarmText v="sub" color={C.coral} style={{ marginTop: 16 }}>{error}</WarmText> : null}
       </ScrollView>
 
-      <View style={s.bottom}>
+      <View style={[s.bottom, { paddingBottom: bottomInset }]}>
         <GreenButton label="방 만들기" onPress={handleCreate} disabled={!canCreate} />
       </View>
     </View>
@@ -119,12 +135,12 @@ function makeStyles(C) {
     content: { paddingHorizontal: 20, paddingBottom: 40, gap: 24 },
     field:   { gap: 8 },
     label:   { marginBottom: 2 },
-    input:   { backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 14, fontFamily: 'GmarketSansLight', fontSize: 15, color: C.text },
+    input:   { backgroundColor: C.neutralSoft, borderWidth: 1, borderColor: C.borderStrong, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 14, fontFamily: 'GmarketSansLight', fontSize: 15, color: C.text },
     iconGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
-    iconCell: { width: 52, height: 52, borderRadius: 14, backgroundColor: C.surface, borderWidth: 1.5, borderColor: C.border, alignItems: 'center', justifyContent: 'center' },
+    iconCell: { width: 48, height: 48, borderRadius: 999, borderWidth: 1, borderColor: 'transparent', alignItems: 'center', justifyContent: 'center' },
     segmented: { flexDirection: 'row', gap: 10 },
-    segItem:   { flex: 1, backgroundColor: C.surface, borderWidth: 1.5, borderColor: C.border, borderRadius: 16, paddingVertical: 16, alignItems: 'center' },
-    inviteCard: { backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 14, padding: 16 },
-    bottom:    { paddingHorizontal: 20, paddingTop: 12, paddingBottom: 24, backgroundColor: C.bg, borderTopWidth: 1, borderTopColor: C.border },
+    segItem:   { flex: 1, backgroundColor: C.neutralFaint, borderWidth: 1, borderColor: C.borderStrong, borderRadius: 16, paddingVertical: 16, alignItems: 'center' },
+    inviteCard: { backgroundColor: C.neutralFaint, borderWidth: 1, borderColor: C.borderStrong, borderRadius: 14, padding: 16 },
+    bottom:    { paddingHorizontal: 20, paddingTop: 20, paddingBottom: 24, backgroundColor: C.bg },
   });
 }

--- a/screens/JoinRoomScreen.jsx
+++ b/screens/JoinRoomScreen.jsx
@@ -6,11 +6,13 @@ import { W } from '../constants/warm';
 import { api } from '../utils/api';
 import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
+import useBottomInset from '../utils/useBottomInset';
 import { RoomTopBar, GreenButton } from '../components/RoomBits';
 
 export default function JoinRoomScreen({ onBack, onJoined }) {
   const C = W;
   const s = useMemo(() => makeStyles(C), [C]);
+  const bottomInset = useBottomInset();
 
   const [code, setCode] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -45,13 +47,13 @@ export default function JoinRoomScreen({ onBack, onJoined }) {
             value={code}
             onChangeText={(t) => { setCode(t.toUpperCase()); setError(''); }}
             placeholder="예) OFF111"
-            placeholderTextColor={C.textSub}
+            placeholderTextColor={C.brown}
             autoCapitalize="characters"
             autoCorrect={false}
             maxLength={8}
             style={[s.input, { letterSpacing: 2 }]}
           />
-          <WarmText v="caption" style={{ marginTop: 4 }}>친구에게 받은 6자리 코드를 입력하세요</WarmText>
+          <WarmText v="caption" color={C.text} style={{ marginTop: 4 }}>친구에게 받은 6자리 코드를 입력하세요 (예: RUN777, BOOK10)</WarmText>
         </View>
 
         {error ? (
@@ -61,7 +63,7 @@ export default function JoinRoomScreen({ onBack, onJoined }) {
         ) : null}
       </ScrollView>
 
-      <View style={s.bottom}>
+      <View style={[s.bottom, { paddingBottom: bottomInset }]}>
         <GreenButton label="참여하기" onPress={handleJoin} disabled={!canJoin} />
       </View>
     </View>
@@ -72,8 +74,8 @@ function makeStyles(C) {
   return StyleSheet.create({
     screen:  { flex: 1, backgroundColor: C.bg },
     content: { paddingHorizontal: 20, paddingBottom: 40, gap: 20 },
-    input:   { backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 14, fontFamily: 'GmarketSansLight', fontSize: 16, color: C.text },
+    input:   { backgroundColor: C.neutralSoft, borderWidth: 1, borderColor: C.borderStrong, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 14, fontFamily: 'GmarketSansLight', fontSize: 15, color: C.text },
     errorBox: { backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 14, paddingVertical: 18, paddingHorizontal: 16 },
-    bottom:  { paddingHorizontal: 20, paddingTop: 12, paddingBottom: 24, backgroundColor: C.bg, borderTopWidth: 1, borderTopColor: C.border },
+    bottom:  { paddingHorizontal: 20, paddingTop: 20, paddingBottom: 24, backgroundColor: C.bg },
   });
 }

--- a/screens/LoginScreen.jsx
+++ b/screens/LoginScreen.jsx
@@ -1,15 +1,13 @@
 import React, { useMemo } from 'react';
 import {
-  View, Text, StyleSheet, TouchableOpacity, Platform,
+  View, StyleSheet, TouchableOpacity, Platform,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useColors } from '../utils/useColors';
-import T from '../components/ThemedText';
-
-const F = 'Kkukkukk';
+import { W } from '../constants/warm';
+import WarmText from '../components/WarmText';
 
 export default function LoginScreen({ onKakaoLogin, onAppleLogin, loading, error }) {
-  const C = useColors();
+  const C = W;
   const s = useMemo(() => makeStyles(C), [C]);
 
   return (
@@ -17,18 +15,16 @@ export default function LoginScreen({ onKakaoLogin, onAppleLogin, loading, error
 
       {/* 상단 브랜딩 */}
       <View style={s.brand}>
-        <View style={s.logoWrap}>
-          <LinearGradient
-            colors={['#22c97a', '#1ab065']}
-            style={s.logoCircle}
-          >
-            <Text style={s.logoMoon}>🌙</Text>
-          </LinearGradient>
-        </View>
-        <T v="logo" size={36} style={s.logoText}>OFFMODE</T>
-        <T v="sub" style={s.tagline}>
+        <LinearGradient
+          colors={['#22c97a', '#1ab065']}
+          style={s.logoCircle}
+        >
+          <WarmText style={s.logoMoon}>🌙</WarmText>
+        </LinearGradient>
+        <WarmText v="logo" style={s.logoText}>OFFMODE</WarmText>
+        <WarmText v="sub" size={15} color={C.green} style={s.tagline}>
           매일 하나의 미션으로{'\n'}오프라인을 시작하세요
-        </T>
+        </WarmText>
       </View>
 
       {/* 로그인 버튼들 */}
@@ -41,35 +37,37 @@ export default function LoginScreen({ onKakaoLogin, onAppleLogin, loading, error
           activeOpacity={0.85}
           disabled={loading}
         >
-          <Text style={s.kakaoIcon}>💬</Text>
-          <Text style={s.kakaoText}>{loading ? '로그인 중...' : '카카오로 시작하기'}</Text>
+          <WarmText size={20}>💬</WarmText>
+          <WarmText v="body" size={16} style={s.kakaoText}>
+            {loading ? '로그인 중...' : '카카오로 시작하기'}
+          </WarmText>
           <View style={{ width: 24 }} />
         </TouchableOpacity>
 
         {/* Apple (iOS only) */}
         {Platform.OS === 'ios' && (
           <TouchableOpacity
-            style={[s.appleBtn, { backgroundColor: C.isDark ? '#ffffff' : '#000000' }]}
+            style={s.appleBtn}
             onPress={onAppleLogin}
             activeOpacity={0.85}
             disabled={loading}
           >
-            <Text style={[s.appleIcon, { color: C.isDark ? '#000' : '#fff' }]}></Text>
-            <Text style={[s.appleText, { color: C.isDark ? '#000' : '#fff' }]}>
+            <WarmText size={18} color="#000000"></WarmText>
+            <WarmText v="body" size={16} style={s.appleText}>
               {loading ? '로그인 중...' : 'Apple로 시작하기'}
-            </Text>
+            </WarmText>
             <View style={{ width: 24 }} />
           </TouchableOpacity>
         )}
 
-        {!!error && <T v="caption" style={s.error}>{error}</T>}
+        {!!error && <WarmText v="caption" color={C.coral} style={s.error}>{error}</WarmText>}
 
       </View>
 
       {/* 하단 약관 */}
-      <T v="caption" style={s.terms}>
+      <WarmText v="caption" color={C.text} style={s.terms}>
         시작하면 서비스 이용약관 및{'\n'}개인정보 처리방침에 동의하는 것으로 간주됩니다
-      </T>
+      </WarmText>
 
     </View>
   );
@@ -83,19 +81,15 @@ function makeStyles(C) {
       paddingHorizontal: 28, paddingTop: 100, paddingBottom: 48,
     },
 
-    brand: { alignItems: 'center', flex: 1, justifyContent: 'center' },
+    brand: { alignItems: 'center', flex: 1, justifyContent: 'center', gap: 18 },
 
-    logoWrap:   { marginBottom: 20 },
     logoCircle: {
       width: 80, height: 80, borderRadius: 40,
       alignItems: 'center', justifyContent: 'center',
     },
     logoMoon: { fontSize: 40 },
-    logoText: { letterSpacing: 6, marginBottom: 16 },
-    tagline:  {
-      textAlign: 'center', lineHeight: 22, opacity: 0.7,
-      fontFamily: F, fontSize: 15,
-    },
+    logoText: { letterSpacing: 6 },
+    tagline:  { textAlign: 'center', lineHeight: 22, opacity: 0.7 },
 
     btns: { width: '100%', gap: 12, marginBottom: 32 },
 
@@ -106,19 +100,19 @@ function makeStyles(C) {
       flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
       gap: 8,
     },
-    kakaoIcon: { fontSize: 20 },
-    kakaoText: { fontFamily: F, fontSize: 16, color: 'rgba(0,0,0,0.85)', flex: 1, textAlign: 'center' },
+    kakaoText: { color: 'rgba(0,0,0,0.85)', flex: 1, textAlign: 'center' },
 
     /* Apple */
     appleBtn: {
+      backgroundColor: '#ffffff',
+      borderWidth: 1, borderColor: '#000000',
       borderRadius: 16, height: 54,
       flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
       gap: 8,
     },
-    appleIcon: { fontSize: 18, fontFamily: F },
-    appleText: { fontFamily: F, fontSize: 16, flex: 1, textAlign: 'center' },
+    appleText: { color: '#000000', flex: 1, textAlign: 'center' },
 
-    error: { textAlign: 'center', color: C.danger, lineHeight: 18 },
+    error: { textAlign: 'center', lineHeight: 18 },
     terms: { textAlign: 'center', lineHeight: 18, opacity: 0.4 },
   });
 }

--- a/screens/MissionPickerScreen.jsx
+++ b/screens/MissionPickerScreen.jsx
@@ -2,12 +2,11 @@ import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import {
   View, StyleSheet, ScrollView, TouchableOpacity, TextInput, ActivityIndicator,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 import { W } from '../constants/warm';
 import { api } from '../utils/api';
 import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
-import { RoomTopBar, GreenButton } from '../components/RoomBits';
+import { RoomTopBar } from '../components/RoomBits';
 
 export default function MissionPickerScreen({ roomId, onBack, onChosen }) {
   const C = W;
@@ -48,7 +47,7 @@ export default function MissionPickerScreen({ roomId, onBack, onChosen }) {
 
   return (
     <View style={s.screen}>
-      <RoomTopBar title="미션 정하기" onBack={onBack} />
+      <RoomTopBar title="미션 직접 입력하기" onBack={onBack} />
       <ScrollView contentContainerStyle={s.content} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
         <WarmText v="label" style={s.sectionLabel}>지난 미션에서 고르기</WarmText>
         {loading ? (
@@ -69,7 +68,6 @@ export default function MissionPickerScreen({ roomId, onBack, onChosen }) {
               >
                 <WarmText size={22}>{m.icon}</WarmText>
                 <WarmText v="body" size={15} style={{ flex: 1 }}>{m.title}</WarmText>
-                <Ionicons name="chevron-forward" size={18} color={C.textSub} />
               </TouchableOpacity>
             ))}
           </View>
@@ -81,15 +79,18 @@ export default function MissionPickerScreen({ roomId, onBack, onChosen }) {
             value={custom}
             onChangeText={setCustom}
             placeholder="예) 좋아하는 노래 들으며 산책"
-            placeholderTextColor={C.textSub}
+            placeholderTextColor={C.brown}
             maxLength={30}
             style={s.input}
           />
-          <GreenButton
-            label="이 미션으로 정하기"
+          <TouchableOpacity
+            activeOpacity={0.8}
             disabled={!canCustom}
             onPress={() => { H.success(); submit({ source: 'DIRECT', title: custom.trim(), icon: '✨' }); }}
-          />
+            style={[s.outlineBtn, !canCustom && { opacity: 0.5 }]}
+          >
+            <WarmText v="section" size={16} color={C.green}>이 미션으로 정하기</WarmText>
+          </TouchableOpacity>
         </View>
 
         {error ? <WarmText v="sub" color={C.coral} style={{ marginTop: 16, textAlign: 'center' }}>{error}</WarmText> : null}
@@ -104,8 +105,9 @@ function makeStyles(C) {
     content: { paddingHorizontal: 20, paddingBottom: 40 },
     center:  { paddingVertical: 30, alignItems: 'center' },
     sectionLabel: { marginTop: 16, marginBottom: 10 },
-    pickRow: { flexDirection: 'row', alignItems: 'center', gap: 12, backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 14, paddingHorizontal: 14, paddingVertical: 14 },
-    input:   { backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 14, fontFamily: 'GmarketSansLight', fontSize: 15, color: C.text },
+    pickRow: { flexDirection: 'row', alignItems: 'center', gap: 12, backgroundColor: C.surface, borderWidth: 1, borderColor: C.borderStrong, borderRadius: 14, paddingHorizontal: 14, paddingVertical: 14 },
+    input:   { backgroundColor: C.neutralSoft, borderWidth: 1, borderColor: C.borderStrong, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 14, fontFamily: 'GmarketSansLight', fontSize: 15, color: C.text },
+    outlineBtn: { alignItems: 'center', justifyContent: 'center', borderRadius: 16, paddingVertical: 15, borderWidth: 1.5, borderColor: C.greenBorder, backgroundColor: C.greenFaint },
     feedEmpty: { backgroundColor: C.surface, borderRadius: 14, borderWidth: 1, borderStyle: 'dashed', borderColor: C.border, paddingVertical: 24, alignItems: 'center' },
   });
 }

--- a/screens/MissionRouletteScreen.jsx
+++ b/screens/MissionRouletteScreen.jsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
 import {
-  View, Text, StyleSheet, TouchableOpacity,
+  View, StyleSheet, TouchableOpacity,
   Animated, Easing, Dimensions, ActivityIndicator,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useColors } from '../utils/useColors';
+import { W, catColorsW } from '../constants/warm';
 import { api } from '../utils/api';
-import T from '../components/ThemedText';
+import WarmText from '../components/WarmText';
 
-const F = 'Kkukkukk';
 const { width } = Dimensions.get('window');
 
 const ITEM_H  = 80;
@@ -16,14 +15,8 @@ const VISIBLE = 3;
 const REPEATS = 6;
 const SLOT_H  = ITEM_H * VISIBLE;
 
-function getCategoryColor(cat, C) {
-  if (cat === 'Energy')    return C.blue;
-  if (cat === 'Intellect') return C.purple;
-  return C.green;
-}
-
 function SlotMachine({ onDone, autoSpin = true, missions }) {
-  const C = useColors();
+  const C = W;
   const slot = useMemo(() => makeSlotStyles(C), [C]);
   const translateY = useRef(new Animated.Value(0)).current;
   const [spinning,  setSpinning]  = useState(false);
@@ -74,8 +67,8 @@ function SlotMachine({ onDone, autoSpin = true, missions }) {
 
   return (
     <View style={slot.root}>
-      <LinearGradient colors={[C.surface, C.surface + '00']} style={[slot.fade, { top: 0 }]}    pointerEvents="none" />
-      <LinearGradient colors={[C.surface + '00', C.surface]} style={[slot.fade, { bottom: 0 }]} pointerEvents="none" />
+      <LinearGradient colors={[C.bg, C.bg + '00']} style={[slot.fade, { top: 0 }]}    pointerEvents="none" />
+      <LinearGradient colors={[C.bg + '00', C.bg]} style={[slot.fade, { bottom: 0 }]} pointerEvents="none" />
       <View style={slot.highlight} pointerEvents="none" />
       <View style={slot.window}>
         <Animated.View style={{ transform: [{ translateY }] }}>
@@ -83,16 +76,20 @@ function SlotMachine({ onDone, autoSpin = true, missions }) {
             const isSelected = landed && i === ((REPEATS - 2) * missions.length + (finalIdx ?? 0));
             return (
               <View key={i} style={slot.item}>
-                <Text style={slot.itemIcon}>{m.icon}</Text>
-                <T
-                  v="sub"
+                <WarmText style={slot.itemIcon}>{m.icon}</WarmText>
+                <WarmText
+                  v="body"
                   size={15}
-                  color={!isSelected && !C.isDark ? C.green : undefined}
-                  style={[{ flex: 1, lineHeight: 22 }, isSelected && { color: getCategoryColor(m.category, C) }]}
+                  style={[
+                    { flex: 1, lineHeight: 22 },
+                    isSelected
+                      ? { color: catColorsW(m.category).main }
+                      : { color: C.text, opacity: 0.55 },
+                  ]}
                   numberOfLines={2}
                 >
                   {m.text}
-                </T>
+                </WarmText>
               </View>
             );
           })}
@@ -102,9 +99,9 @@ function SlotMachine({ onDone, autoSpin = true, missions }) {
       {/* 수동 모드: 아직 돌리기 전 버튼 */}
       {!autoSpin && !started && (
         <TouchableOpacity onPress={spin} style={slot.manualBtn} activeOpacity={0.8}>
-          <LinearGradient colors={['#26d67a', '#1ab065']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }} style={slot.manualBtnInner}>
-            <T v="btn" size={16}>🎰  돌리기</T>
-          </LinearGradient>
+          <View style={slot.manualBtnInner}>
+            <WarmText v="btn">🎰  돌리기</WarmText>
+          </View>
         </TouchableOpacity>
       )}
     </View>
@@ -115,24 +112,24 @@ function makeSlotStyles(C) {
   return StyleSheet.create({
     root: {
       height: SLOT_H, overflow: 'hidden',
-      borderRadius: 16, borderWidth: 1, borderColor: C.border, backgroundColor: C.surface,
+      borderRadius: 16, borderWidth: 1, borderColor: C.green, backgroundColor: C.bg,
     },
     window:    { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, overflow: 'hidden' },
     highlight: {
       position: 'absolute', top: ITEM_H, left: 0, right: 0, height: ITEM_H,
-      borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.greenBorder,
-      backgroundColor: C.greenFaint, zIndex: 1,
+      borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.green,
+      backgroundColor: C.greenSoft, zIndex: 1,
     },
     fade: { position: 'absolute', left: 0, right: 0, height: ITEM_H * 1.2, zIndex: 2 },
     item: { height: ITEM_H, flexDirection: 'row', alignItems: 'center', paddingHorizontal: 20, gap: 14 },
     itemIcon: { fontSize: 28, width: 36, textAlign: 'center' },
-    manualBtn: { position: 'absolute', left: 0, right: 0, top: 0, bottom: 0, alignItems: 'center', justifyContent: 'center', zIndex: 10, backgroundColor: C.surface + 'cc' },
-    manualBtnInner: { paddingHorizontal: 40, paddingVertical: 16, borderRadius: 16 },
+    manualBtn: { position: 'absolute', left: 0, right: 0, top: 0, bottom: 0, alignItems: 'center', justifyContent: 'center', zIndex: 10, backgroundColor: C.bg + 'cc' },
+    manualBtnInner: { paddingHorizontal: 40, paddingVertical: 16, borderRadius: 16, backgroundColor: C.green },
   });
 }
 
 export default function MissionRouletteScreen({ onStart, onSkip, autoSpin = true }) {
-  const C = useColors();
+  const C = W;
   const styles = useMemo(() => makeStyles(C), [C]);
   const [result,          setResult]          = useState(null);
   const [showBtn,         setShowBtn]         = useState(false);
@@ -164,7 +161,7 @@ export default function MissionRouletteScreen({ onStart, onSkip, autoSpin = true
     Animated.timing(btnOpacity, { toValue: 1, duration: 500, delay: 200, useNativeDriver: true }).start();
   };
 
-  const catColor = result ? getCategoryColor(result.category, C) : C.green;
+  const catW = catColorsW(result?.category);
 
   return (
     <View style={styles.screen}>
@@ -172,18 +169,15 @@ export default function MissionRouletteScreen({ onStart, onSkip, autoSpin = true
         opacity: titleAnim,
         transform: [{ translateY: titleAnim.interpolate({ inputRange: [0,1], outputRange: [-20, 0] }) }],
       }]}>
-        <T v="sub" style={{ letterSpacing: 1, marginBottom: 6 }}>매일 하나의 미션</T>
-        <T v="heading" size={28} style={{ letterSpacing: 0.5 }}>
-          {autoSpin ? '오늘의 미션 도착!' : '미션을 뽑을 시간!'}
-        </T>
+        <WarmText v="sub" color={C.green} style={{ letterSpacing: 1, marginBottom: 6 }}>매일 하나의 미션</WarmText>
+        <WarmText v="heading" size={28} style={{ letterSpacing: 0.5 }}>랜덤 미션 뽑기</WarmText>
       </Animated.View>
 
       {result && (
-        <View style={[styles.resultCard, { borderColor: catColor + '60', backgroundColor: catColor + '10' }]}>
-          <Text style={styles.resultIcon}>{result.icon}</Text>
+        <View style={[styles.resultCard, { borderColor: catW.main, backgroundColor: catW.border }]}>
+          <WarmText style={styles.resultIcon}>{result.icon}</WarmText>
           <View style={styles.resultInfo}>
-            <T v="label" color={catColor} style={{ marginBottom: 4, letterSpacing: 0.5 }}>{result.category} +1</T>
-            <T v="body" size={16} style={{ lineHeight: 22 }}>{result.text}</T>
+            <WarmText v="body" size={16} style={{ lineHeight: 22 }}>{result.text}</WarmText>
           </View>
         </View>
       )}
@@ -202,29 +196,34 @@ export default function MissionRouletteScreen({ onStart, onSkip, autoSpin = true
         {showBtn && (
           <>
             <TouchableOpacity onPress={() => onStart && onStart(result)} activeOpacity={0.85}>
-              <LinearGradient colors={['#26d67a', '#1ab065']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }} style={styles.startBtn}>
-                <T v="btn" size={17}>이 미션 시작하기 →</T>
-              </LinearGradient>
+              <View style={styles.startBtn}>
+                <WarmText v="btn" size={17}>이 미션으로 정하기</WarmText>
+              </View>
             </TouchableOpacity>
             {!hasRetried && (
               <TouchableOpacity
                 style={styles.skipBtn}
+                hitSlop={10}
                 onPress={() => {
                   setResult(null); setShowBtn(false); btnOpacity.setValue(0);
                   setRouletteKey(k => k + 1); setHasRetried(true);
                 }}
                 activeOpacity={0.7}
               >
-                <T v="sub" style={{ opacity: 0.6 }}>다시 돌리기</T>
+                <WarmText v="section" size={13} style={{ opacity: 0.6 }}>다시 돌리기</WarmText>
               </TouchableOpacity>
             )}
           </>
         )}
-        {!showBtn && <T v="body" style={{ opacity: 0.5 }}>{autoSpin ? '미션을 뽑는 중...' : '버튼을 눌러 미션을 뽑아보세요'}</T>}
+        {!showBtn && (
+          <WarmText v="body" style={{ opacity: 0.5 }}>
+            {autoSpin ? '미션을 뽑는 중...' : '버튼을 눌러 미션을 뽑아보세요'}
+          </WarmText>
+        )}
       </Animated.View>
 
       <TouchableOpacity style={styles.closeBtn} onPress={onSkip} activeOpacity={0.7}>
-        <T v="body" color={C.textSub}>✕</T>
+        <WarmText size={20} color={C.text}>✕</WarmText>
       </TouchableOpacity>
     </View>
   );
@@ -234,18 +233,17 @@ function makeStyles(C) {
   return StyleSheet.create({
     screen:         { flex: 1, backgroundColor: C.bg, paddingHorizontal: 24, justifyContent: 'center' },
     header:         { alignItems: 'center', marginBottom: 28 },
-    resultCard:     { flexDirection: 'row', alignItems: 'center', gap: 14, borderWidth: 1, borderRadius: 16, paddingHorizontal: 18, paddingVertical: 14, marginBottom: 16 },
+    resultCard:     { flexDirection: 'row', alignItems: 'center', gap: 14, borderWidth: 1, borderRadius: 16, paddingHorizontal: 18, paddingVertical: 14, marginBottom: 60 },
     resultIcon:     { fontSize: 32 },
     resultInfo:     { flex: 1 },
-    slotWrap:       { marginBottom: 28 },
-    slotLoading:    { height: SLOT_H, borderRadius: 16, borderWidth: 1, borderColor: C.border, backgroundColor: C.surface, alignItems: 'center', justifyContent: 'center' },
-    btns:           { alignItems: 'center', gap: 12 },
-    startBtn:       { width: width - 48, borderRadius: 16, paddingVertical: 17, alignItems: 'center' },
-    skipBtn:        { paddingVertical: 10 },
+    slotWrap:       { marginBottom: 50 },
+    slotLoading:    { height: SLOT_H, borderRadius: 16, borderWidth: 1, borderColor: C.green, backgroundColor: C.bg, alignItems: 'center', justifyContent: 'center' },
+    btns:           { alignItems: 'center', gap: 30 },
+    startBtn:       { width: width - 48, borderRadius: 16, paddingVertical: 17, alignItems: 'center', backgroundColor: C.green + 'cc' },
+    skipBtn:        { paddingVertical: 0 },
     closeBtn: {
       position: 'absolute', top: 16, right: 24,
       width: 36, height: 36, borderRadius: 18,
-      backgroundColor: C.surface, borderWidth: 1, borderColor: C.border,
       alignItems: 'center', justifyContent: 'center',
     },
   });

--- a/screens/OnboardingScreen.jsx
+++ b/screens/OnboardingScreen.jsx
@@ -86,7 +86,9 @@ export default function OnboardingScreen({ onDone }) {
           const Hero = slide.hero;
           return (
             <View key={slide.key} style={[s.slide, { width }]}>
-              <Hero C={C} />
+              <View style={s.heroBox}>
+                <Hero C={C} />
+              </View>
               <WarmText v="heading" size={26} style={s.title}>{slide.title}</WarmText>
               <WarmText v="section" size={15} color={C.brown} style={s.subtitle}>{slide.subtitle}</WarmText>
             </View>
@@ -114,7 +116,7 @@ function DirectBadge({ C }) {
   return (
     <View style={{
       flexDirection: 'row', alignItems: 'center', gap: 3,
-      backgroundColor: C.greenFaint, borderWidth: 1, borderColor: C.greenBorder,
+      backgroundColor: C.greenFaint, borderWidth: 1, borderColor: C.green,
       borderRadius: 7, paddingHorizontal: 6, paddingVertical: 2,
     }}>
       <WarmText size={9}>✏️</WarmText>
@@ -153,7 +155,7 @@ function HeroRoomCard({ C }) {
         <WarmText v="body" size={12} style={{ flex: 1 }} numberOfLines={1}>동네 한 바퀴 산책하기</WarmText>
       </View>
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-        <View style={[heroStyles.track, { backgroundColor: C.greenFaint }]}>
+        <View style={[heroStyles.track, { backgroundColor: C.greenSoft }]}>
           <View style={{ height: '100%', width: '50%', borderRadius: 3, backgroundColor: C.green }} />
         </View>
         <WarmText v="caption" size={10} color={C.brown}>2/4 인증</WarmText>
@@ -220,7 +222,7 @@ function HeroProofCard({ C }) {
               <WarmText size={10} color={C.text}>{r.count}</WarmText>
             </View>
           ))}
-          <View style={[heroStyles.addReact, { borderColor: C.brown }]}>
+          <View style={[heroStyles.addReact, { backgroundColor: C.borderStrong, borderColor: C.brown }]}>
             <WarmText size={10} color={C.text}>+</WarmText>
           </View>
         </View>
@@ -249,7 +251,7 @@ const heroStyles = StyleSheet.create({
 
   proofCard: { width: 300, borderWidth: 1, borderRadius: 15, overflow: 'hidden',
     shadowColor: '#2b211a', shadowOffset: { width: 0, height: 10 }, shadowOpacity: 0.12, shadowRadius: 28, elevation: 4 },
-  photo: { height: 150, width: '100%' },
+  photo: { height: 182, width: '100%' },
   userRow: {
     position: 'absolute', top: 10, left: 10, right: 10,
     flexDirection: 'row', alignItems: 'center', gap: 8,
@@ -267,10 +269,12 @@ function makeStyles(C) {
     screen: { flex: 1, backgroundColor: C.bg },
     topBar: { flexDirection: 'row', justifyContent: 'flex-end', paddingHorizontal: 24, paddingTop: 20, minHeight: 32 },
     slide: { paddingHorizontal: 24, paddingTop: 44, alignItems: 'center' },
-    title: { marginTop: 40, textAlign: 'center' },
+    // 3장 모두 타이틀이 같은 y(피그마 388)에 오도록 히어로를 고정 높이로 감싼다
+    heroBox: { height: 260, alignSelf: 'stretch', alignItems: 'center', justifyContent: 'center' },
+    title: { marginTop: 32, textAlign: 'center' },
     subtitle: { marginTop: 14, textAlign: 'center', lineHeight: 23 },
     bottom: { paddingHorizontal: 24, paddingBottom: 32 },
-    dots: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, marginBottom: 20 },
+    dots: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, marginBottom: 44 },
     dot: { height: 8, borderRadius: 4 },
     dotActive: { width: 20, backgroundColor: C.green },
     dotIdle: { width: 8, backgroundColor: C.border },

--- a/screens/ProfileScreen.jsx
+++ b/screens/ProfileScreen.jsx
@@ -13,6 +13,7 @@ import { getAvatarSource, getAvatarDefaultSource } from '../utils/avatars';
 import * as H from '../utils/haptics';
 import CharacterDecor from '../components/CharacterDecor';
 import { PARTS, isPartUnlocked, getCharacterSource } from '../constants/parts';
+import { usePagerBottomBarHeight } from '../components/PageIndicator';
 
 /**
  * GET /api/v1/parts/me 응답을 정적 카탈로그(PARTS)와 key로 병합.
@@ -186,6 +187,7 @@ function ProfileEditModal({ visible, profile, onSave, onClose }) {
 }
 
 export default function ProfileScreen({ profile, onSaveProfile, currentMission }) {
+  const pagerBottom = usePagerBottomBarHeight(); // 플로팅 인디케이터+인셋 높이
   const [userProfile, setUserProfile] = useState(null);
   const [userStats, setUserStats] = useState(null);
   const [weekItems, setWeekItems] = useState([]);
@@ -261,7 +263,7 @@ export default function ProfileScreen({ profile, onSaveProfile, currentMission }
     <View style={s.screen}>
       <ScrollView
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingBottom: 48 }}
+        contentContainerStyle={{ paddingBottom: 48 + pagerBottom }}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={W.green} colors={[W.green]} />}
       >
         {/* 헤더 */}
@@ -340,7 +342,7 @@ const s = StyleSheet.create({
   },
   nameBlock: { gap: 5 },
   editBadge: {
-    backgroundColor: W.neutral, borderWidth: 1, borderColor: W.borderStrong,
+    backgroundColor: W.neutralStrong, borderWidth: 1, borderColor: W.borderStrong,
     borderRadius: 15, paddingHorizontal: 8, paddingVertical: 3,
     height: 30, minWidth: 50, alignItems: 'center', justifyContent: 'center',
   },
@@ -355,12 +357,13 @@ const s = StyleSheet.create({
   /* 이번 주 활동 */
   weekWrap: { paddingHorizontal: 16, paddingBottom: 24 },
   weekCard: {
-    backgroundColor: W.neutralFaint, borderWidth: 1, borderColor: W.borderStrong,
+    backgroundColor: W.neutralSoft, borderWidth: 1, borderColor: W.borderStrong,
     borderRadius: 16, padding: 16, gap: 14,
   },
   weekHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   streakBadge: {
-    backgroundColor: W.coralFaint, borderWidth: 1, borderColor: W.coralBorder,
+    // Figma 정확값 — 코랄 15%/30% 틴트 (토큰 없음, 하드코딩 허용)
+    backgroundColor: 'rgba(232,81,58,0.15)', borderWidth: 1, borderColor: 'rgba(232,81,58,0.3)',
     borderRadius: 8, paddingHorizontal: 8, paddingVertical: 3,
   },
   weekRow: { flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between' },

--- a/screens/ProofDetailScreen.jsx
+++ b/screens/ProofDetailScreen.jsx
@@ -96,6 +96,7 @@ export default function ProofDetailScreen({ roomId, proofId, missionTitle, isGro
       <RoomTopBar
         title="인증 상세"
         subtitle={missionTitle}
+        subtitleColor={W.textSub}
         onBack={onBack}
         rightIcon={proof && !proof.mine ? 'ellipsis-horizontal' : undefined}
         onRight={() => { H.tap(); setReportOpen(true); }}
@@ -110,42 +111,45 @@ export default function ProofDetailScreen({ roomId, proofId, missionTitle, isGro
       ) : (
         <ScrollView contentContainerStyle={s.content} showsVerticalScrollIndicator={false}>
           <View style={s.card}>
-            <View style={s.cardTop}>
-              <MemberAvatar avatarId={proof.authorAvatarId} size={32} />
-              <View style={{ flex: 1 }}>
-                <WarmText v="section" size={14}>{proof.authorNickname}</WarmText>
-                <WarmText v="caption" size={11}>{timeLabel(proof.createdAt)} 미션 완료</WarmText>
+            <View style={s.photoWrap}>
+              {photo ? (
+                <Image source={{ uri: photo }} style={s.photo} resizeMode="cover" />
+              ) : (
+                <View style={[s.photo, s.photoEmpty]}><WarmText size={52}>📷</WarmText></View>
+              )}
+              <View style={s.statusBadge}><ProofStatusBadge status={proof.status} /></View>
+              <View style={s.authorOverlay}>
+                <MemberAvatar avatarId={proof.authorAvatarId} size={32} />
+                <WarmText v="section" size={14} color="#fff" style={{ flex: 1 }} numberOfLines={1}>
+                  {proof.authorNickname}
+                </WarmText>
+                <WarmText v="sub" size={13} color="rgba(255,255,255,0.6)">{timeLabel(proof.createdAt)}</WarmText>
               </View>
-              <ProofStatusBadge status={proof.status} />
             </View>
 
-            {photo ? (
-              <Image source={{ uri: photo }} style={s.photo} resizeMode="cover" />
-            ) : (
-              <View style={[s.photo, s.photoEmpty]}><WarmText size={52}>📷</WarmText></View>
-            )}
+            <View style={s.cardBody}>
+              {proof.caption ? <WarmText v="body" size={14} style={{ lineHeight: 21 }}>{proof.caption}</WarmText> : null}
 
-            {proof.caption ? <WarmText v="body" size={15} style={{ marginTop: 12 }}>{proof.caption}</WarmText> : null}
-
-            <View style={{ marginTop: 14 }}>
-              <ReactionBar reactions={proof.reactions} onToggle={handleReact} />
-            </View>
-
-            {isGroup ? (
-              <View style={s.confirmRow}>
-                <WarmText v="caption" size={12}>{proof.confirmCount ?? 0}/{proof.requiredConfirm ?? 0}명 인증</WarmText>
-                <TouchableOpacity
-                  activeOpacity={0.8}
-                  disabled={proof.myConfirmed}
-                  onPress={handleConfirm}
-                  style={[s.confirmBtn, proof.myConfirmed && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
-                >
-                  <WarmText v="section" size={14} color={proof.myConfirmed ? C.green : C.text}>
-                    {proof.myConfirmed ? '✓ 인증함' : '인증해주기'}
-                  </WarmText>
-                </TouchableOpacity>
+              <View style={proof.caption ? { marginTop: 14 } : null}>
+                <ReactionBar reactions={proof.reactions} onToggle={handleReact} />
               </View>
-            ) : null}
+
+              {isGroup ? (
+                <View style={s.confirmRow}>
+                  <WarmText v="caption" size={12} color={C.text}>{proof.confirmCount ?? 0}/{proof.requiredConfirm ?? 0}명 인증</WarmText>
+                  <TouchableOpacity
+                    activeOpacity={0.8}
+                    disabled={proof.myConfirmed}
+                    onPress={handleConfirm}
+                    style={[s.confirmBtn, proof.myConfirmed && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
+                  >
+                    <WarmText v="caption" size={12} color={proof.myConfirmed ? C.green : C.text}>
+                      {proof.myConfirmed ? '✓ 인증함' : '인증해주기'}
+                    </WarmText>
+                  </TouchableOpacity>
+                </View>
+              ) : null}
+            </View>
           </View>
         </ScrollView>
       )}
@@ -166,11 +170,18 @@ function makeStyles(C) {
     screen:  { flex: 1, backgroundColor: C.bg },
     center:  { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
     content: { padding: 20 },
-    card:    { backgroundColor: C.surface, borderRadius: 20, borderWidth: 1, borderColor: C.border, padding: 14 },
-    cardTop: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 },
-    photo:   { width: '100%', height: 300, borderRadius: 14, backgroundColor: C.surface2 },
+    card:    { backgroundColor: C.surface, borderRadius: 18, borderWidth: 1, borderColor: C.borderStrong, overflow: 'hidden' },
+    photoWrap: { position: 'relative' },
+    photo:   { width: '100%', height: 300, backgroundColor: C.surface2 },
     photoEmpty: { alignItems: 'center', justifyContent: 'center' },
-    confirmRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 16, paddingTop: 14, borderTopWidth: 1, borderTopColor: C.border },
-    confirmBtn: { borderWidth: 1, borderColor: C.border, borderRadius: 20, paddingHorizontal: 18, paddingVertical: 9, backgroundColor: C.bg },
+    statusBadge: { position: 'absolute', top: 12, right: 12 },
+    authorOverlay: {
+      position: 'absolute', left: 0, right: 0, bottom: 0,
+      flexDirection: 'row', alignItems: 'center', gap: 8,
+      backgroundColor: 'rgba(0,0,0,0.3)', paddingHorizontal: 12, paddingVertical: 8,
+    },
+    cardBody: { padding: 14 },
+    confirmRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 16, paddingTop: 14, borderTopWidth: 1, borderTopColor: 'rgba(122,92,79,0.25)' },
+    confirmBtn: { borderWidth: 1, borderColor: C.brown, borderRadius: 20, paddingHorizontal: 14, paddingVertical: 6, backgroundColor: C.neutralStrong },
   });
 }

--- a/screens/RoomCompleteScreen.jsx
+++ b/screens/RoomCompleteScreen.jsx
@@ -1,44 +1,10 @@
-import React, { useMemo, useRef, useEffect } from 'react';
-import { View, StyleSheet, Animated } from 'react-native';
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import LottieView from 'lottie-react-native';
 import { W } from '../constants/warm';
 import WarmText from '../components/WarmText';
 import { MemberAvatar, GreenButton } from '../components/RoomBits';
-
-// 웜 팔레트 3색 컨페티 (그린 · 코랄 · 브라운)
-const CONFETTI = [
-  { left: '12%', color: W.green, delay: 0 },
-  { left: '24%', color: W.coral, delay: 120 },
-  { left: '38%', color: W.brown, delay: 60 },
-  { left: '52%', color: W.green, delay: 200 },
-  { left: '66%', color: W.coral, delay: 90 },
-  { left: '78%', color: W.brown, delay: 160 },
-  { left: '88%', color: W.green, delay: 40 },
-  { left: '18%', color: W.coral, delay: 240 },
-  { left: '60%', color: W.brown, delay: 300 },
-  { left: '44%', color: W.green, delay: 180 },
-];
-
-function ConfettiDot({ left, color, delay }) {
-  const fall = useRef(new Animated.Value(0)).current;
-  useEffect(() => {
-    Animated.loop(
-      Animated.sequence([
-        Animated.delay(delay),
-        Animated.timing(fall, { toValue: 1, duration: 2600, useNativeDriver: true }),
-      ]),
-    ).start();
-  }, [fall, delay]);
-  const translateY = fall.interpolate({ inputRange: [0, 1], outputRange: [-20, 380] });
-  const opacity = fall.interpolate({ inputRange: [0, 0.1, 0.85, 1], outputRange: [0, 1, 1, 0] });
-  return (
-    <Animated.View style={[confettiBase.dot, { left, backgroundColor: color, transform: [{ translateY }], opacity }]} />
-  );
-}
-
-const confettiBase = StyleSheet.create({
-  dot: { position: 'absolute', top: 40, width: 8, height: 14, borderRadius: 2 },
-});
 
 export default function RoomCompleteScreen({ summary, onBack }) {
   const C = W;
@@ -48,22 +14,18 @@ export default function RoomCompleteScreen({ summary, onBack }) {
 
   return (
     <View style={s.screen}>
-      <View style={StyleSheet.absoluteFill} pointerEvents="none">
-        {CONFETTI.map((c, i) => <ConfettiDot key={i} {...c} />)}
-      </View>
-
       <View style={s.body}>
-        <View style={s.iconCircle}><WarmText size={48}>🎉</WarmText></View>
-        <WarmText v="heading" size={26} style={{ marginTop: 20, textAlign: 'center' }}>오늘 미션 완료!</WarmText>
-        <WarmText v="sub" style={{ marginTop: 10, textAlign: 'center', lineHeight: 20 }}>
+        <View style={s.iconCircle}><WarmText size={60}>🎉</WarmText></View>
+        <WarmText v="heading" size={24} style={{ marginTop: 20, textAlign: 'center' }}>오늘 미션 완료!</WarmText>
+        <WarmText v="body" size={14} style={{ marginTop: 10, textAlign: 'center', lineHeight: 21 }}>
           {summary?.name ? `${summary.name} 멤버 모두가\n오늘의 미션을 인증했어요` : '멤버 모두가 오늘의 미션을 인증했어요'}
         </WarmText>
 
         <View style={s.avatarRow}>
           {members.slice(0, 5).map((m, i) => (
-            <View key={m.memberId ?? i} style={s.avatarWrap}>
-              <MemberAvatar avatarId={m.avatarId} size={48} />
-              <View style={s.check}><Ionicons name="checkmark" size={11} color="#fff" /></View>
+            <View key={m.memberId ?? i} style={[s.avatarWrap, i > 0 && { marginLeft: -8 }]}>
+              <MemberAvatar avatarId={m.avatarId} size={44} borderColor="#ffffff" />
+              <View style={s.check}><Ionicons name="checkmark" size={9} color="#fff" /></View>
             </View>
           ))}
         </View>
@@ -76,7 +38,17 @@ export default function RoomCompleteScreen({ summary, onBack }) {
       </View>
 
       <View style={s.bottom}>
-        <GreenButton label="방으로 돌아가기" onPress={onBack} />
+        <GreenButton label="방으로 돌아가기" onPress={onBack} radius={14} />
+      </View>
+
+      <View style={s.confettiOverlay} pointerEvents="none">
+        <LottieView
+          source={require('../assets/Confetti.json')}
+          autoPlay
+          loop={false}
+          style={s.confetti}
+          resizeMode="cover"
+        />
       </View>
     </View>
   );
@@ -86,11 +58,13 @@ function makeStyles(C) {
   return StyleSheet.create({
     screen: { flex: 1, backgroundColor: C.bg },
     body:   { flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32 },
-    iconCircle: { width: 96, height: 96, borderRadius: 48, backgroundColor: C.surface2, alignItems: 'center', justifyContent: 'center' },
-    avatarRow: { flexDirection: 'row', gap: 10, marginTop: 24 },
+    iconCircle: { width: 120, height: 120, borderRadius: 60, backgroundColor: C.greenFaint, alignItems: 'center', justifyContent: 'center' },
+    avatarRow: { flexDirection: 'row', alignItems: 'center', marginTop: 24 },
     avatarWrap: { position: 'relative' },
-    check: { position: 'absolute', bottom: -2, right: -2, width: 18, height: 18, borderRadius: 9, backgroundColor: C.green, borderWidth: 2, borderColor: C.bg, alignItems: 'center', justifyContent: 'center' },
-    streakBadge: { marginTop: 22, backgroundColor: C.coralFaint, borderWidth: 1, borderColor: C.coralBorder, borderRadius: 14, paddingHorizontal: 14, paddingVertical: 8 },
+    check: { position: 'absolute', bottom: -3, alignSelf: 'center', width: 15, height: 15, borderRadius: 7.5, backgroundColor: C.green, borderWidth: 2, borderColor: '#ffffff', alignItems: 'center', justifyContent: 'center' },
+    streakBadge: { marginTop: 22, backgroundColor: C.coralFaint, borderRadius: 999, paddingHorizontal: 14, paddingVertical: 8 },
     bottom: { paddingHorizontal: 20, paddingBottom: 32 },
+    confettiOverlay: { ...StyleSheet.absoluteFillObject, zIndex: 10, alignItems: 'center' },
+    confetti: { width: '100%', aspectRatio: 940 / 752, marginTop: -40 },
   });
 }

--- a/screens/RoomDetailScreen.jsx
+++ b/screens/RoomDetailScreen.jsx
@@ -8,8 +8,8 @@ import { api, BASE_URL } from '../utils/api';
 import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
 import {
-  RoomTopBar, MemberAvatar, SourceBadge, ProgressBar, GreenButton, OutlineButton,
-  ReactionBar, ProofStatusBadge, NudgeChip,
+  RoomTopBar, MemberAvatar, SourceBadge, GreenButton, OutlineButton,
+  ReactionBar, NudgeChip,
 } from '../components/RoomBits';
 import { roomIconEmoji } from '../constants/rooms';
 
@@ -28,50 +28,136 @@ function timeLabel(createdAt) {
   return `${p(d.getHours())}:${p(d.getMinutes())}`;
 }
 
-/* ── 인증 카드 ─────────────────────────────────────────── */
-function ProofCard({ proof, isGroup, onReact, onPeerVerify, onOpen }) {
+function reactionTotal(proof) {
+  return (proof.reactions ?? []).reduce((sum, r) => sum + (r.count ?? 0), 0);
+}
+
+/* ── 사진 위 상태 배지 (피그마 오버레이 스타일) ─────────── */
+function OverlayStatusBadge({ status }) {
+  const C = W;
+  const verified = status === 'VERIFIED';
+  return (
+    <View style={{
+      backgroundColor: C.borderStrong, borderWidth: 1, borderColor: C.brown,
+      borderRadius: 5, paddingHorizontal: 6, paddingVertical: 4,
+    }}>
+      <WarmText v="caption" size={11} color={C.text}>{verified ? 'V 인증완료' : '대기 중'}</WarmText>
+    </View>
+  );
+}
+
+/* ── 인증해주기 칩 (Featured 카드 푸터) ─────────────────── */
+function VerifyChip({ proof, onPress }) {
+  const C = W;
+  const confirmed = proof.myConfirmed;
+  return (
+    <TouchableOpacity
+      activeOpacity={0.8}
+      disabled={confirmed}
+      onPress={() => { H.success(); onPress?.(); }}
+      style={[{
+        backgroundColor: C.borderStrong, borderWidth: 1, borderColor: C.brown,
+        borderRadius: 20, paddingHorizontal: 12, paddingVertical: 5,
+      }, confirmed && { backgroundColor: C.greenFaint, borderColor: C.greenBorder }]}
+    >
+      <WarmText v="caption" size={11} color={confirmed ? C.green : C.text}>
+        {confirmed ? '✓ 인증함' : `인증해주기 ${proof.confirmCount ?? 0}/${proof.requiredConfirm ?? 0}`}
+      </WarmText>
+    </TouchableOpacity>
+  );
+}
+
+/* ── Featured 카드 (가장 많은 리액션 / 솔로 인증) ───────── */
+function FeaturedCard({ proof, solo, onReact, onPeerVerify, onOpen }) {
   const C = W;
   const s = useMemo(() => makeStyles(C), [C]);
   const photo = resolvePhoto(proof.photoUrl);
 
   return (
-    <TouchableOpacity activeOpacity={0.9} onPress={onOpen} style={s.proofCard}>
-      <View style={s.proofTop}>
-        <MemberAvatar avatarId={proof.authorAvatarId} size={30} />
-        <View style={{ flex: 1 }}>
-          <WarmText v="section" size={14}>{proof.authorNickname}</WarmText>
-          <WarmText v="caption" size={11}>{timeLabel(proof.createdAt)} 미션 완료</WarmText>
+    <TouchableOpacity activeOpacity={0.9} onPress={onOpen} style={s.featuredCard}>
+      <View>
+        {photo ? (
+          <Image source={{ uri: photo }} style={s.featuredPhoto} resizeMode="cover" />
+        ) : (
+          <View style={[s.featuredPhoto, s.photoEmpty]}><WarmText size={44}>📷</WarmText></View>
+        )}
+        <View style={s.featuredOverlay}>
+          <MemberAvatar avatarId={proof.authorAvatarId} size={32} />
+          <View style={{ flex: 1, gap: 3 }}>
+            <WarmText v="body" size={14} color={C.white} numberOfLines={1}>{proof.authorNickname}</WarmText>
+            <WarmText v="caption" size={13} color="rgba(255,255,255,0.6)" numberOfLines={1}>
+              🕐 {timeLabel(proof.createdAt)} 미션 완료
+            </WarmText>
+          </View>
+          <OverlayStatusBadge status={proof.status} />
         </View>
-        <ProofStatusBadge status={proof.status} />
       </View>
 
-      {photo ? (
-        <Image source={{ uri: photo }} style={s.proofPhoto} resizeMode="cover" />
+      {proof.caption ? (
+        <WarmText v="body" size={14} style={{ paddingHorizontal: 14, paddingTop: 10 }}>{proof.caption}</WarmText>
+      ) : null}
+
+      {solo ? (
+        <View style={s.soloFooter}>
+          <ReactionBar reactions={proof.reactions} onToggle={(emoji) => onReact?.(proof.id, emoji)} />
+          <WarmText v="caption" size={13} color={C.brown}>오늘도 미션 완료 🎉</WarmText>
+        </View>
       ) : (
-        <View style={[s.proofPhoto, s.proofPhotoEmpty]}><WarmText size={44}>📷</WarmText></View>
+        <View style={s.featuredFooter}>
+          <View style={{ flex: 1 }}>
+            <ReactionBar reactions={proof.reactions} onToggle={(emoji) => onReact?.(proof.id, emoji)} />
+          </View>
+          <VerifyChip proof={proof} onPress={() => onPeerVerify?.(proof.id)} />
+        </View>
       )}
+    </TouchableOpacity>
+  );
+}
 
-      {proof.caption ? <WarmText v="body" size={14} style={{ marginTop: 10 }}>{proof.caption}</WarmText> : null}
+/* ── 그리드 인증 카드 (모든 인증 2열) ───────────────────── */
+function GridProofCard({ proof, onReact, onPeerVerify, onOpen }) {
+  const C = W;
+  const s = useMemo(() => makeStyles(C), [C]);
+  const photo = resolvePhoto(proof.photoUrl);
+  const confirmed = proof.myConfirmed;
 
-      <View style={s.proofFooter}>
+  return (
+    <TouchableOpacity activeOpacity={0.9} onPress={onOpen} style={s.gridCard}>
+      <View>
+        {photo ? (
+          <Image source={{ uri: photo }} style={s.gridPhoto} resizeMode="cover" />
+        ) : (
+          <View style={[s.gridPhoto, s.photoEmpty]}><WarmText size={32}>📷</WarmText></View>
+        )}
+        <View style={s.gridTopOverlay}>
+          <MemberAvatar avatarId={proof.authorAvatarId} size={16} />
+          <WarmText v="caption" size={11} color={C.white} numberOfLines={1} style={{ flex: 1 }}>
+            {proof.authorNickname}
+          </WarmText>
+        </View>
+        <View style={s.gridBottomOverlay}>
+          <WarmText v="caption" size={11} color={C.bg}>{timeLabel(proof.createdAt)}</WarmText>
+          <WarmText v="caption" size={11} color={C.bg} numberOfLines={1} style={{ flex: 1 }}>미션 완료</WarmText>
+          <WarmText v="caption" size={11} color={C.bg}>{proof.status === 'VERIFIED' ? 'V' : '대기'}</WarmText>
+        </View>
+      </View>
+
+      <View style={s.gridReactions}>
         <ReactionBar reactions={proof.reactions} onToggle={(emoji) => onReact?.(proof.id, emoji)} />
       </View>
 
-      {isGroup ? (
-        <View style={s.confirmRow}>
-          <WarmText v="caption" size={11}>{proof.confirmCount ?? 0}/{proof.requiredConfirm ?? 0}명 인증</WarmText>
-          <TouchableOpacity
-            activeOpacity={0.8}
-            disabled={proof.myConfirmed}
-            onPress={() => { H.success(); onPeerVerify?.(proof.id); }}
-            style={[s.confirmBtn, proof.myConfirmed && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
-          >
-            <WarmText v="caption" size={12} color={proof.myConfirmed ? C.green : C.text}>
-              {proof.myConfirmed ? '✓ 인증함' : '인증해주기'}
-            </WarmText>
-          </TouchableOpacity>
-        </View>
-      ) : null}
+      <View style={s.gridVerifyWrap}>
+        <TouchableOpacity
+          activeOpacity={0.8}
+          disabled={confirmed}
+          onPress={() => { H.success(); onPeerVerify?.(proof.id); }}
+          style={[s.gridVerifyBtn, confirmed && { backgroundColor: C.greenFaint, borderColor: C.greenBorder }]}
+        >
+          <WarmText v="caption" size={12} color={confirmed ? C.green : C.text}>
+            {confirmed ? '✓ 인증함' : '인증해주기'}
+          </WarmText>
+        </TouchableOpacity>
+      </View>
     </TouchableOpacity>
   );
 }
@@ -187,10 +273,23 @@ export default function RoomDetailScreen({
   const mission = room.todayMission;
   const status = room.myTodayStatus; // NONE / PENDING / DONE
   const prog = room.progress ?? { verifiedCount: 0, requiredCount: room.memberCount ?? 0 };
+  const progressPct = solo
+    ? (status === 'DONE' ? 100 : 0)
+    : (prog.requiredCount > 0 ? Math.min(100, (prog.verifiedCount / prog.requiredCount) * 100) : 0);
 
   const pendingMembers = (room.members ?? []).filter(m => m.todayStatus !== 'DONE');
   const proofs = room.proofs ?? [];
   const filtered = filter === 'all' ? proofs : proofs.filter(p => p.status === filter);
+
+  // Featured — 리액션 합이 가장 큰 인증 (그룹, 리액션 1개 이상일 때만)
+  let featured = null;
+  if (!solo && filtered.length > 0) {
+    const top = filtered.reduce((a, b) => (reactionTotal(b) > reactionTotal(a) ? b : a), filtered[0]);
+    if (reactionTotal(top) > 0) featured = top;
+  }
+  const gridProofs = featured ? filtered.filter(p => p.id !== featured.id) : filtered;
+
+  const openProof = (p) => { H.tap(); onOpenProof?.({ proofId: p.id, missionTitle: mission?.title, isGroup: !solo }); };
 
   return (
     <View style={s.screen}>
@@ -202,151 +301,178 @@ export default function RoomDetailScreen({
         onRight={() => { H.tap(); onOpenSettings?.(); }}
       />
 
-      <ScrollView contentContainerStyle={s.content} showsVerticalScrollIndicator={false}>
-        {/* 상단 미션 요약 바 */}
+      <ScrollView contentContainerStyle={[s.content, !mission && s.contentCentered]} showsVerticalScrollIndicator={false}>
         {mission ? (
-          <View style={s.summaryBar}>
-            <View style={s.missionRow}>
-              <WarmText size={18}>{mission.icon}</WarmText>
-              <WarmText v="body" size={14} numberOfLines={1} style={{ flex: 1 }}>{mission.title}</WarmText>
-              {!solo ? (
-                <TouchableOpacity
-                  activeOpacity={0.7}
-                  hitSlop={8}
-                  onPress={() => { H.tap(); onOpenLeaderboard?.({ roomName: room.name, roomIcon: roomIconEmoji(room.iconKey) }); }}
-                >
-                  <Ionicons name="trophy-outline" size={18} color={C.textSub} />
-                </TouchableOpacity>
-              ) : null}
-            </View>
-            <View style={{ marginTop: 10 }}>
+          <>
+            {/* 미션 바 */}
+            <View style={s.missionBar}>
+              <View style={s.missionRow}>
+                <WarmText size={18}>{mission.icon}</WarmText>
+                <WarmText v="body" size={17} numberOfLines={1} style={{ flex: 1 }}>{mission.title}</WarmText>
+                <SourceBadge source={mission.source} />
+                {!solo ? (
+                  <TouchableOpacity
+                    activeOpacity={0.7}
+                    hitSlop={8}
+                    onPress={() => { H.tap(); onOpenLeaderboard?.({ roomName: room.name, roomIcon: roomIconEmoji(room.iconKey) }); }}
+                  >
+                    <Ionicons name="trophy-outline" size={18} color={C.textSub} />
+                  </TouchableOpacity>
+                ) : null}
+              </View>
+              <View style={s.progressTrack}>
+                <View style={[s.progressFill, { width: `${progressPct}%` }]} />
+              </View>
               {solo ? (
-                <ProgressBar value={status === 'DONE' ? 1 : 0} total={1} showLabel={false} />
+                <WarmText v="caption" size={13} color={C.green}>
+                  {status === 'DONE' ? '오늘 미션 인증 완료' : '아직 인증 전이에요'}
+                </WarmText>
               ) : (
-                <ProgressBar value={prog.verifiedCount} total={prog.requiredCount} showLabel={false} />
+                <View style={s.countRow}>
+                  <WarmText v="section" size={16} color={C.green}>{prog.verifiedCount}명</WarmText>
+                  <WarmText v="section" size={16} color={C.textSub}> / {prog.requiredCount}명 인증 완료</WarmText>
+                </View>
               )}
             </View>
-            <WarmText v="caption" size={11} color={C.green} style={{ marginTop: 8 }}>
-              {solo
-                ? (status === 'DONE' ? '오늘 미션 인증 완료' : '아직 인증 전이에요')
-                : `${prog.verifiedCount}명 / ${prog.requiredCount}명 인증 완료`}
-            </WarmText>
-          </View>
-        ) : null}
 
-        {/* 오늘의 미션 */}
-        {mission ? (
-          <View style={s.section}>
-            <View style={s.sectionHead}>
-              <WarmText v="section" size={15}>오늘의 미션</WarmText>
-              <SourceBadge source={mission.source} />
-            </View>
-            <View style={s.missionCard}>
-              <View style={s.missionIconBox}><WarmText size={34}>{mission.icon}</WarmText></View>
-              <WarmText v="mission" size={24} style={{ marginTop: 14, marginBottom: 16 }}>{mission.title}</WarmText>
-              {status === 'DONE' ? (
-                <View style={s.doneBanner}><WarmText v="section" size={15} color={C.green}>✓  인증 완료!</WarmText></View>
-              ) : status === 'PENDING' ? (
-                <View style={s.doneBanner}><WarmText v="section" size={15} color={C.green}>인증 대기 중…</WarmText></View>
-              ) : (
-                <GreenButton label="인증하기" ionicon="camera-outline" onPress={() => { H.tap(); onOpenVerify?.(room); }} style={{ width: '100%' }} />
-              )}
-            </View>
-          </View>
+            {/* 인증하기 버튼 / 상태 배너 */}
+            {status === 'DONE' || status === 'PENDING' ? (
+              <View style={s.doneBanner}>
+                <WarmText v="section" size={15} color={C.green}>
+                  {status === 'DONE' ? '✓  인증 완료!' : '인증 대기 중…'}
+                </WarmText>
+              </View>
+            ) : (
+              <TouchableOpacity activeOpacity={0.85} onPress={() => { H.tap(); onOpenVerify?.(room); }} style={s.verifyBtn}>
+                <Ionicons name="camera-outline" size={20} color="#fff9f3" />
+                <WarmText v="btn">인증하기</WarmText>
+              </TouchableOpacity>
+            )}
+
+            {/* 수행 중 멤버 (그룹) */}
+            {!solo && pendingMembers.length > 0 ? (
+              <View style={s.pendingStrip}>
+                <View style={s.sectionHead}>
+                  <WarmText v="section" size={15}>수행 중</WarmText>
+                  <WarmText v="caption" size={11} color={C.text}>{pendingMembers.length}명 미인증</WarmText>
+                </View>
+                <View style={{ gap: 12 }}>
+                  {pendingMembers.map(m => {
+                    // 아직 미션을 시작하지 않은(NONE) 다른 멤버만 콕 찌를 수 있다
+                    const canNudge = !m.isMe && m.todayStatus !== 'PENDING';
+                    const nudged = m.nudgedByMe || nudgedIds.has(m.memberId);
+                    return (
+                      <View key={m.memberId} style={s.pendingRow}>
+                        <MemberAvatar avatarId={m.avatarId} size={30} />
+                        <WarmText v="body" size={14} style={{ flex: 1 }}>{m.nickname}</WarmText>
+                        {canNudge ? (
+                          <NudgeChip nudged={nudged} onPress={() => handleNudge(m.memberId)} />
+                        ) : (
+                          <WarmText v="caption" size={11} color={m.todayStatus === 'PENDING' ? C.green : C.textSub}>
+                            {m.todayStatus === 'PENDING' ? '인증 대기' : '미인증'}
+                          </WarmText>
+                        )}
+                      </View>
+                    );
+                  })}
+                </View>
+              </View>
+            ) : null}
+
+            {/* 인증 피드 */}
+            {!solo ? (
+              <View style={s.feed}>
+                {/* 필터 칩 */}
+                <View style={s.filterRow}>
+                  {FILTERS.map(f => {
+                    const active = filter === f.key;
+                    return (
+                      <TouchableOpacity
+                        key={f.key}
+                        activeOpacity={0.8}
+                        onPress={() => { H.tap(); setFilter(f.key); }}
+                        style={[s.filterChip, active && { borderColor: C.brown, backgroundColor: C.borderStrong }]}
+                      >
+                        <WarmText v="body" size={14} color={active ? C.surface : C.text}>{f.label}</WarmText>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+
+                {/* 가장 많은 리액션 */}
+                {featured ? (
+                  <>
+                    <WarmText v="section" size={15}>✦  가장 많은 리액션</WarmText>
+                    <FeaturedCard
+                      proof={featured}
+                      onReact={handleReact}
+                      onPeerVerify={handlePeerVerify}
+                      onOpen={() => openProof(featured)}
+                    />
+                  </>
+                ) : null}
+
+                {/* 모든 인증 */}
+                <View style={s.sectionHead}>
+                  <WarmText v="section" size={15}>모든 인증</WarmText>
+                  <TouchableOpacity onPress={() => { H.tap(); onOpenHistory?.(); }} activeOpacity={0.7}>
+                    <WarmText v="caption" size={13} color={C.brown}>지난기록 보기</WarmText>
+                  </TouchableOpacity>
+                </View>
+
+                {filtered.length === 0 ? (
+                  <View style={s.feedEmpty}>
+                    <WarmText size={26} style={{ marginBottom: 6 }}>🫶</WarmText>
+                    <WarmText v="sub" style={{ textAlign: 'center' }}>아직 인증이 없어요{'\n'}첫 인증의 주인공이 되어보세요</WarmText>
+                  </View>
+                ) : gridProofs.length > 0 ? (
+                  <View style={s.grid}>
+                    {gridProofs.map(p => (
+                      <GridProofCard
+                        key={p.id}
+                        proof={p}
+                        onReact={handleReact}
+                        onPeerVerify={handlePeerVerify}
+                        onOpen={() => openProof(p)}
+                      />
+                    ))}
+                  </View>
+                ) : null}
+              </View>
+            ) : (
+              <View style={s.feed}>
+                <WarmText v="section" size={15}>오늘의 인증</WarmText>
+                {proofs.length === 0 ? (
+                  <View style={s.feedEmpty}>
+                    <WarmText size={26} style={{ marginBottom: 6 }}>🫶</WarmText>
+                    <WarmText v="sub" style={{ textAlign: 'center' }}>아직 인증이 없어요{'\n'}첫 인증의 주인공이 되어보세요</WarmText>
+                  </View>
+                ) : (
+                  proofs.map(p => (
+                    <FeaturedCard
+                      key={p.id}
+                      proof={p}
+                      solo
+                      onReact={handleReact}
+                      onOpen={() => openProof(p)}
+                    />
+                  ))
+                )}
+              </View>
+            )}
+          </>
         ) : (
-          /* 미션 미정 (Empty) */
+          /* 미션 미정 (Empty) — 화면 세로 중앙 */
           <View style={s.emptyMission}>
-            <View style={s.emptyIcon}><WarmText size={30}>🎲</WarmText></View>
-            <WarmText v="title" size={18} style={{ marginTop: 14 }}>오늘의 미션이 아직 없어요</WarmText>
-            <WarmText v="sub" style={{ textAlign: 'center', marginTop: 6, marginBottom: 20 }}>
+            <View style={s.emptyIcon}><WarmText size={38}>🎲</WarmText></View>
+            <WarmText v="title" size={17} style={{ marginTop: 14 }}>오늘의 미션이 아직 없어요</WarmText>
+            <WarmText v="sub" color={C.brown} style={{ textAlign: 'center', marginTop: 6, marginBottom: 20 }}>
               {solo ? '오늘의 미션을 정해보세요' : '미션을 정하면 멤버 모두에게 알림이 가요'}
             </WarmText>
             <GreenButton label="랜덤 미션 뽑기" ionicon="dice-outline" onPress={handleRandom} style={{ width: '100%', marginBottom: 10 }} />
             <OutlineButton label="직접 정하기" ionicon="create-outline" onPress={() => { H.tap(); onOpenMissionPicker?.(); }} style={{ width: '100%' }} />
           </View>
         )}
-
-        {/* 수행 중 멤버 (그룹) */}
-        {!solo && mission && pendingMembers.length > 0 ? (
-          <View style={s.section}>
-            <View style={s.sectionHead}>
-              <WarmText v="section" size={15}>수행 중</WarmText>
-              <WarmText v="caption">{pendingMembers.length}명 미인증</WarmText>
-            </View>
-            <View style={{ gap: 8 }}>
-              {pendingMembers.map(m => {
-                // 아직 미션을 시작하지 않은(NONE) 다른 멤버만 콕 찌를 수 있다
-                const canNudge = !m.isMe && m.todayStatus !== 'PENDING';
-                const nudged = m.nudgedByMe || nudgedIds.has(m.memberId);
-                return (
-                  <View key={m.memberId} style={s.pendingRow}>
-                    <MemberAvatar avatarId={m.avatarId} size={30} />
-                    <WarmText v="body" size={14} style={{ flex: 1 }}>{m.nickname}</WarmText>
-                    {canNudge ? (
-                      <NudgeChip nudged={nudged} onPress={() => handleNudge(m.memberId)} />
-                    ) : (
-                      <WarmText v="caption" size={11} color={m.todayStatus === 'PENDING' ? C.green : C.textSub}>
-                        {m.todayStatus === 'PENDING' ? '인증 대기' : '미인증'}
-                      </WarmText>
-                    )}
-                  </View>
-                );
-              })}
-            </View>
-          </View>
-        ) : null}
-
-        {/* 인증 피드 */}
-        {mission && (proofs.length > 0 || !solo) ? (
-          <View style={s.section}>
-            <View style={s.sectionHead}>
-              <WarmText v="section" size={15}>{solo ? '오늘의 인증' : '오늘의 인증'}</WarmText>
-              {!solo ? (
-                <TouchableOpacity onPress={() => { H.tap(); onOpenHistory?.(); }} activeOpacity={0.7}>
-                  <WarmText v="caption" color={C.green}>지난 기록 보기</WarmText>
-                </TouchableOpacity>
-              ) : null}
-            </View>
-
-            {!solo ? (
-              <View style={s.filterRow}>
-                {FILTERS.map(f => {
-                  const active = filter === f.key;
-                  return (
-                    <TouchableOpacity
-                      key={f.key}
-                      activeOpacity={0.8}
-                      onPress={() => { H.tap(); setFilter(f.key); }}
-                      style={[s.filterChip, active && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
-                    >
-                      <WarmText v="caption" size={12} color={active ? C.green : C.textSub}>{f.label}</WarmText>
-                    </TouchableOpacity>
-                  );
-                })}
-              </View>
-            ) : null}
-
-            {filtered.length === 0 ? (
-              <View style={s.feedEmpty}>
-                <WarmText size={26} style={{ marginBottom: 6 }}>🫶</WarmText>
-                <WarmText v="sub" style={{ textAlign: 'center' }}>아직 인증이 없어요{'\n'}첫 인증의 주인공이 되어보세요</WarmText>
-              </View>
-            ) : (
-              <View style={{ gap: 14 }}>
-                {filtered.map(p => (
-                  <ProofCard
-                    key={p.id}
-                    proof={p}
-                    isGroup={!solo}
-                    onReact={handleReact}
-                    onPeerVerify={handlePeerVerify}
-                    onOpen={() => { H.tap(); onOpenProof?.({ proofId: p.id, missionTitle: mission?.title, isGroup: !solo }); }}
-                  />
-                ))}
-              </View>
-            )}
-          </View>
-        ) : null}
       </ScrollView>
     </View>
   );
@@ -357,33 +483,50 @@ function makeStyles(C) {
     screen:  { flex: 1, backgroundColor: C.bg },
     center:  { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
     content: { paddingBottom: 40 },
+    contentCentered: { flexGrow: 1, justifyContent: 'center', paddingBottom: 80 },
 
-    summaryBar: { marginHorizontal: 20, marginTop: 4, backgroundColor: C.surface, borderRadius: 16, borderWidth: 1, borderColor: C.border, padding: 14 },
+    // 미션 바 (피그마 MissionBar: bg back / border #a8958a / r14 / px14 py20)
+    missionBar: { marginHorizontal: 20, marginTop: 4, backgroundColor: C.bg, borderRadius: 14, borderWidth: 1, borderColor: C.borderStrong, paddingHorizontal: 14, paddingVertical: 20, gap: 10 },
     missionRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+    // 미션바 진행률 — 피그마: 트랙 rgba(168,149,138,0.4) / 채움 브라운
+    progressTrack: { height: 7, borderRadius: 3.5, backgroundColor: C.neutralStrong, overflow: 'hidden' },
+    progressFill:  { height: '100%', borderRadius: 3.5, backgroundColor: C.brown },
+    countRow: { flexDirection: 'row', alignItems: 'baseline' },
 
-    section:     { marginHorizontal: 20, marginTop: 16, backgroundColor: C.surface, borderRadius: 20, borderWidth: 1, borderColor: C.border, padding: 18 },
-    sectionHead: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 },
+    verifyBtn:  { marginHorizontal: 20, marginTop: 16, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, backgroundColor: C.green, borderRadius: 14, paddingVertical: 15 },
+    doneBanner: { marginHorizontal: 20, marginTop: 16, borderWidth: 1, borderColor: C.greenBorder, backgroundColor: C.greenFaint, borderRadius: 14, paddingVertical: 15, alignItems: 'center' },
 
-    missionCard:  { alignItems: 'center', backgroundColor: C.bg, borderRadius: 16, borderWidth: 1, borderColor: C.border, padding: 20 },
-    missionIconBox: { width: 80, height: 80, borderRadius: 20, backgroundColor: C.greenFaint, borderWidth: 1, borderColor: C.greenBorder, alignItems: 'center', justifyContent: 'center' },
-    doneBanner:   { width: '100%', borderWidth: 1, borderColor: C.greenBorder, backgroundColor: C.greenFaint, borderRadius: 14, paddingVertical: 15, alignItems: 'center' },
+    // 수행 중 (피그마 PendingStrip: greenFaint / greenBorder / r20 / p16)
+    pendingStrip: { marginHorizontal: 20, marginTop: 16, backgroundColor: C.greenFaint, borderWidth: 1, borderColor: C.greenBorder, borderRadius: 20, padding: 16 },
+    sectionHead:  { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 },
+    pendingRow:   { flexDirection: 'row', alignItems: 'center', gap: 10 },
 
-    emptyMission: { marginHorizontal: 20, marginTop: 16, backgroundColor: C.surface, borderRadius: 20, borderWidth: 1, borderColor: C.border, paddingVertical: 28, paddingHorizontal: 20, alignItems: 'center' },
-    emptyIcon:    { width: 70, height: 70, borderRadius: 35, backgroundColor: C.surface2, alignItems: 'center', justifyContent: 'center' },
+    // 인증 피드
+    feed:       { marginHorizontal: 20, marginTop: 16, gap: 16 },
+    filterRow:  { flexDirection: 'row', gap: 8 },
+    filterChip: { borderWidth: 1, borderColor: C.borderStrong, borderRadius: 20, paddingHorizontal: 14, paddingVertical: 10, backgroundColor: C.bg },
+    feedEmpty:  { backgroundColor: C.surface, borderRadius: 16, borderWidth: 1, borderStyle: 'dashed', borderColor: C.borderStrong, paddingVertical: 26, alignItems: 'center' },
 
-    pendingRow: { flexDirection: 'row', alignItems: 'center', gap: 10, backgroundColor: C.bg, borderWidth: 1, borderColor: C.border, borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10 },
+    // Featured 카드 (사진 220 + 오버레이 유저행)
+    featuredCard:    { backgroundColor: C.neutral, borderRadius: 18, borderWidth: 1, borderColor: C.borderStrong, overflow: 'hidden' },
+    featuredPhoto:   { width: '100%', height: 220, backgroundColor: C.surface2 },
+    featuredOverlay: { position: 'absolute', top: 12, left: 12, right: 12, height: 48, flexDirection: 'row', alignItems: 'center', gap: 10, backgroundColor: 'rgba(0,0,0,0.3)', borderRadius: 12, paddingHorizontal: 10, paddingVertical: 8 },
+    featuredFooter:  { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 8, paddingHorizontal: 14, paddingVertical: 10 },
+    soloFooter:      { paddingHorizontal: 14, paddingVertical: 10, gap: 10 },
+    photoEmpty:      { alignItems: 'center', justifyContent: 'center' },
 
-    filterRow:  { flexDirection: 'row', gap: 8, marginBottom: 14 },
-    filterChip: { borderWidth: 1, borderColor: C.border, borderRadius: 16, paddingHorizontal: 12, paddingVertical: 6, backgroundColor: C.bg },
+    // 그리드 카드 (2열, 사진 150 + 오버레이)
+    grid:              { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+    gridCard:          { flexGrow: 1, flexBasis: '45%', maxWidth: '48.5%', backgroundColor: C.neutral, borderRadius: 14, borderWidth: 1, borderColor: C.borderStrong, overflow: 'hidden' },
+    gridPhoto:         { width: '100%', height: 150, backgroundColor: C.surface2 },
+    gridTopOverlay:    { position: 'absolute', top: 7, left: 7, right: 7, height: 26, flexDirection: 'row', alignItems: 'center', gap: 4, backgroundColor: 'rgba(0,0,0,0.45)', borderRadius: 8, paddingHorizontal: 7 },
+    gridBottomOverlay: { position: 'absolute', bottom: 7, left: 7, right: 7, height: 22, flexDirection: 'row', alignItems: 'center', gap: 4, backgroundColor: 'rgba(0,0,0,0.45)', borderRadius: 6, paddingHorizontal: 8 },
+    gridReactions:     { paddingHorizontal: 8, paddingTop: 10, paddingBottom: 8 },
+    gridVerifyWrap:    { paddingHorizontal: 8, paddingBottom: 8 },
+    gridVerifyBtn:     { alignItems: 'center', justifyContent: 'center', paddingVertical: 7, borderRadius: 10, backgroundColor: C.borderStrong, borderWidth: 1, borderColor: C.brown },
 
-    feedEmpty:  { backgroundColor: C.bg, borderRadius: 16, borderWidth: 1, borderStyle: 'dashed', borderColor: C.border, paddingVertical: 26, alignItems: 'center' },
-
-    proofCard:  { backgroundColor: C.bg, borderRadius: 16, borderWidth: 1, borderColor: C.border, padding: 12 },
-    proofTop:   { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 },
-    proofPhoto: { width: '100%', height: 200, borderRadius: 12, backgroundColor: C.surface2 },
-    proofPhotoEmpty: { alignItems: 'center', justifyContent: 'center' },
-    proofFooter: { marginTop: 12 },
-    confirmRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 12, paddingTop: 12, borderTopWidth: 1, borderTopColor: C.border },
-    confirmBtn: { borderWidth: 1, borderColor: C.border, borderRadius: 20, paddingHorizontal: 14, paddingVertical: 7, backgroundColor: C.surface },
+    // 미션 미정 Empty (피그마: r22 / 1.5px rgba(168,149,138,0.4) / pt32 pb24 px24)
+    emptyMission: { marginHorizontal: 20, backgroundColor: C.surface, borderRadius: 22, borderWidth: 1.5, borderColor: C.neutralStrong, paddingTop: 32, paddingBottom: 24, paddingHorizontal: 24, alignItems: 'center' },
+    emptyIcon:    { width: 88, height: 88, borderRadius: 44, backgroundColor: C.greenFaint, alignItems: 'center', justifyContent: 'center' },
   });
 }

--- a/screens/RoomHistoryScreen.jsx
+++ b/screens/RoomHistoryScreen.jsx
@@ -61,10 +61,10 @@ export default function RoomHistoryScreen({ roomId, onBack }) {
       <RoomTopBar title="지난 기록 보기" onBack={onBack} />
 
       <View style={s.monthRow}>
+        <WarmText v="title" size={16} style={{ flex: 1 }}>{month.getFullYear()}년 {month.getMonth() + 1}월</WarmText>
         <TouchableOpacity onPress={() => shiftMonth(-1)} hitSlop={10} activeOpacity={0.7}>
           <Ionicons name="chevron-back" size={20} color={C.textSub} />
         </TouchableOpacity>
-        <WarmText v="title" size={18}>{month.getFullYear()}년 {month.getMonth() + 1}월</WarmText>
         <TouchableOpacity onPress={() => shiftMonth(1)} hitSlop={10} activeOpacity={0.7}>
           <Ionicons name="chevron-forward" size={20} color={C.textSub} />
         </TouchableOpacity>
@@ -93,10 +93,10 @@ export default function RoomHistoryScreen({ roomId, onBack }) {
                   key={d.date}
                   activeOpacity={0.8}
                   onPress={() => { H.tap(); setSelected(d.date); }}
-                  style={[s.dateChip, active && { borderColor: C.greenBorder, backgroundColor: C.greenFaint }]}
+                  style={[s.dateChip, active && { borderColor: C.greenBorderStrong, backgroundColor: C.greenFaint }]}
                 >
-                  <WarmText v="section" size={17} color={active ? C.green : C.text}>{dt ? dt.getDate() : '-'}</WarmText>
-                  <WarmText v="caption" size={11} color={active ? C.green : C.textSub}>{dt ? WEEKDAYS[dt.getDay()] : ''}</WarmText>
+                  <WarmText v="section" size={15} color={active ? C.green : C.text}>{dt ? dt.getDate() : '-'}</WarmText>
+                  <WarmText v="caption" size={11} color={active ? C.green : C.text}>{dt ? WEEKDAYS[dt.getDay()] : ''}</WarmText>
                 </TouchableOpacity>
               );
             })}
@@ -106,38 +106,43 @@ export default function RoomHistoryScreen({ roomId, onBack }) {
             {selectedDay ? (
               <>
                 <View style={s.dayHead}>
-                  <WarmText v="section" size={16}>
+                  <WarmText v="section" size={15}>
                     {parseDate(selectedDay.date)?.getMonth() + 1}월 {parseDate(selectedDay.date)?.getDate()}일 ({WEEKDAYS[parseDate(selectedDay.date)?.getDay()]})
                   </WarmText>
-                  <WarmText v="caption">{selectedDay.confirmedCount ?? 0}명 인증</WarmText>
+                  <WarmText v="caption" size={12}>{selectedDay.confirmedCount ?? 0}명 인증</WarmText>
                 </View>
                 {selectedDay.mission ? (
-                  <View style={s.missionRow}>
-                    <WarmText size={18}>{selectedDay.mission.icon}</WarmText>
-                    <WarmText v="body" size={14} style={{ flex: 1 }}>{selectedDay.mission.title}</WarmText>
-                  </View>
+                  <WarmText size={13} color={C.brown} style={s.missionLine}>
+                    {selectedDay.mission.icon} {selectedDay.mission.title}
+                  </WarmText>
                 ) : null}
 
-                <View style={{ marginTop: 16, gap: 16 }}>
-                  {(selectedDay.proofs ?? []).map((p, i) => {
+                <View style={{ marginTop: 12 }}>
+                  {(selectedDay.proofs ?? []).map((p, i, arr) => {
                     const photo = resolvePhoto(p.photoUrl);
+                    const isLast = i === arr.length - 1;
                     return (
                       <View key={i} style={s.timelineRow}>
-                        <View style={s.timelineLeft}>
-                          <WarmText v="caption" size={11}>{p.time}</WarmText>
-                          <View style={[s.dot, { backgroundColor: p.status === 'VERIFIED' ? C.green : C.textSub }]} />
+                        <View style={s.timeCol}>
+                          <WarmText v="caption" size={12}>{p.time}</WarmText>
                         </View>
-                        {photo ? (
-                          <Image source={{ uri: photo }} style={s.thumb} resizeMode="cover" />
-                        ) : (
-                          <View style={[s.thumb, s.thumbEmpty]}><WarmText size={28}>📷</WarmText></View>
-                        )}
-                        <View style={{ flex: 1, gap: 6 }}>
-                          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                            <MemberAvatar avatarId={p.authorAvatarId} size={24} />
-                            <WarmText v="body" size={13}>{p.authorNickname}</WarmText>
+                        <View style={s.dotCol}>
+                          <View style={[s.dot, { backgroundColor: p.status === 'VERIFIED' ? C.green : C.textSub }]} />
+                          {!isLast ? <View style={s.dotLine} /> : null}
+                        </View>
+                        <View style={[s.entryBody, !isLast && { paddingBottom: 18 }]}>
+                          {photo ? (
+                            <Image source={{ uri: photo }} style={s.thumb} resizeMode="cover" />
+                          ) : (
+                            <View style={[s.thumb, s.thumbEmpty]}><WarmText size={28}>📷</WarmText></View>
+                          )}
+                          <View style={{ flex: 1, gap: 8 }}>
+                            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                              <MemberAvatar avatarId={p.authorAvatarId} size={24} />
+                              <WarmText v="body" size={13}>{p.authorNickname}</WarmText>
+                            </View>
+                            <View style={{ alignSelf: 'flex-start' }}><ProofStatusBadge status={p.status} /></View>
                           </View>
-                          <View style={{ alignSelf: 'flex-start' }}><ProofStatusBadge status={p.status} /></View>
                         </View>
                       </View>
                     );
@@ -156,16 +161,19 @@ function makeStyles(C) {
   return StyleSheet.create({
     screen:  { flex: 1, backgroundColor: C.bg },
     center:  { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-    content: { paddingHorizontal: 20, paddingBottom: 40 },
-    monthRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 18, paddingVertical: 10 },
-    dateStrip: { paddingHorizontal: 20, paddingVertical: 12, gap: 8 },
-    dateChip: { width: 52, height: 64, borderRadius: 14, borderWidth: 1, borderColor: C.border, backgroundColor: C.surface, alignItems: 'center', justifyContent: 'center', gap: 4 },
-    dayHead: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 8, marginBottom: 8 },
-    missionRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-    timelineRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
-    timelineLeft: { width: 40, alignItems: 'center', gap: 6 },
-    dot: { width: 8, height: 8, borderRadius: 4 },
-    thumb: { width: 80, height: 80, borderRadius: 12, backgroundColor: C.surface2 },
+    content: { paddingHorizontal: 20, paddingTop: 8, paddingBottom: 40 },
+    monthRow: { flexDirection: 'row', alignItems: 'center', gap: 16, paddingHorizontal: 20, paddingTop: 10, paddingBottom: 12 },
+    dateStrip: { paddingHorizontal: 20, paddingBottom: 8, gap: 8 },
+    dateChip: { width: 46, height: 52, borderRadius: 14, borderWidth: 1, borderColor: C.borderStrong, backgroundColor: C.neutralFaint, alignItems: 'center', justifyContent: 'center', gap: 2 },
+    dayHead: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 8 },
+    missionLine: { marginTop: 3 },
+    timelineRow: { flexDirection: 'row', gap: 10 },
+    timeCol: { width: 46 },
+    dotCol: { width: 16, alignItems: 'center', paddingTop: 2, gap: 4 },
+    dot: { width: 11, height: 11, borderRadius: 5.5 },
+    dotLine: { flex: 1, width: 2, borderRadius: 1, backgroundColor: C.border },
+    entryBody: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 12 },
+    thumb: { width: 150, height: 112, borderRadius: 12, backgroundColor: C.surface2 },
     thumbEmpty: { alignItems: 'center', justifyContent: 'center' },
   });
 }

--- a/screens/RoomListScreen.jsx
+++ b/screens/RoomListScreen.jsx
@@ -7,7 +7,8 @@ import { W } from '../constants/warm';
 import { api } from '../utils/api';
 import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
-import { RoomIcon, AvatarStack, ProgressBar, GreenButton, OutlineButton } from '../components/RoomBits';
+import { RoomIcon, AvatarStack, ProgressBar, GreenButton, OutlineButton, SourceBadge } from '../components/RoomBits';
+import { usePagerBottomBarHeight } from '../components/PageIndicator';
 
 /* ── 방 카드 ───────────────────────────────────────────── */
 function RoomCard({ room, solo, onPress }) {
@@ -16,17 +17,20 @@ function RoomCard({ room, solo, onPress }) {
   const mission = room.todayMission;
 
   return (
-    <TouchableOpacity activeOpacity={0.85} onPress={onPress} style={[s.card, solo && { borderColor: C.greenBorder }]}>
+    <TouchableOpacity activeOpacity={0.85} onPress={onPress} style={[s.card, solo && s.cardSolo]}>
       <View style={s.cardTop}>
-        <RoomIcon iconKey={room.iconKey} size={44} accent={solo} />
+        <RoomIcon iconKey={room.iconKey} size={30} accent={solo} />
         <View style={{ flex: 1, gap: 3 }}>
-          <WarmText v="section" size={16} numberOfLines={1}>{room.name}</WarmText>
-          <WarmText v="caption">{solo ? '혼자 수행하는 방' : `멤버 ${room.memberCount}명`}</WarmText>
+          <View style={s.nameRow}>
+            <WarmText v="section" size={16} numberOfLines={1} style={{ flexShrink: 1 }}>{room.name}</WarmText>
+            {mission?.source ? <SourceBadge source={mission.source} /> : null}
+          </View>
+          <WarmText v="caption" color={C.text}>{solo ? '혼자 수행하는 방' : `멤버 ${room.memberCount}명`}</WarmText>
         </View>
         {!solo && room.members ? <AvatarStack members={room.members} /> : null}
       </View>
 
-      <View style={s.divider} />
+      <View style={[s.divider, solo && s.dividerSolo]} />
 
       {mission ? (
         <View style={s.missionRow}>
@@ -64,10 +68,10 @@ function EmptyState() {
   return (
     <View style={s.empty}>
       <View style={s.emptyIcon}>
-        <Ionicons name="home-outline" size={34} color={C.textSub} />
+        <Ionicons name="home-outline" size={36} color={C.green} />
       </View>
-      <WarmText v="title" size={18} style={{ marginTop: 16 }}>아직 참여한 방이 없어요</WarmText>
-      <WarmText v="sub" style={{ textAlign: 'center', marginTop: 8, lineHeight: 20 }}>
+      <WarmText v="title" size={16} style={{ marginTop: 16 }}>아직 참여한 방이 없어요</WarmText>
+      <WarmText v="sub" color={C.brown} style={{ textAlign: 'center', marginTop: 8, lineHeight: 20 }}>
         첫 방을 만들거나 초대코드로 참여해{'\n'}오늘의 미션을 시작해보세요
       </WarmText>
     </View>
@@ -77,6 +81,7 @@ function EmptyState() {
 export default function RoomListScreen({ onOpenRoom, onCreate, onJoin, onOpenNotifications, version }) {
   const C = W;
   const s = useMemo(() => makeStyles(C), [C]);
+  const pagerBottom = usePagerBottomBarHeight(); // 플로팅 인디케이터+인셋 높이
 
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -110,13 +115,14 @@ export default function RoomListScreen({ onOpenRoom, onCreate, onJoin, onOpenNot
     <View style={s.screen}>
       <ScrollView
         style={s.screen}
-        contentContainerStyle={s.content}
+        contentContainerStyle={[s.content, { paddingBottom: 110 + pagerBottom }]}
         showsVerticalScrollIndicator={false}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={C.green} colors={[C.green]} />}
       >
         <View style={s.header}>
           <WarmText v="logo">OFFMODE</WarmText>
           <WarmText v="section" size={17} color={C.green} style={{ marginTop: 8 }}>스크린 OFF. 일상 ON.</WarmText>
+          {/* TODO(알림): 백엔드 알림 피드 API 미구현 → 진입점 숨김. 알림 도메인(콕찌르기·리액션·피어확인·초대·방완료 적재 + GET /notifications + 읽음처리) 구현 후 벨 아이콘 복원. NotificationsScreen 은 현재 하드코딩 샘플.
           <TouchableOpacity
             style={s.bell}
             hitSlop={12}
@@ -125,10 +131,11 @@ export default function RoomListScreen({ onOpenRoom, onCreate, onJoin, onOpenNot
           >
             <Ionicons name="notifications-outline" size={24} color={C.text} />
           </TouchableOpacity>
+          */}
         </View>
 
         <View style={s.banner}>
-          <WarmText v="body" size={14} color={C.textSub}>📸  혼자 또는 친구와 미션을 인증해요</WarmText>
+          <WarmText v="body" size={14} color={C.text}>📸  혼자 또는 친구와 미션을 인증해요</WarmText>
         </View>
 
         {loading ? (
@@ -144,14 +151,14 @@ export default function RoomListScreen({ onOpenRoom, onCreate, onJoin, onOpenNot
           <>
             {solo ? (
               <>
-                <WarmText v="label" style={s.sectionLabel}>나의 방</WarmText>
+                <WarmText v="label" color={C.green} style={s.sectionLabel}>나의 방</WarmText>
                 <RoomCard room={solo} solo onPress={() => { H.tap(); onOpenRoom?.(solo.id); }} />
               </>
             ) : null}
 
             <View style={s.sectionLabelRow}>
               <WarmText v="label">함께하는 방</WarmText>
-              <WarmText v="caption" size={11}>{groups.length}개</WarmText>
+              <WarmText v="caption" size={11} color={C.text}>{groups.length}개</WarmText>
             </View>
             {groups.length === 0 ? (
               <View style={s.emptyGroups}>
@@ -165,9 +172,9 @@ export default function RoomListScreen({ onOpenRoom, onCreate, onJoin, onOpenNot
         )}
       </ScrollView>
 
-      <View style={s.bottomBar}>
+      <View style={[s.bottomBar, { bottom: pagerBottom }]}>
         <GreenButton label="새 방 만들기" ionicon="add" onPress={() => { H.tap(); onCreate?.(); }} style={{ flex: 1 }} />
-        <OutlineButton label="초대코드로 참여" ionicon="link-outline" onPress={() => { H.tap(); onJoin?.(); }} style={{ flex: 1 }} />
+        <OutlineButton label="초대코드로 참여하기" ionicon="link-outline" onPress={() => { H.tap(); onJoin?.(); }} style={{ flex: 1 }} />
       </View>
     </View>
   );
@@ -181,19 +188,24 @@ function makeStyles(C) {
 
     header: { paddingHorizontal: 24, paddingTop: 24, paddingBottom: 12 },
     bell:   { position: 'absolute', right: 20, top: 24, width: 40, height: 40, alignItems: 'center', justifyContent: 'center' },
-    banner: { marginTop: 4, paddingVertical: 14, paddingHorizontal: 24, backgroundColor: C.surface, borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.border },
+    banner: { marginTop: 4, paddingVertical: 14, paddingHorizontal: 24, backgroundColor: C.neutralSoft, borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.borderStrong },
     sectionLabel: { paddingHorizontal: 20, marginTop: 20, marginBottom: 10 },
     sectionLabelRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 20, marginTop: 24, marginBottom: 10 },
 
-    card:    { marginHorizontal: 20, marginBottom: 12, backgroundColor: C.surface, borderRadius: 20, borderWidth: 1, borderColor: C.border, padding: 16 },
-    cardTop: { flexDirection: 'row', alignItems: 'center', gap: 12 },
-    divider: { height: 1, backgroundColor: C.border, marginVertical: 12 },
+    card:     { marginHorizontal: 20, marginBottom: 12, backgroundColor: C.neutralSoft, borderRadius: 20, borderWidth: 1, borderColor: C.borderStrong, padding: 16 },
+    cardSolo: { backgroundColor: C.greenFaint, borderColor: C.greenBorder },
+    cardTop:  { flexDirection: 'row', alignItems: 'center', gap: 10 },
+    nameRow:  { flexDirection: 'row', alignItems: 'center', gap: 6 },
+    divider:  { height: 1, backgroundColor: C.borderStrong, marginVertical: 12 },
+    dividerSolo: { backgroundColor: C.greenBorder },
     missionRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
 
     empty:     { alignItems: 'center', paddingVertical: 70, paddingHorizontal: 40 },
-    emptyIcon: { width: 76, height: 76, borderRadius: 38, backgroundColor: C.surface2, alignItems: 'center', justifyContent: 'center' },
+    emptyIcon: { width: 84, height: 84, borderRadius: 42, backgroundColor: C.greenFaint, alignItems: 'center', justifyContent: 'center' },
     emptyGroups: { marginHorizontal: 20, backgroundColor: C.surface, borderRadius: 20, borderWidth: 1.5, borderStyle: 'dashed', borderColor: C.border, paddingVertical: 28, alignItems: 'center' },
 
-    bottomBar: { position: 'absolute', left: 0, right: 0, bottom: 0, flexDirection: 'row', gap: 10, paddingHorizontal: 20, paddingTop: 12, paddingBottom: 24, backgroundColor: C.bg, borderTopWidth: 1, borderTopColor: C.border },
+    // bottom 위치는 호출부에서 플로팅 바텀 높이만큼 올려줌(인디케이터와 겹침 방지)
+    // 배경 완전 투명 — 버튼 자체 배경만 보이고 컨텐츠가 그 주변으로 비침 (엣지-투-엣지)
+    bottomBar: { position: 'absolute', left: 0, right: 0, bottom: 0, flexDirection: 'row', gap: 16, paddingHorizontal: 20, paddingTop: 12, paddingBottom: 12, backgroundColor: 'transparent' },
   });
 }

--- a/screens/RoomSettingsScreen.jsx
+++ b/screens/RoomSettingsScreen.jsx
@@ -127,7 +127,7 @@ export default function RoomSettingsScreen({ roomId, onBack, onLeft, onChanged }
                   <MemberAvatar avatarId={m.avatarId} size={34} />
                   <WarmText v="body" size={14} style={{ flex: 1 }}>{m.nickname}</WarmText>
                   {m.role === 'OWNER' ? (
-                    <WarmText v="caption">방장</WarmText>
+                    <WarmText v="caption" color={C.brown}>방장</WarmText>
                   ) : isOwner ? (
                     <TouchableOpacity activeOpacity={0.7} onPress={() => kick(m)}>
                       <WarmText v="caption" color={C.coral}>내보내기</WarmText>
@@ -157,11 +157,11 @@ function makeStyles(C) {
     screen:  { flex: 1, backgroundColor: C.bg },
     content: { paddingHorizontal: 20, paddingBottom: 40 },
     label:   { marginTop: 20, marginBottom: 10 },
-    input:   { backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 14, fontFamily: 'GmarketSansLight', fontSize: 15, color: C.text },
+    input:   { backgroundColor: C.neutralSoft, borderWidth: 1, borderColor: C.borderStrong, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 14, fontFamily: 'GmarketSansLight', fontSize: 15, color: C.text },
     codeRow: { flexDirection: 'row', alignItems: 'center', backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 14, paddingHorizontal: 16, paddingVertical: 14 },
-    shareBtn: { borderWidth: 1.5, borderColor: C.greenBorder, backgroundColor: C.greenFaint, borderRadius: 12, paddingHorizontal: 14, paddingVertical: 8 },
-    memberRow: { flexDirection: 'row', alignItems: 'center', gap: 12, backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 14, paddingHorizontal: 14, paddingVertical: 12 },
+    shareBtn: { borderWidth: 1, borderColor: C.green, backgroundColor: C.greenFaint, borderRadius: 12, paddingHorizontal: 14, paddingVertical: 8 },
+    memberRow: { flexDirection: 'row', alignItems: 'center', gap: 12, backgroundColor: C.surface, borderWidth: 1, borderColor: C.borderStrong, borderRadius: 14, paddingHorizontal: 14, paddingVertical: 12 },
     soloInfo: { backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 16, paddingVertical: 24, alignItems: 'center', marginTop: 4 },
-    dangerBtn: { alignItems: 'center', borderWidth: 1.5, borderColor: C.coralBorder, backgroundColor: C.coralFaint, borderRadius: 16, paddingVertical: 15, marginTop: 28 },
+    dangerBtn: { alignItems: 'center', borderWidth: 1, borderColor: C.coralBorder, backgroundColor: C.coralFaint, borderRadius: 16, paddingVertical: 15, marginTop: 28 },
   });
 }

--- a/screens/RoomVerifyScreen.jsx
+++ b/screens/RoomVerifyScreen.jsx
@@ -86,7 +86,7 @@ export default function RoomVerifyScreen({ room, onBack, onVerified }) {
 
   return (
     <View style={s.screen}>
-      <RoomTopBar title="미션 인증" onBack={onBack} />
+      <RoomTopBar title="미션 인증" titleSize={20} onBack={onBack} />
 
       {!permission?.granted ? (
         <PermissionScreen onRequest={requestPermission} />
@@ -94,13 +94,16 @@ export default function RoomVerifyScreen({ room, onBack, onVerified }) {
         <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
           <ScrollView ref={scrollRef} contentContainerStyle={s.content} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
             <View style={s.roomBadge}>
-              <WarmText v="caption" color={C.green}>{roomIconEmoji(room?.iconKey)} {room?.name} · 오늘의 미션 인증</WarmText>
+              <WarmText v="sub" size={13} color={C.text}>
+                {roomIconEmoji(room?.iconKey)} {room?.name}
+                <WarmText v="caption" size={12} color={C.textSub}> · 오늘의 미션 인증</WarmText>
+              </WarmText>
             </View>
 
             <View style={s.missionInfo}>
               <WarmText size={26}>{mission?.icon ?? '📋'}</WarmText>
               <View style={{ flex: 1 }}>
-                <WarmText v="caption" color={C.green} style={{ marginBottom: 2 }}>오늘의 미션</WarmText>
+                <WarmText v="caption" size={11} color={C.text} style={{ marginBottom: 2, opacity: 0.8 }}>오늘의 미션</WarmText>
                 <WarmText v="body">{mission?.title ?? '미션 완료하기'}</WarmText>
               </View>
             </View>
@@ -109,7 +112,14 @@ export default function RoomVerifyScreen({ room, onBack, onVerified }) {
               <View style={s.cameraWrap}>
                 <CameraView ref={cameraRef} style={{ flex: 1 }} facing={facing} />
                 <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
-                  <View style={s.tsTop}><WarmText v="sub" color="#fff">🕐 {timestamp}</WarmText></View>
+                  <View style={[s.bracket, s.brTL]} pointerEvents="none" />
+                  <View style={[s.bracket, s.brTR]} pointerEvents="none" />
+                  <View style={[s.bracket, s.brBL]} pointerEvents="none" />
+                  <View style={[s.bracket, s.brBR]} pointerEvents="none" />
+                  <View style={s.tsTop}>
+                    <Ionicons name="time-outline" size={13} color="#fff" />
+                    <WarmText v="sub" size={13} color="#fff" style={s.tsText}>{timestamp}</WarmText>
+                  </View>
                   <TouchableOpacity style={s.flipBtn} onPress={() => setFacing(f => f === 'back' ? 'front' : 'back')} activeOpacity={0.7}>
                     <Ionicons name="camera-reverse-outline" size={20} color="#fff" />
                   </TouchableOpacity>
@@ -125,7 +135,10 @@ export default function RoomVerifyScreen({ room, onBack, onVerified }) {
             ) : (
               <View style={s.takenWrap}>
                 <Image source={{ uri: photoUri }} style={s.takenPhoto} resizeMode="cover" />
-                <View style={s.takenTs}><WarmText v="caption" color="#fff">{timestamp}</WarmText></View>
+                <View style={s.takenTs}>
+                  <Ionicons name="time-outline" size={13} color="#fff" />
+                  <WarmText v="sub" size={13} color="#fff" style={s.tsText}>{timestamp}</WarmText>
+                </View>
                 <TouchableOpacity style={s.retakeBtn} onPress={() => setPhotoUri(null)} activeOpacity={0.7}>
                   <WarmText v="sub">다시 찍기</WarmText>
                 </TouchableOpacity>
@@ -140,10 +153,10 @@ export default function RoomVerifyScreen({ room, onBack, onVerified }) {
                 placeholderTextColor={C.textSub}
                 value={caption}
                 onChangeText={setCaption}
-                maxLength={80}
+                maxLength={50}
                 onFocus={() => setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 100)}
               />
-              <WarmText v="caption" style={{ opacity: 0.5, textAlign: 'right' }}>{caption.length}/80</WarmText>
+              <WarmText v="caption" style={{ opacity: 0.5, textAlign: 'right' }}>{caption.length}/50</WarmText>
             </View>
 
             <GreenButton
@@ -161,18 +174,24 @@ export default function RoomVerifyScreen({ room, onBack, onVerified }) {
 function makeStyles(C) {
   return StyleSheet.create({
     screen:  { flex: 1, backgroundColor: C.bg },
-    content: { paddingHorizontal: 20, paddingBottom: 40, gap: 16 },
-    roomBadge: { alignSelf: 'flex-start', backgroundColor: C.greenFaint, borderWidth: 1, borderColor: C.greenBorder, borderRadius: 14, paddingHorizontal: 12, paddingVertical: 6 },
-    missionInfo: { flexDirection: 'row', alignItems: 'center', gap: 12, backgroundColor: C.surface, borderRadius: 14, borderWidth: 1, borderColor: C.border, paddingHorizontal: 14, paddingVertical: 12 },
-    cameraWrap: { borderRadius: 20, overflow: 'hidden', borderWidth: 1, borderColor: C.border, height: 360 },
-    tsTop: { position: 'absolute', top: 12, alignSelf: 'center', backgroundColor: 'rgba(0,0,0,0.5)', borderRadius: 8, paddingHorizontal: 12, paddingVertical: 5 },
-    flipBtn: { position: 'absolute', top: 12, right: 12, width: 36, height: 36, borderRadius: 18, backgroundColor: 'rgba(0,0,0,0.45)', alignItems: 'center', justifyContent: 'center' },
+    content: { paddingHorizontal: 20, paddingBottom: 40, gap: 20 },
+    roomBadge: { alignSelf: 'flex-start', backgroundColor: C.coralFaint, borderWidth: 1, borderColor: C.coralBorder, borderRadius: 14, paddingHorizontal: 12, paddingVertical: 6 },
+    missionInfo: { flexDirection: 'row', alignItems: 'center', gap: 12, backgroundColor: C.neutralStrong, borderRadius: 14, borderWidth: 1, borderColor: C.text, paddingHorizontal: 14, paddingVertical: 12 },
+    cameraWrap: { borderRadius: 20, overflow: 'hidden', borderWidth: 1, borderColor: C.border, height: 387 },
+    bracket: { position: 'absolute', width: 22, height: 22, borderColor: 'rgba(255,255,255,0.8)' },
+    brTL: { top: 12, left: 12, borderTopWidth: 2, borderLeftWidth: 2 },
+    brTR: { top: 12, right: 12, borderTopWidth: 2, borderRightWidth: 2 },
+    brBL: { bottom: 112, left: 12, borderBottomWidth: 2, borderLeftWidth: 2 },
+    brBR: { bottom: 112, right: 12, borderBottomWidth: 2, borderRightWidth: 2 },
+    tsTop: { position: 'absolute', top: 14, alignSelf: 'center', flexDirection: 'row', alignItems: 'center', gap: 5 },
+    tsText: { textShadowColor: 'rgba(0,0,0,0.6)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 3 },
+    flipBtn: { position: 'absolute', top: 46, right: 12, width: 36, height: 36, borderRadius: 18, backgroundColor: 'rgba(0,0,0,0.45)', alignItems: 'center', justifyContent: 'center' },
     shutterRow: { position: 'absolute', bottom: 0, left: 0, right: 0, backgroundColor: 'rgba(0,0,0,0.45)', paddingVertical: 16, alignItems: 'center' },
     shutter: { width: 68, height: 68, borderRadius: 34, backgroundColor: 'rgba(255,255,255,0.15)', borderWidth: 3, borderColor: '#fff', alignItems: 'center', justifyContent: 'center' },
     shutterInner: { width: 52, height: 52, borderRadius: 26, backgroundColor: '#fff' },
     takenWrap: { borderRadius: 20, overflow: 'hidden', borderWidth: 1, borderColor: C.greenBorder },
     takenPhoto: { width: '100%', height: 320 },
-    takenTs: { position: 'absolute', bottom: 44, left: 10, backgroundColor: 'rgba(0,0,0,0.55)', borderRadius: 8, paddingHorizontal: 10, paddingVertical: 5 },
+    takenTs: { position: 'absolute', bottom: 52, left: 12, flexDirection: 'row', alignItems: 'center', gap: 5 },
     retakeBtn: { backgroundColor: C.surface2, paddingVertical: 11, alignItems: 'center', borderTopWidth: 1, borderTopColor: C.border },
     captionWrap: { backgroundColor: C.surface, borderRadius: 14, borderWidth: 1, borderColor: C.border, paddingHorizontal: 14, paddingTop: 12, paddingBottom: 8, gap: 6 },
     captionInput: { fontFamily: F, fontSize: 14, color: C.text, borderBottomWidth: 1, borderBottomColor: C.border, paddingVertical: 6 },

--- a/screens/SettingsScreen.jsx
+++ b/screens/SettingsScreen.jsx
@@ -12,13 +12,14 @@ import {
   scheduleMissionNotification, cancelMissionNotification,
   scheduleReminderNotification, cancelReminderNotification,
 } from '../utils/notifications';
+import { usePagerBottomBarHeight } from '../components/PageIndicator';
 
 const openLink = (url) =>
   Linking.openURL(url).catch(() =>
     Alert.alert('오류', '페이지를 열 수 없어요. 잠시 후 다시 시도해주세요.')
   );
 
-/* ── 웜 토글 (Figma 46×26 pill) ──────────────────────── */
+/* ── 웜 토글 (Figma 46×28 pill) ──────────────────────── */
 function WarmToggle({ value, onValueChange }) {
   const C = W;
   return (
@@ -38,12 +39,12 @@ function WarmToggle({ value, onValueChange }) {
 }
 
 const toggleStyles = StyleSheet.create({
-  track: { width: 46, height: 26, borderRadius: 13, padding: 2, justifyContent: 'center' },
-  knob:  { width: 22, height: 22, borderRadius: 11, backgroundColor: '#fff' },
+  track: { width: 46, height: 28, borderRadius: 14, padding: 2, justifyContent: 'center' },
+  knob:  { width: 24, height: 24, borderRadius: 12, backgroundColor: '#fff' },
 });
 
 /* ── 설정 행 ─────────────────────────────────────────── */
-function SettingRow({ icon, label, sub, right, onPress, danger = false, last = false }) {
+function SettingRow({ icon, label, sub, right, onPress, last = false }) {
   const C = W;
   const row = useMemo(() => makeRowStyles(C), [C]);
   return (
@@ -54,9 +55,9 @@ function SettingRow({ icon, label, sub, right, onPress, danger = false, last = f
     >
       <View style={row.left}>
         <WarmText size={18}>{icon}</WarmText>
-        <View style={{ gap: 2 }}>
-          <WarmText v="body" size={15} color={danger ? C.coral : C.text}>{label}</WarmText>
-          {sub ? <WarmText v="caption" size={12} color={C.textSub}>{sub}</WarmText> : null}
+        <View style={{ gap: 6 }}>
+          <WarmText v="body" size={16} color={C.text}>{label}</WarmText>
+          {sub ? <WarmText v="caption" size={14} color={C.green}>{sub}</WarmText> : null}
         </View>
       </View>
       <View style={row.right}>{right}</View>
@@ -66,8 +67,8 @@ function SettingRow({ icon, label, sub, right, onPress, danger = false, last = f
 
 function makeRowStyles(C) {
   return StyleSheet.create({
-    wrap:    { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 14 },
-    divider: { borderBottomWidth: 1, borderBottomColor: C.border },
+    wrap:    { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 16 },
+    divider: { borderBottomWidth: 1, borderBottomColor: C.borderStrong },
     left:    { flexDirection: 'row', alignItems: 'center', gap: 12, flex: 1 },
     right:   { alignItems: 'flex-end' },
   });
@@ -79,7 +80,7 @@ function Section({ title, children }) {
   const sec = useMemo(() => makeSecStyles(C), [C]);
   return (
     <View style={sec.wrap}>
-      {title ? <WarmText v="label" size={12} color={C.textSub}>{title}</WarmText> : null}
+      {title ? <WarmText v="label" size={16} color={C.text} style={{ opacity: 0.6, letterSpacing: 1 }}>{title}</WarmText> : null}
       <View style={sec.card}>{children}</View>
     </View>
   );
@@ -87,12 +88,12 @@ function Section({ title, children }) {
 
 function makeSecStyles(C) {
   return StyleSheet.create({
-    wrap: { gap: 8 },
-    card: { backgroundColor: C.surface, borderRadius: 16, borderWidth: 1, borderColor: C.border, overflow: 'hidden' },
+    wrap: { gap: 15 },
+    card: { backgroundColor: C.neutralSoft, borderRadius: 16, borderWidth: 1, borderColor: C.borderStrong, overflow: 'hidden' },
   });
 }
 
-const Chevron = () => <WarmText size={16} color={W.textSub}>›</WarmText>;
+const Chevron = () => <WarmText size={13} color={W.green}>›</WarmText>;
 
 /* ── 메인 설정 화면 ──────────────────────────────────── */
 export default function SettingsScreen({
@@ -106,10 +107,11 @@ export default function SettingsScreen({
 }) {
   const C = W;
   const s = useMemo(() => makeStyles(C), [C]);
+  const pagerBottom = usePagerBottomBarHeight(); // 플로팅 인디케이터+인셋 높이
 
   const pad = (n) => String(n).padStart(2, '0');
   const { hour = 8, minute = 0 } = missionTime ?? {};
-  const timeLabel = `${hour < 12 ? '오전' : '오후'} ${hour % 12 === 0 ? 12 : hour % 12}:${pad(minute)}`;
+  const timeLabel = `${pad(hour)}:${pad(minute)}`;
 
   const [pushNotif, setPushNotif] = useState(false);
   const [reminder,  setReminder]  = useState(false);
@@ -197,19 +199,20 @@ export default function SettingsScreen({
         ) : (
           <View style={s.side} />
         )}
-        <WarmText v="body" size={18}>설정</WarmText>
+        <WarmText v="body" size={20}>설정</WarmText>
         <View style={s.side} />
       </View>
 
-      <ScrollView contentContainerStyle={s.content} showsVerticalScrollIndicator={false}>
+      <ScrollView contentContainerStyle={[s.content, { paddingBottom: 40 + pagerBottom }]} showsVerticalScrollIndicator={false}>
         {/* 미션 */}
         <Section title="미션">
           <SettingRow
             icon="⏰"
             label="알림 시간"
+            sub="이 시간에 미션이 도착해요"
             right={
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <WarmText size={14} color={C.green}>{timeLabel}</WarmText>
+                <WarmText size={15} color={C.green}>{timeLabel}</WarmText>
                 <Chevron />
               </View>
             }
@@ -296,7 +299,6 @@ export default function SettingsScreen({
           <SettingRow
             icon="⚠️"
             label="회원 탈퇴"
-            danger
             right={<Chevron />}
             onPress={() => {
               Alert.alert(
@@ -314,8 +316,8 @@ export default function SettingsScreen({
 
         {/* 버전 푸터 */}
         <View style={s.footer}>
-          <WarmText size={20} color={C.green}>OFFMODE</WarmText>
-          <WarmText v="caption" size={11} color={C.textSub} style={{ marginTop: 4, opacity: 0.6 }}>v1.0.0  •  Made with 🌙</WarmText>
+          <WarmText size={20} color={C.text} style={{ letterSpacing: 2 }}>OFFMODE</WarmText>
+          <WarmText v="caption" size={11} color={C.green} style={{ marginTop: 4, opacity: 0.6 }}>v1.0.0  •  Made with 🌙</WarmText>
         </View>
       </ScrollView>
     </View>

--- a/screens/SignupScreen.jsx
+++ b/screens/SignupScreen.jsx
@@ -168,7 +168,7 @@ export default function SignupScreen({ defaultName = '', onComplete }) {
             <T v="sub" style={{ textAlign: 'center' }}>나중에 설정에서 변경할 수 있어요</T>
           </View>
 
-          <View style={{ height: 56 }} />
+          <View style={{ height: 73 }} />
 
           {/* 선택된 아바타 미리보기 */}
           <View style={s.previewRing}>
@@ -216,9 +216,19 @@ export default function SignupScreen({ defaultName = '', onComplete }) {
             <T v="caption" color={W.green} style={{ opacity: 0.4 }}>{name.length}/12</T>
           </View>
 
-          <View style={{ height: 48 }} />
+          <View style={{ height: 100 }} />
 
-          <GreenButton label="다음 →" onPress={handleNext} disabled={!canNext} style={{ width: '100%' }} />
+          {/* Figma py 18 — GreenButton은 내부 패딩 오버라이드가 안 돼 동일 규격 로컬 버튼 사용 */}
+          <TouchableOpacity
+            activeOpacity={0.85}
+            onPress={handleNext}
+            disabled={!canNext}
+            style={{ width: '100%' }}
+          >
+            <View style={[s.nextBtn, !canNext && s.nextBtnDisabled]}>
+              <T v="btn" style={!canNext ? { color: W.text } : undefined}>다음 →</T>
+            </View>
+          </TouchableOpacity>
         </ScrollView>
       </KeyboardAvoidingView>
     );
@@ -355,6 +365,17 @@ function makeStyles() {
       flexDirection: 'row', alignItems: 'center', marginTop: 12,
     },
     input: { flex: 1, fontFamily: GL, fontSize: 16, color: W.green },
+
+    // "다음" 버튼 — GreenButton 규격 + Figma py 18
+    nextBtn: {
+      alignItems: 'center', justifyContent: 'center',
+      borderRadius: 16, paddingVertical: 18,
+      backgroundColor: W.green,
+    },
+    nextBtnDisabled: {
+      backgroundColor: W.neutralStrong,
+      borderWidth: 1, borderColor: W.text,
+    },
 
     // Step 2
     previewWrap: {

--- a/utils/useBottomInset.js
+++ b/utils/useBottomInset.js
@@ -1,0 +1,12 @@
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+/**
+ * 화면 하단에 고정 버튼/바를 둘 때 쓰는 하단 여백.
+ * - 홈버튼 없는 기기(하단 세이프 인셋 존재): 인디케이터 높이만큼만 (추가 패딩 없음)
+ * - 홈버튼 있는 기기(인셋 0): 하단 패딩 24px
+ * SafeAreaProvider 하위에서만 호출할 것.
+ */
+export default function useBottomInset() {
+  const insets = useSafeAreaInsets();
+  return insets.bottom > 0 ? insets.bottom : 24;
+}


### PR DESCRIPTION
## 🔗 Issue

- close #127
- ref #112

---

## 📌 Summary

Rooms v2 웜크림 리디자인 마감 + 하단 인셋 대응 릴리스. 커밋 단위로 정리:

- **[Feat] 엣지-투-엣지 하단 인셋 인프라** — 기기별 하단 여백을 계산하는 `useBottomInset` 훅 추가, PageIndicator를 투명 플로팅 오버레이로 전환, 상단 크롬 웜 크림 통일. CreateRoom·JoinRoom 하단 버튼 여백 적용
- **[Feat] 웜크림 디자인 정합성 일괄 적용** — warm.js 색 토큰 확장, GreenButton 그라디언트→단색, RoomBits·CharacterDecor·다수 화면 Figma 규격 폴리싱. LoginScreen·MissionRouletteScreen 구 테마 API(useColors/T) → W/WarmText 마이그레이션. RoomList 알림 벨은 백엔드 알림 API 미구현으로 진입점 숨김(TODO)
- **[Feat] RoomDetail 인증 피드 카드 재설계** — 단일 ProofCard → FeaturedCard·GridProofCard·VerifyChip·OverlayStatusBadge 분해, 피어 인증 UI 피드화(로직 유지)
- **[Fix] #127 프로필 탭 순서** — Profile·Mission·Settings로 정렬 (Mission 가운데)
- **[Chore] iOS 버전 범프** — 1.0.1 / build 3

---

## ✅ Test

- [x] `npm run lint` 0 errors
- [ ] 실기기: 하단 인셋(홈버튼/인디케이터 기기), 웜크림 화면 전반, RoomDetail 인증 피드, 탭 순서 확인