### PR TITLE
[Fix] #138 피어인증·리액션 동시성 race 및 RoomService N+1 쿼리 수정

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/feed/repository/VerificationRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/repository/VerificationRepository.java
@@ -2,9 +2,12 @@ package com.offmode.boundedcontext.feed.repository;
 
 import com.offmode.boundedcontext.feed.dto.response.FeedItemResponse;
 import com.offmode.boundedcontext.feed.entity.Verification;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +15,12 @@ import org.springframework.data.repository.query.Param;
 public interface VerificationRepository extends JpaRepository<Verification, Long> {
 
   boolean existsByUserMissionId(Long userMissionId);
+
+  // confirm/react 직렬화용 행 락 — 같은 인증에 대한 동시 요청이 순서대로 처리되어
+  // 임계치 이중 통과(이중 레벨업/뱃지)와 UNIQUE 위반 500을 막는다.
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT v FROM Verification v WHERE v.id = :id")
+  Optional<Verification> findWithLockById(@Param("id") Long id);
 
   @Query(
       """

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
@@ -82,9 +82,10 @@ public class FeedService {
 
   @Transactional
   public void confirm(Long userId, Long verificationId) {
+    // 행 락으로 같은 인증의 confirm 을 직렬화 — count 기반 임계치 판정의 이중 통과 방지
     Verification v =
         verificationRepository
-            .findById(verificationId)
+            .findWithLockById(verificationId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.VERIFICATION_NOT_FOUND));
 
     // 본인 인증은 불가
@@ -121,9 +122,10 @@ public class FeedService {
 
   @Transactional
   public List<ReactionSummaryResponse> react(Long userId, Long verificationId, String emoji) {
+    // 행 락으로 같은 인증의 토글을 직렬화 — find-then-save 경합의 UNIQUE 위반 방지
     Verification v =
         verificationRepository
-            .findById(verificationId)
+            .findWithLockById(verificationId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.VERIFICATION_NOT_FOUND));
 
     List<Reaction> userReactions =

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomMemberRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomMemberRepository.java
@@ -21,4 +21,25 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
 
   @Query("SELECT m FROM RoomMember m JOIN FETCH m.room WHERE m.user.id = :userId")
   List<RoomMember> findWithRoomByUserId(@Param("userId") Long userId);
+
+  // 방 목록용: 방별 멤버 수를 한 번에 집계
+  @Query(
+      """
+        SELECT m.room.id, COUNT(m)
+        FROM RoomMember m
+        WHERE m.room.id IN :roomIds
+        GROUP BY m.room.id
+    """)
+  List<Object[]> countRowsByRoomIdIn(@Param("roomIds") List<Long> roomIds);
+
+  // 방 상세용: 멤버를 유저와 함께 한 번에 로드 (멤버마다 유저 쿼리 없음)
+  @Query(
+      """
+        SELECT m
+        FROM RoomMember m
+        JOIN FETCH m.user
+        WHERE m.room.id = :roomId
+        ORDER BY m.joinedAt ASC
+    """)
+  List<RoomMember> findWithUserByRoomIdOrderByJoinedAtAsc(@Param("roomId") Long roomId);
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomMissionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomMissionRepository.java
@@ -10,6 +10,9 @@ public interface RoomMissionRepository extends JpaRepository<RoomMission, Long> 
 
   Optional<RoomMission> findByRoomIdAndDate(Long roomId, LocalDate date);
 
+  // 방 목록용: 여러 방의 오늘 미션을 한 번에 조회
+  List<RoomMission> findByRoomIdInAndDate(List<Long> roomIds, LocalDate date);
+
   List<RoomMission> findByRoomIdAndDateBetweenOrderByDateDesc(
       Long roomId, LocalDate start, LocalDate end);
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofConfirmRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofConfirmRepository.java
@@ -1,11 +1,23 @@
 package com.offmode.boundedcontext.room.repository;
 
 import com.offmode.boundedcontext.room.entity.RoomProofConfirm;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomProofConfirmRepository extends JpaRepository<RoomProofConfirm, Long> {
 
   boolean existsByRoomProofIdAndUserId(Long roomProofId, Long userId);
 
   long countByRoomProofId(Long roomProofId);
+
+  // 방 상세용: 여러 인증의 confirm (proofId, userId) 행을 한 번에 조회해 애플리케이션에서 집계
+  @Query(
+      """
+        SELECT c.roomProof.id, c.user.id
+        FROM RoomProofConfirm c
+        WHERE c.roomProof.id IN :proofIds
+    """)
+  List<Object[]> findRowsByRoomProofIdIn(@Param("proofIds") List<Long> proofIds);
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -3,18 +3,48 @@ package com.offmode.boundedcontext.room.repository;
 import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.room.entity.RoomProof;
 import com.offmode.boundedcontext.room.types.ProofStatus;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
 
   List<RoomProof> findByRoomMissionIdOrderByCreatedAtDesc(Long roomMissionId);
+
+  // confirm/리액션 직렬화용 행 락 — 같은 인증에 대한 동시 요청이 순서대로 처리되어
+  // 임계치 이중 통과(이중 진급/뱃지)와 UNIQUE 위반 500을 막는다.
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT p FROM RoomProof p WHERE p.id = :id")
+  Optional<RoomProof> findWithLockById(@Param("id") Long id);
+
+  // 방 목록용: 미션별 VERIFIED 수를 한 번에 집계 (방 개수만큼 반복 호출하지 않는다)
+  @Query(
+      """
+        SELECT p.roomMission.id, COUNT(p)
+        FROM RoomProof p
+        WHERE p.roomMission.id IN :missionIds AND p.status = :status
+        GROUP BY p.roomMission.id
+    """)
+  List<Object[]> countRowsByRoomMissionIdInAndStatus(
+      @Param("missionIds") List<Long> missionIds, @Param("status") ProofStatus status);
+
+  // 방 상세용: 오늘 인증들을 업로더와 함께 한 번에 로드 (인증 건마다 유저 쿼리 없음)
+  @Query(
+      """
+        SELECT p
+        FROM RoomProof p
+        JOIN FETCH p.user
+        WHERE p.roomMission.id = :missionId
+        ORDER BY p.createdAt DESC
+    """)
+  List<RoomProof> findWithUserByRoomMissionId(@Param("missionId") Long missionId);
 
   Optional<RoomProof> findByRoomMissionIdAndUserId(Long roomMissionId, Long userId);
 

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofAssembler.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofAssembler.java
@@ -7,9 +7,13 @@ import com.offmode.boundedcontext.room.repository.RoomProofConfirmRepository;
 import com.offmode.boundedcontext.room.repository.RoomReactionRepository;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -25,33 +29,46 @@ public class RoomProofAssembler {
   private final RoomReactionRepository reactionRepository;
 
   public RoomProofResponse build(RoomProof proof, int requiredConfirm, Long currentUserId) {
-    int confirmCount = (int) confirmRepository.countByRoomProofId(proof.getId());
-    boolean myConfirmed =
-        confirmRepository.existsByRoomProofIdAndUserId(proof.getId(), currentUserId);
-    boolean mine = proof.getUser().getId().equals(currentUserId);
-    List<RoomReactionSummaryResponse> reactions =
-        aggregateReactions(reactionRepository.findRowsByRoomProofId(proof.getId()), currentUserId);
-
-    return new RoomProofResponse(
-        proof.getId(),
-        proof.getUser().getName(),
-        proof.getUser().getAvatar(),
-        proof.getPhotoUrl(),
-        proof.getCaption(),
-        proof.getCreatedAt(),
-        proof.getStatus(),
-        confirmCount,
-        requiredConfirm,
-        myConfirmed,
-        mine,
-        reactions);
+    return buildAll(List.of(proof), requiredConfirm, currentUserId).getFirst();
   }
 
   public List<RoomProofResponse> buildAll(
       List<RoomProof> proofs, int requiredConfirm, Long currentUserId) {
+    if (proofs.isEmpty()) return List.of();
+
+    // confirm/리액션을 인증 건수와 무관하게 상수 쿼리로 배치 조회해 집계한다.
+    List<Long> proofIds = proofs.stream().map(RoomProof::getId).toList();
+    Map<Long, Long> confirmCounts = new HashMap<>();
+    Set<Long> myConfirmedProofIds = new HashSet<>();
+    for (Object[] row : confirmRepository.findRowsByRoomProofIdIn(proofIds)) {
+      Long proofId = ((Number) row[0]).longValue();
+      Long confirmerUserId = ((Number) row[1]).longValue();
+      confirmCounts.merge(proofId, 1L, Long::sum);
+      if (confirmerUserId.equals(currentUserId)) {
+        myConfirmedProofIds.add(proofId);
+      }
+    }
+    Map<Long, List<Object[]>> reactionRowsByProofId =
+        reactionRepository.findRowsByRoomProofIdIn(proofIds).stream()
+            .collect(Collectors.groupingBy(row -> ((Number) row[0]).longValue()));
+
     List<RoomProofResponse> result = new ArrayList<>();
     for (RoomProof proof : proofs) {
-      result.add(build(proof, requiredConfirm, currentUserId));
+      result.add(
+          new RoomProofResponse(
+              proof.getId(),
+              proof.getUser().getName(),
+              proof.getUser().getAvatar(),
+              proof.getPhotoUrl(),
+              proof.getCaption(),
+              proof.getCreatedAt(),
+              proof.getStatus(),
+              confirmCounts.getOrDefault(proof.getId(), 0L).intValue(),
+              requiredConfirm,
+              myConfirmedProofIds.contains(proof.getId()),
+              proof.getUser().getId().equals(currentUserId),
+              aggregateReactions(
+                  reactionRowsByProofId.getOrDefault(proof.getId(), List.of()), currentUserId)));
     }
     return result;
   }

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofService.java
@@ -123,7 +123,7 @@ public class RoomProofService {
       Long userId, Long roomId, Long proofId, String emoji) {
     roomService.getRoomOrThrow(roomId);
     roomService.getMembershipOrThrow(roomId, userId);
-    RoomProof proof = getProofInRoomOrThrow(proofId, roomId);
+    RoomProof proof = getProofInRoomForUpdateOrThrow(proofId, roomId);
 
     RoomReaction existing =
         reactionRepository.findByRoomProofIdAndUserId(proofId, userId).stream()
@@ -149,7 +149,7 @@ public class RoomProofService {
   public ConfirmResponse confirm(Long userId, Long roomId, Long proofId) {
     Room room = roomService.getRoomOrThrow(roomId);
     roomService.getMembershipOrThrow(roomId, userId);
-    RoomProof proof = getProofInRoomOrThrow(proofId, roomId);
+    RoomProof proof = getProofInRoomForUpdateOrThrow(proofId, roomId);
 
     if (proof.getUser().getId().equals(userId)) {
       throw new BusinessException(ErrorStatus.ROOM_SELF_CONFIRM_NOT_ALLOWED);
@@ -259,10 +259,25 @@ public class RoomProofService {
   }
 
   private RoomProof getProofInRoomOrThrow(Long proofId, Long roomId) {
-    RoomProof proof =
+    return checkProofInRoom(
         proofRepository
             .findById(proofId)
-            .orElseThrow(() -> new BusinessException(ErrorStatus.ROOM_PROOF_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(ErrorStatus.ROOM_PROOF_NOT_FOUND)),
+        roomId);
+  }
+
+  // 쓰기 경로(confirm/리액션)용 — 행 락으로 같은 인증의 동시 요청을 직렬화한다.
+  // 임계치 이중 통과(이중 진급/뱃지)와 find-then-save 경합의 UNIQUE 위반을 막는다.
+  // 읽기 경로(getProof)는 락 없는 getProofInRoomOrThrow 를 유지한다.
+  private RoomProof getProofInRoomForUpdateOrThrow(Long proofId, Long roomId) {
+    return checkProofInRoom(
+        proofRepository
+            .findWithLockById(proofId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.ROOM_PROOF_NOT_FOUND)),
+        roomId);
+  }
+
+  private RoomProof checkProofInRoom(RoomProof proof, Long roomId) {
     if (!proof.getRoomMission().getRoom().getId().equals(roomId)) {
       throw new BusinessException(ErrorStatus.ROOM_PROOF_NOT_FOUND);
     }

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
@@ -33,11 +33,13 @@ import com.offmode.global.status.ErrorStatus;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -105,10 +107,27 @@ public class RoomService {
     List<GroupRoomSummaryResponse> groupRooms = new ArrayList<>();
     LocalDate today = LocalDate.now();
 
+    // 오늘 미션·멤버 수·달성 수를 방 개수와 무관하게 상수 쿼리로 배치 조회한다.
+    List<Long> roomIds = memberships.stream().map(m -> m.getRoom().getId()).toList();
+    Map<Long, RoomMission> todayMissions =
+        roomIds.isEmpty()
+            ? Map.of()
+            : missionRepository.findByRoomIdInAndDate(roomIds, today).stream()
+                .collect(
+                    Collectors.toMap(mission -> mission.getRoom().getId(), mission -> mission));
+    Map<Long, Long> memberCounts =
+        roomIds.isEmpty() ? Map.of() : toCountMap(memberRepository.countRowsByRoomIdIn(roomIds));
+    List<Long> missionIds = todayMissions.values().stream().map(RoomMission::getId).toList();
+    Map<Long, Long> verifiedCounts =
+        missionIds.isEmpty()
+            ? Map.of()
+            : toCountMap(
+                proofRepository.countRowsByRoomMissionIdInAndStatus(
+                    missionIds, ProofStatus.VERIFIED));
+
     for (RoomMember membership : memberships) {
       Room room = membership.getRoom();
-      RoomMission todayMission =
-          missionRepository.findByRoomIdAndDate(room.getId(), today).orElse(null);
+      RoomMission todayMission = todayMissions.get(room.getId());
       MiniMissionResponse mini =
           todayMission == null
               ? null
@@ -125,17 +144,15 @@ public class RoomService {
                 room.getName(),
                 room.getIconKey(),
                 room.getType(),
-                (int) memberRepository.countByRoomId(room.getId()),
+                memberCounts.getOrDefault(room.getId(), 0L).intValue(),
                 mini,
                 done);
       } else {
-        int memberCount = (int) memberRepository.countByRoomId(room.getId());
+        int memberCount = memberCounts.getOrDefault(room.getId(), 0L).intValue();
         int verifiedCount =
             todayMission == null
                 ? 0
-                : (int)
-                    proofRepository.countByRoomMissionIdAndStatus(
-                        todayMission.getId(), ProofStatus.VERIFIED);
+                : verifiedCounts.getOrDefault(todayMission.getId(), 0L).intValue();
         groupRooms.add(
             new GroupRoomSummaryResponse(
                 room.getId(),
@@ -159,7 +176,9 @@ public class RoomService {
     Room room = getRoomOrThrow(roomId);
     RoomMember myMembership = getMembershipOrThrow(roomId, userId);
 
-    int memberCount = (int) memberRepository.countByRoomId(roomId);
+    List<RoomMember> memberEntities =
+        memberRepository.findWithUserByRoomIdOrderByJoinedAtAsc(roomId);
+    int memberCount = memberEntities.size();
     int requiredConfirm = requiredConfirm(room.getType(), memberCount);
     LocalDate today = LocalDate.now();
 
@@ -173,8 +192,18 @@ public class RoomService {
             ? Set.of()
             : new HashSet<>(nudgeRepository.findToUserIdsByMissionAndFromUser(missionId, userId));
 
+    // 오늘 인증을 한 번에 로드해 멤버별 상태·달성 수를 애플리케이션에서 집계한다
+    // (멤버/인증 수와 무관하게 상수 쿼리).
+    List<RoomProof> todayProofs =
+        missionId == null ? List.of() : proofRepository.findWithUserByRoomMissionId(missionId);
+    Map<Long, ProofStatus> statusByUserId =
+        todayProofs.stream()
+            .collect(
+                Collectors.toMap(
+                    proof -> proof.getUser().getId(), RoomProof::getStatus, (first, dup) -> first));
+
     List<RoomMemberResponse> members =
-        memberRepository.findByRoomIdOrderByJoinedAtAsc(roomId).stream()
+        memberEntities.stream()
             .map(
                 member -> {
                   Long memberUserId = member.getUser().getId();
@@ -186,31 +215,22 @@ public class RoomService {
                       member.getRole(),
                       missionId == null
                           ? MemberTodayStatus.NONE
-                          : computeTodayStatus(missionId, memberUserId),
+                          : toTodayStatus(statusByUserId.get(memberUserId)),
                       memberUserId.equals(userId),
                       nudgedTargetIds.contains(memberUserId));
                 })
             .toList();
 
     int verifiedCount =
-        todayMission == null
-            ? 0
-            : (int)
-                proofRepository.countByRoomMissionIdAndStatus(
-                    todayMission.getId(), ProofStatus.VERIFIED);
+        (int) todayProofs.stream().filter(p -> p.getStatus() == ProofStatus.VERIFIED).count();
 
     List<RoomProofResponse> proofs =
         todayMission == null
             ? List.of()
-            : proofAssembler.buildAll(
-                proofRepository.findByRoomMissionIdOrderByCreatedAtDesc(todayMission.getId()),
-                requiredConfirm,
-                userId);
+            : proofAssembler.buildAll(todayProofs, requiredConfirm, userId);
 
     MemberTodayStatus myTodayStatus =
-        todayMission == null
-            ? MemberTodayStatus.NONE
-            : computeTodayStatus(todayMission.getId(), userId);
+        missionId == null ? MemberTodayStatus.NONE : toTodayStatus(statusByUserId.get(userId));
 
     return new RoomDetailResponse(
         room.getId(),
@@ -347,11 +367,23 @@ public class RoomService {
   }
 
   private MemberTodayStatus computeTodayStatus(Long roomMissionId, Long userId) {
-    Optional<RoomProof> proof = proofRepository.findByRoomMissionIdAndUserId(roomMissionId, userId);
-    if (proof.isEmpty()) return MemberTodayStatus.NONE;
-    return proof.get().getStatus() == ProofStatus.VERIFIED
-        ? MemberTodayStatus.DONE
-        : MemberTodayStatus.PENDING;
+    return proofRepository
+        .findByRoomMissionIdAndUserId(roomMissionId, userId)
+        .map(proof -> toTodayStatus(proof.getStatus()))
+        .orElse(MemberTodayStatus.NONE);
+  }
+
+  private static MemberTodayStatus toTodayStatus(ProofStatus status) {
+    if (status == null) return MemberTodayStatus.NONE;
+    return status == ProofStatus.VERIFIED ? MemberTodayStatus.DONE : MemberTodayStatus.PENDING;
+  }
+
+  private static Map<Long, Long> toCountMap(List<Object[]> rows) {
+    Map<Long, Long> result = new HashMap<>();
+    for (Object[] row : rows) {
+      result.put(((Number) row[0]).longValue(), ((Number) row[1]).longValue());
+    }
+    return result;
   }
 
   // 오늘(완료 시) 또는 어제부터 거꾸로 이어진 VERIFIED 달성 일수

--- a/backend/src/main/java/com/offmode/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/offmode/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.offmode.global.dto.response.ApiResponse;
 import com.offmode.global.status.ErrorStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
@@ -60,6 +61,14 @@ public class GlobalExceptionHandler {
   })
   public ResponseEntity<ApiResponse<?>> handleBadRequest(Exception e) {
     return ApiResponse.onFailure(ErrorStatus.BAD_REQUEST);
+  }
+
+  // check-then-save 경합으로 UNIQUE 제약에 걸린 경우 — 서버 오류(500)가 아니라 중복 요청(409)이다.
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<ApiResponse<?>> handleDataIntegrityViolation(
+      DataIntegrityViolationException e, HttpServletRequest request) {
+    log.warn("Data integrity violation on path={}: {}", request.getRequestURI(), e.getMessage());
+    return ApiResponse.onFailure(ErrorStatus.CONFLICT);
   }
 
   @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
+++ b/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
@@ -13,6 +13,7 @@ public enum ErrorStatus {
   BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
   FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
+  CONFLICT(HttpStatus.CONFLICT, "COMMON_409", "이미 처리된 요청입니다."),
   VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALID_400_001", "입력값이 올바르지 않습니다."),
 
   // Auth

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceConcurrencyTest.java
@@ -1,0 +1,176 @@
+package com.offmode.boundedcontext.feed.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.offmode.boundedcontext.badge.entity.UserBadge;
+import com.offmode.boundedcontext.badge.repository.UserBadgeRepository;
+import com.offmode.boundedcontext.feed.entity.Verification;
+import com.offmode.boundedcontext.feed.repository.VerificationConfirmRepository;
+import com.offmode.boundedcontext.feed.repository.VerificationRepository;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.status.ErrorStatus;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * 피드 피어 인증(confirm) 동시성 검증 — 임계치 도달 시 미션 VERIFIED 전환·레벨업·뱃지 수여가 정확히 한 번만 일어나야 한다.
+ *
+ * <p>스레드 간 커밋 가시성이 필요하므로 테스트에 @Transactional 을 붙이지 않는다.
+ */
+@ActiveProfiles("dev")
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:feed-concurrency-test;MODE=MySQL;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000",
+      "spring.jpa.hibernate.ddl-auto=validate",
+      "spring.flyway.locations=classpath:db/migration/h2",
+      "spring.sql.init.mode=never"
+    })
+class FeedServiceConcurrencyTest {
+
+  @Autowired private FeedService feedService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private UserMissionRepository userMissionRepository;
+  @Autowired private VerificationRepository verificationRepository;
+  @Autowired private VerificationConfirmRepository confirmRepository;
+  @Autowired private UserBadgeRepository userBadgeRepository;
+
+  @Test
+  void concurrentConfirmsFromTwoUsersVerifyMissionExactlyOnce() throws Exception {
+    // 임계치(1) 도달 confirm 이 동시에 2건 — 미션 전환·뱃지 수여는 한 번만, 예외 없음
+    Fixture f = createPendingVerification("feed-c1");
+
+    List<Throwable> errors =
+        runConcurrently(
+            () -> feedService.confirm(f.confirmerA.getId(), f.verification.getId()),
+            () -> feedService.confirm(f.confirmerB.getId(), f.verification.getId()));
+
+    assertThat(errors).isEmpty();
+    UserMission reloaded = userMissionRepository.findById(f.mission.getId()).orElseThrow();
+    assertThat(reloaded.getStatus()).isEqualTo(MissionStatus.VERIFIED);
+    assertThat(reloaded.getVerifiedAt()).isNotNull();
+    assertThat(confirmRepository.countByVerificationId(f.verification.getId())).isEqualTo(2);
+    assertBadgesNotDuplicated(f.owner.getId());
+  }
+
+  @Test
+  void concurrentDoubleTapFromSameUserSavesSingleConfirm() throws Exception {
+    // 같은 유저 동시 이중 탭 — 한쪽만 성공하고 다른 쪽은 409 계약(이미 인증)으로 떨어진다. 500 은 없어야 한다.
+    Fixture f = createPendingVerification("feed-c2");
+
+    List<Throwable> errors =
+        runConcurrently(
+            () -> feedService.confirm(f.confirmerA.getId(), f.verification.getId()),
+            () -> feedService.confirm(f.confirmerA.getId(), f.verification.getId()));
+
+    assertThat(errors)
+        .hasSize(1)
+        .allSatisfy(
+            error ->
+                assertThat(error)
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorStatus())
+                    .isEqualTo(ErrorStatus.VERIFICATION_ALREADY_CONFIRMED));
+    assertThat(confirmRepository.countByVerificationId(f.verification.getId())).isEqualTo(1);
+  }
+
+  @Test
+  void concurrentReactionTogglesDoNotFailWithUniqueViolation() throws Exception {
+    // 같은 이모지 동시 토글 — UNIQUE 위반 500 없이 직렬화된다
+    Fixture f = createPendingVerification("feed-c3");
+
+    List<Throwable> errors =
+        runConcurrently(
+            () -> feedService.react(f.confirmerA.getId(), f.verification.getId(), "🔥"),
+            () -> feedService.react(f.confirmerA.getId(), f.verification.getId(), "🔥"));
+
+    assertThat(errors).isEmpty();
+  }
+
+  // ===== 픽스처/헬퍼 =====
+
+  private record Fixture(
+      User owner,
+      User confirmerA,
+      User confirmerB,
+      UserMission mission,
+      Verification verification) {}
+
+  private Fixture createPendingVerification(String tag) {
+    User owner = saveUser(tag + "-owner");
+    User confirmerA = saveUser(tag + "-confirmer-a");
+    User confirmerB = saveUser(tag + "-confirmer-b");
+
+    UserMission mission =
+        userMissionRepository.save(
+            UserMission.builder()
+                .user(owner)
+                .missionIcon("🔥")
+                .missionText("산책하기 " + tag)
+                .missionCategory(MissionCategory.VITALITY)
+                .status(MissionStatus.PENDING)
+                .build());
+    Verification verification =
+        verificationRepository.save(
+            Verification.builder()
+                .userMission(mission)
+                .user(owner)
+                .photoUrl("/uploads/test.jpg")
+                .build());
+    return new Fixture(owner, confirmerA, confirmerB, mission, verification);
+  }
+
+  private User saveUser(String providerId) {
+    return userRepository.save(User.builder().provider("test").providerId(providerId).build());
+  }
+
+  private void assertBadgesNotDuplicated(Long userId) {
+    List<UserBadge> badges = userBadgeRepository.findByUserId(userId);
+    Set<String> distinctKeys =
+        badges.stream().map(UserBadge::getBadgeKey).collect(Collectors.toSet());
+    assertThat(badges).hasSameSizeAs(distinctKeys);
+  }
+
+  // 모든 작업을 같은 순간에 출발시키고, 각 스레드의 예외를 수집해 반환한다.
+  private List<Throwable> runConcurrently(Runnable... tasks) throws InterruptedException {
+    ExecutorService pool = Executors.newFixedThreadPool(tasks.length);
+    CountDownLatch ready = new CountDownLatch(tasks.length);
+    CountDownLatch start = new CountDownLatch(1);
+    List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+    for (Runnable task : tasks) {
+      pool.execute(
+          () -> {
+            ready.countDown();
+            try {
+              start.await();
+              task.run();
+            } catch (Throwable t) {
+              errors.add(t);
+            }
+          });
+    }
+    ready.await();
+    start.countDown();
+    pool.shutdown();
+    assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+    return errors;
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
@@ -84,7 +84,7 @@ class FeedServiceTest {
   void confirmRejectsSelfConfirm() {
     User owner = User.builder().id(1L).provider("kakao").providerId("owner").build();
     Verification verification = Verification.builder().id(20L).user(owner).build();
-    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(verificationRepository.findWithLockById(20L)).thenReturn(Optional.of(verification));
 
     assertThatThrownBy(() -> feedService.confirm(1L, 20L))
         .isInstanceOf(BusinessException.class)
@@ -105,7 +105,7 @@ class FeedServiceTest {
             .build();
     Verification verification =
         Verification.builder().id(20L).user(owner).userMission(mission).build();
-    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(verificationRepository.findWithLockById(20L)).thenReturn(Optional.of(verification));
     when(confirmRepository.existsByVerificationIdAndUserId(20L, 2L)).thenReturn(false);
     when(userService.getById(2L)).thenReturn(confirmer);
     when(confirmRepository.countByVerificationId(20L)).thenReturn(1L);
@@ -126,7 +126,7 @@ class FeedServiceTest {
     Verification verification = Verification.builder().id(20L).build();
     Reaction reaction =
         Reaction.builder().id(30L).verification(verification).user(user).emoji("🔥").build();
-    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(verificationRepository.findWithLockById(20L)).thenReturn(Optional.of(verification));
     when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of(reaction));
     when(reactionRepository.findRowsByVerificationId(20L)).thenReturn(List.of());
 
@@ -141,7 +141,7 @@ class FeedServiceTest {
     User viewer = User.builder().id(1L).provider("kakao").providerId("viewer").build();
     User reactor = User.builder().id(2L).provider("kakao").providerId("reactor").build();
     Verification verification = Verification.builder().id(20L).build();
-    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(verificationRepository.findWithLockById(20L)).thenReturn(Optional.of(verification));
     when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of());
     when(userService.getById(1L)).thenReturn(viewer);
     when(reactionRepository.findRowsByVerificationId(20L))
@@ -169,7 +169,7 @@ class FeedServiceTest {
     Verification verification = Verification.builder().id(20L).build();
     Reaction heart =
         Reaction.builder().id(30L).verification(verification).user(viewer).emoji("💜").build();
-    when(verificationRepository.findById(20L)).thenReturn(Optional.of(verification));
+    when(verificationRepository.findWithLockById(20L)).thenReturn(Optional.of(verification));
     when(reactionRepository.findByVerificationIdAndUserId(20L, 1L)).thenReturn(List.of(heart));
     when(userService.getById(1L)).thenReturn(viewer);
     when(reactionRepository.findRowsByVerificationId(20L))

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceConcurrencyTest.java
@@ -1,0 +1,193 @@
+package com.offmode.boundedcontext.room.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.offmode.boundedcontext.badge.entity.UserBadge;
+import com.offmode.boundedcontext.badge.repository.UserBadgeRepository;
+import com.offmode.boundedcontext.room.entity.Room;
+import com.offmode.boundedcontext.room.entity.RoomMember;
+import com.offmode.boundedcontext.room.entity.RoomMission;
+import com.offmode.boundedcontext.room.entity.RoomProof;
+import com.offmode.boundedcontext.room.repository.RoomMemberRepository;
+import com.offmode.boundedcontext.room.repository.RoomMissionRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofConfirmRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.repository.RoomRepository;
+import com.offmode.boundedcontext.room.types.MissionSource;
+import com.offmode.boundedcontext.room.types.ProofStatus;
+import com.offmode.boundedcontext.room.types.RoomIconKey;
+import com.offmode.boundedcontext.room.types.RoomRole;
+import com.offmode.boundedcontext.room.types.RoomType;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * 피어 인증(confirm) 동시성 검증 — 같은 인증에 동시에 confirm 이 몰려도 임계치 판정과 진급/뱃지 처리가 정확히 한 번만 일어나야 한다.
+ *
+ * <p>스레드 간 커밋 가시성이 필요하므로 테스트에 @Transactional 을 붙이지 않는다 (각 서비스 호출이 자체 트랜잭션으로 커밋된다).
+ */
+@ActiveProfiles("dev")
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:room-proof-concurrency-test;MODE=MySQL;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000",
+      "spring.jpa.hibernate.ddl-auto=validate",
+      "spring.flyway.locations=classpath:db/migration/h2",
+      "spring.sql.init.mode=never"
+    })
+class RoomProofServiceConcurrencyTest {
+
+  @Autowired private RoomProofService proofService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private RoomRepository roomRepository;
+  @Autowired private RoomMemberRepository memberRepository;
+  @Autowired private RoomMissionRepository missionRepository;
+  @Autowired private RoomProofRepository proofRepository;
+  @Autowired private RoomProofConfirmRepository confirmRepository;
+  @Autowired private UserBadgeRepository userBadgeRepository;
+
+  @Test
+  void concurrentConfirmsFromTwoMembersVerifyProofExactlyOnce() throws Exception {
+    // GROUP 방 3명(requiredConfirm=2) — 확인자 2명이 동시에 confirm 하면 정확히 한 번만 VERIFIED 전환
+    Fixture f = createGroupRoomWithProof("room-c1", 2);
+
+    List<Throwable> errors =
+        runConcurrently(
+            () -> proofService.confirm(f.confirmerA.getId(), f.room.getId(), f.proof.getId()),
+            () -> proofService.confirm(f.confirmerB.getId(), f.room.getId(), f.proof.getId()));
+
+    assertThat(errors).isEmpty();
+    RoomProof reloaded = proofRepository.findById(f.proof.getId()).orElseThrow();
+    assertThat(reloaded.getStatus()).isEqualTo(ProofStatus.VERIFIED);
+    assertThat(confirmRepository.countByRoomProofId(f.proof.getId())).isEqualTo(2);
+    assertBadgesNotDuplicated(f.uploader.getId());
+  }
+
+  @Test
+  void concurrentDoubleTapFromSameMemberStaysIdempotent() throws Exception {
+    // 같은 확인자의 동시 이중 탭 — 멱등 계약(에러 없음) 유지 + confirm 은 1건만 저장
+    Fixture f = createGroupRoomWithProof("room-c2", 2);
+
+    List<Throwable> errors =
+        runConcurrently(
+            () -> proofService.confirm(f.confirmerA.getId(), f.room.getId(), f.proof.getId()),
+            () -> proofService.confirm(f.confirmerA.getId(), f.room.getId(), f.proof.getId()));
+
+    assertThat(errors).isEmpty();
+    assertThat(confirmRepository.countByRoomProofId(f.proof.getId())).isEqualTo(1);
+    RoomProof reloaded = proofRepository.findById(f.proof.getId()).orElseThrow();
+    assertThat(reloaded.getStatus()).isEqualTo(ProofStatus.PENDING);
+  }
+
+  @Test
+  void concurrentReactionTogglesDoNotFailWithUniqueViolation() throws Exception {
+    // 같은 이모지 동시 토글 — UNIQUE 위반 500 없이 직렬화된다 (토글 2회 = 원상복귀 시맨틱)
+    Fixture f = createGroupRoomWithProof("room-c3", 2);
+
+    List<Throwable> errors =
+        runConcurrently(
+            () ->
+                proofService.toggleReaction(
+                    f.confirmerA.getId(), f.room.getId(), f.proof.getId(), "🔥"),
+            () ->
+                proofService.toggleReaction(
+                    f.confirmerA.getId(), f.room.getId(), f.proof.getId(), "🔥"));
+
+    assertThat(errors).isEmpty();
+  }
+
+  // ===== 픽스처/헬퍼 =====
+
+  private record Fixture(
+      User uploader, User confirmerA, User confirmerB, Room room, RoomProof proof) {}
+
+  private Fixture createGroupRoomWithProof(String tag, int requiredConfirm) {
+    User uploader = saveUser(tag + "-uploader");
+    User confirmerA = saveUser(tag + "-confirmer-a");
+    User confirmerB = saveUser(tag + "-confirmer-b");
+
+    Room room =
+        roomRepository.save(
+            Room.builder()
+                .name("동시성 테스트 방")
+                .iconKey(RoomIconKey.FIRE)
+                .type(RoomType.GROUP)
+                .build());
+    memberRepository.save(
+        RoomMember.builder().room(room).user(uploader).role(RoomRole.OWNER).build());
+    memberRepository.save(
+        RoomMember.builder().room(room).user(confirmerA).role(RoomRole.MEMBER).build());
+    memberRepository.save(
+        RoomMember.builder().room(room).user(confirmerB).role(RoomRole.MEMBER).build());
+
+    RoomMission mission =
+        missionRepository.save(
+            RoomMission.builder()
+                .room(room)
+                .date(LocalDate.now())
+                .title("산책하기")
+                .icon("🔥")
+                .source(MissionSource.DIRECT)
+                .build());
+    RoomProof proof =
+        proofRepository.save(
+            RoomProof.builder()
+                .roomMission(mission)
+                .user(uploader)
+                .photoUrl("/uploads/test.jpg")
+                .status(ProofStatus.PENDING)
+                .build());
+    return new Fixture(uploader, confirmerA, confirmerB, room, proof);
+  }
+
+  private User saveUser(String providerId) {
+    return userRepository.save(User.builder().provider("test").providerId(providerId).build());
+  }
+
+  private void assertBadgesNotDuplicated(Long userId) {
+    List<UserBadge> badges = userBadgeRepository.findByUserId(userId);
+    Set<String> distinctKeys =
+        badges.stream().map(UserBadge::getBadgeKey).collect(Collectors.toSet());
+    assertThat(badges).hasSameSizeAs(distinctKeys);
+  }
+
+  // 모든 작업을 같은 순간에 출발시키고, 각 스레드의 예외를 수집해 반환한다.
+  private List<Throwable> runConcurrently(Runnable... tasks) throws InterruptedException {
+    ExecutorService pool = Executors.newFixedThreadPool(tasks.length);
+    CountDownLatch ready = new CountDownLatch(tasks.length);
+    CountDownLatch start = new CountDownLatch(1);
+    List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+    for (Runnable task : tasks) {
+      pool.execute(
+          () -> {
+            ready.countDown();
+            try {
+              start.await();
+              task.run();
+            } catch (Throwable t) {
+              errors.add(t);
+            }
+          });
+    }
+    ready.await();
+    start.countDown();
+    pool.shutdown();
+    assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+    return errors;
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceTest.java
@@ -77,7 +77,7 @@ class RoomProofServiceTest {
     RoomProof proof = proofOf(100L, 2L, 1L, ProofStatus.PENDING);
     when(roomService.getRoomOrThrow(2L)).thenReturn(room);
     when(roomService.getMembershipOrThrow(2L, 1L)).thenReturn(new RoomMember());
-    when(proofRepository.findById(100L)).thenReturn(Optional.of(proof));
+    when(proofRepository.findWithLockById(100L)).thenReturn(Optional.of(proof));
 
     assertThatThrownBy(() -> service().confirm(1L, 2L, 100L))
         .isInstanceOf(BusinessException.class)
@@ -91,7 +91,7 @@ class RoomProofServiceTest {
     User confirmer = User.builder().id(1L).provider("kakao").providerId("c").build();
     when(roomService.getRoomOrThrow(2L)).thenReturn(room);
     when(roomService.getMembershipOrThrow(2L, 1L)).thenReturn(new RoomMember());
-    when(proofRepository.findById(100L)).thenReturn(Optional.of(proof));
+    when(proofRepository.findWithLockById(100L)).thenReturn(Optional.of(proof));
     when(roomService.getMemberCount(2L)).thenReturn(4L);
     when(roomService.requiredConfirm(RoomType.GROUP, 4)).thenReturn(3);
     when(confirmRepository.existsByRoomProofIdAndUserId(100L, 1L)).thenReturn(false);
@@ -116,7 +116,7 @@ class RoomProofServiceTest {
     RoomProof proof = proofOf(100L, 2L, 9L, ProofStatus.PENDING);
     when(roomService.getRoomOrThrow(2L)).thenReturn(room);
     when(roomService.getMembershipOrThrow(2L, 1L)).thenReturn(new RoomMember());
-    when(proofRepository.findById(100L)).thenReturn(Optional.of(proof));
+    when(proofRepository.findWithLockById(100L)).thenReturn(Optional.of(proof));
     when(roomService.getMemberCount(2L)).thenReturn(4L);
     when(roomService.requiredConfirm(RoomType.GROUP, 4)).thenReturn(3);
     when(confirmRepository.existsByRoomProofIdAndUserId(100L, 1L)).thenReturn(true);

--- a/backend/src/test/java/com/offmode/global/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/offmode/global/exception/GlobalExceptionHandlerTest.java
@@ -41,6 +41,21 @@ class GlobalExceptionHandlerTest {
   }
 
   @Test
+  void dataIntegrityViolationReturnsConflict() {
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/api/v1/rooms/1/proofs/2/confirm");
+
+    ResponseEntity<ApiResponse<?>> response =
+        handler.handleDataIntegrityViolation(
+            new org.springframework.dao.DataIntegrityViolationException("duplicate key"), request);
+
+    assertThat(response.getStatusCode()).isEqualTo(ErrorStatus.CONFLICT.getHttpStatus());
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getCode()).isEqualTo("COMMON_409");
+    assertThat(response.getBody().getMessage()).isEqualTo("이미 처리된 요청입니다.");
+  }
+
+  @Test
   void typeMismatchReturnsValidationError() {
     MethodArgumentTypeMismatchException exception =
         new MethodArgumentTypeMismatchException("abc", Long.class, "id", null, null);


### PR DESCRIPTION
## 🔗 Issue

- close #138

---

## 📌 Summary

- **confirm 이중 실행 차단**: `FeedService.confirm` / `RoomProofService.confirm`(+리액션 토글)의 대상 조회를 `@Lock(PESSIMISTIC_WRITE)` 행 락 조회(`findWithLockById`)로 교체. 같은 인증에 대한 동시 요청이 직렬화되어 count 기반 임계치 판정의 이중 통과(이중 레벨업·이중 뱃지 → `uk_user_badges` 위반 500)와 check-then-save 경합의 UNIQUE 위반 500이 모두 차단됨. 기존 계약 유지(Feed 중복 confirm은 409, Room 중복 confirm은 멱등 반환)
- **DIVE 전역 방어선**: `DataIntegrityViolationException` → `COMMON_409` "이미 처리된 요청입니다." 매핑 추가 (잔여 check-then-save 경로가 경합해도 500 대신 409)
- **RoomService N+1 제거**: `getMyRooms`(방 N개 × 3쿼리), `getDetail`(멤버 M명 × 2쿼리), `RoomProofAssembler.buildAll`(인증 P건 × 3쿼리)을 `FeedService.getFeed`의 IN 배치 조회 패턴으로 전환해 상수 쿼리화. 배치용 리포지토리 메서드 6종 신설, 기존 메서드는 다른 호출처가 있어 유지
- 스키마 변경 없음 (필요한 UNIQUE 제약은 V1/V6에 이미 존재) — Flyway 마이그레이션 불필요

---

## ✅ Test

- [x] `./gradlew spotlessCheck && ./gradlew test && ./gradlew build -x test` 전체 통과 (CI 로컬 재현)
- [x] 동시성 통합테스트 신설: `RoomProofServiceConcurrencyTest` / `FeedServiceConcurrencyTest` — `@SpringBootTest` + H2 + `CountDownLatch` 동시 출발로 6케이스 검증 (동시 confirm 시 VERIFIED 1회 전환·confirm 2건 저장·뱃지 중복 없음 / 같은 유저 이중 탭 멱등·409 계약 / 동시 리액션 토글 UNIQUE 위반 없음)
- [x] 기존 단위테스트 stub 갱신 (`findById` → `findWithLockById`) + `GlobalExceptionHandlerTest` DIVE→409 케이스 추가