### PR TITLE
[Refactor] #141 App.jsx 인증/룰렛 훅 분리, 공통 모듈 추출, api.js 401 처리

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -61,9 +61,10 @@ if (!__DEV__ && Platform.OS === 'ios') {
     });
   }
 }
-import { signInWithApple, signInWithKakao } from './utils/auth';
-import { api, loadToken, clearToken } from './utils/api';
-import { scheduleMissionNotification, cancelMissionNotification } from './utils/notifications';
+import { api } from './utils/api';
+import { scheduleMissionNotification } from './utils/notifications';
+import useAuth from './utils/useAuth';
+import useMissionRouletteTrigger from './utils/useMissionRouletteTrigger';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
@@ -80,38 +81,6 @@ function PagerBottomInset() {
 function AppInner() {
   const { colors: C, scheme } = useTheme();
 
-  // ── 인증 상태: 'loading' | 'unauthenticated' | 'signingUp' | 'authenticated'
-  const [authStatus, setAuthStatus] = useState('loading');
-  const [authUser,   setAuthUser]   = useState(null);
-  const [loginLoading, setLoginLoading] = useState(false);
-  const [loginError, setLoginError] = useState('');
-
-  useEffect(() => {
-    loadToken().then(async (token) => {
-      if (token) {
-        try {
-          const user = await api.get('/api/v1/users/me');
-          setProfile({ name: user.name ?? '오프모더', avatar: user.avatar ?? '01' });
-          const hour   = user.missionHour   ?? 8;
-          const minute = user.missionMinute ?? 0;
-          if (user.missionHour != null) setMissionTime({ hour, minute });
-          if (user.autoRoulette != null) setAutoRoulette(user.autoRoulette);
-          await loadTodayMission();
-          scheduleMissionNotification(hour, minute);
-          setAuthStatus('authenticated');
-        } catch (e) {
-          console.warn('자동 로그인 실패:', e);
-          setAuthStatus('unauthenticated');
-        }
-      } else {
-        setAuthStatus('unauthenticated');
-      }
-    }).catch((e) => {
-      console.warn('자동 로그인 토큰 로드 실패:', e);
-      setAuthStatus('unauthenticated');
-    });
-  }, []);
-
   const [tab, setTab]                           = useState('mission');
   const [stack, setStack]                       = useState([]);
   const [missionTime, setMissionTime]           = useState({ hour: 8, minute: 0 });
@@ -123,7 +92,6 @@ function AppInner() {
   const [autoRoulette, setAutoRoulette]         = useState(true);
   const [profile, setProfile]                   = useState({ name: '오프모더', avatar: '01' });
   const [roomVersion, setRoomVersion]           = useState(0);
-  const lastTriggeredRef = useRef(null);
   const celebratedRoomsRef = useRef(new Set());
 
   // 방 데이터 변경(생성/참여/나가기/미션/인증) 후 목록·상세 새로고침 트리거
@@ -149,76 +117,31 @@ function AppInner() {
     }
   };
 
-  const handleKakaoLogin = async () => {
-    setLoginLoading(true);
-    setLoginError('');
-    try {
-      const { user, isNew } = await signInWithKakao();
-      setAuthUser(user);
-      if (!isNew) {
-        setProfile({ name: user.name ?? '오프모더', avatar: user.avatar ?? '01' });
-        const hour   = user.missionHour   ?? 8;
-        const minute = user.missionMinute ?? 0;
-        if (user.missionHour != null) setMissionTime({ hour, minute });
-        if (user.autoRoulette != null) setAutoRoulette(user.autoRoulette);
-        await loadTodayMission();
-        scheduleMissionNotification(hour, minute);
-      }
-      setAuthStatus(isNew ? 'signingUp' : 'authenticated');
-    } catch (e) {
-      console.warn(e);
-      setLoginError(e?.message || '카카오 로그인에 실패했습니다.');
-    } finally {
-      setLoginLoading(false);
-    }
+  // 로그인/자동 로그인 성공 시 공통 후처리 — 프로필·미션시간·오늘미션·알림 예약
+  const applySession = async (user) => {
+    setProfile({ name: user.name ?? '오프모더', avatar: user.avatar ?? '01' });
+    const hour   = user.missionHour   ?? 8;
+    const minute = user.missionMinute ?? 0;
+    if (user.missionHour != null) setMissionTime({ hour, minute });
+    if (user.autoRoulette != null) setAutoRoulette(user.autoRoulette);
+    await loadTodayMission();
+    scheduleMissionNotification(hour, minute);
   };
 
-  const handleAppleLogin = async () => {
-    setLoginLoading(true);
-    setLoginError('');
-    try {
-      const { user, isNew } = await signInWithApple();
-      setAuthUser(user);
-      if (!isNew) {
-        setProfile({ name: user.name ?? '오프모더', avatar: user.avatar ?? '01' });
-        const hour   = user.missionHour   ?? 8;
-        const minute = user.missionMinute ?? 0;
-        if (user.missionHour != null) setMissionTime({ hour, minute });
-        if (user.autoRoulette != null) setAutoRoulette(user.autoRoulette);
-        await loadTodayMission();
-        scheduleMissionNotification(hour, minute);
-      }
-      setAuthStatus(isNew ? 'signingUp' : 'authenticated');
-    } catch (e) {
-      if (e?.code !== 'ERR_CANCELED') {
-        console.warn(e);
-        setLoginError(e?.message || 'Apple 로그인에 실패했습니다.');
-      }
-    } finally {
-      setLoginLoading(false);
-    }
-  };
-
-  const handleLogout = async () => {
-    await cancelMissionNotification();
-    await clearToken();
-    setAuthUser(null);
+  // 로그아웃 시 세션 상태 초기화
+  const resetSession = () => {
     setProfile({ name: '오프모더', avatar: '01' });
     setMissionTime({ hour: 8, minute: 0 });
     setHasMission(false);
     setCurrentMission(null);
     setCurrentMissionId(null);
-    setAuthStatus('unauthenticated');
   };
 
-  const handleDeleteAccount = async () => {
-    try {
-      await api.delete('/api/v1/users/me');
-    } catch (e) {
-      console.warn('회원탈퇴 실패:', e);
-    }
-    await handleLogout();
-  };
+  // ── 인증 상태: 'loading' | 'unauthenticated' | 'signingUp' | 'authenticated'
+  const {
+    authStatus, setAuthStatus, authUser, loginLoading, loginError,
+    handleKakaoLogin, handleAppleLogin, handleLogout, handleDeleteAccount,
+  } = useAuth({ applySession, resetSession });
 
   const handleSignupComplete = async (profileData) => {
     const { name, avatar, missionTime: mt } = profileData;
@@ -259,23 +182,10 @@ function AppInner() {
 
   /* ── 설정 시간 감지 → 룰렛 표시 ──
      정책: 오늘 미션이 이미 있으면 시간을 바꿔도 룰렛을 다시 띄우지 않음 */
-  useEffect(() => {
-    const id = setInterval(() => {
-      const now = new Date();
-      const key = `${now.getHours()}:${now.getMinutes()}`;
-      if (
-        now.getHours()   === missionTime.hour &&
-        now.getMinutes() === missionTime.minute &&
-        lastTriggeredRef.current !== key &&
-        !hasMission   // 오늘 미션이 없을 때만 룰렛 트리거
-      ) {
-        lastTriggeredRef.current = key;
-        setShowRoulette(true);
-        setTab('mission');
-      }
-    }, 1000);
-    return () => clearInterval(id);
-  }, [missionTime, hasMission]);
+  useMissionRouletteTrigger(missionTime, hasMission, () => {
+    setShowRoulette(true);
+    setTab('mission');
+  });
 
   /* ── 최상위 3페이지 좌우 스와이프 (Mission | Profile | Settings) ──
      세로 스크롤과 충돌하지 않도록 수평 우세 제스처만 캡처 (ProfileScreen 기존 방식 확장) */

--- a/components/AvatarImage.jsx
+++ b/components/AvatarImage.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { View, Image } from 'react-native';
+
+/** 아바타 얼굴 이미지 렌더러 — source가 없으면 같은 크기의 빈 자리 유지 */
+export default function AvatarImage({ source, width = 72, height = 72 }) {
+  if (!source) return <View style={{ width, height }} />;
+  return <Image source={source} style={{ width, height }} resizeMode="contain" />;
+}

--- a/components/WheelPicker.jsx
+++ b/components/WheelPicker.jsx
@@ -1,0 +1,90 @@
+import React, { useRef, useEffect, useCallback } from 'react';
+import { View, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export const ITEM_H = 60;
+export const VISIBLE = 3;
+export const PICKER_H = ITEM_H * VISIBLE;
+
+/**
+ * 스크롤-스냅 휠 피커 (시간 선택용).
+ *
+ * @param items          표시할 값 배열 (예: 시/분 숫자)
+ * @param selectedIndex  현재 선택된 인덱스
+ * @param onChange       (index) => void — 스냅/탭으로 선택이 바뀔 때 호출
+ * @param colors         { surface, greenBorder, greenFaint } 색 토큰 객체 (useColors() 결과 또는 W)
+ * @param renderLabel    (val, selected) => node — 항목 텍스트 렌더러 (화면별 폰트/크기/색 결정)
+ */
+export default function WheelPicker({ items, selectedIndex, onChange, colors, renderLabel }) {
+  const scrollRef          = useRef(null);
+  const isProgrammatic     = useRef(false);
+  const selectedIndexRef   = useRef(selectedIndex);
+  selectedIndexRef.current = selectedIndex; // 매 렌더마다 최신값 유지
+
+  // selectedIndex 변경 시 스크롤 위치 동기화
+  useEffect(() => {
+    isProgrammatic.current = true;
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ y: selectedIndex * ITEM_H, animated: false });
+      requestAnimationFrame(() => { isProgrammatic.current = false; });
+    });
+  }, [selectedIndex]);
+
+  // 초기 레이아웃 완료 후 위치 설정 (ref로 최신값 참조 → stale closure 방지)
+  const onLayout = useCallback(() => {
+    isProgrammatic.current = true;
+    scrollRef.current?.scrollTo({ y: selectedIndexRef.current * ITEM_H, animated: false });
+    requestAnimationFrame(() => { isProgrammatic.current = false; });
+  }, []);
+
+  // 사용자가 직접 스크롤했을 때만 onChange 호출
+  const handleMomentumEnd = useCallback((e) => {
+    if (isProgrammatic.current) return;
+    const idx = Math.round(e.nativeEvent.contentOffset.y / ITEM_H);
+    const clamped = Math.max(0, Math.min(idx, items.length - 1));
+    if (clamped !== selectedIndex) onChange(clamped);
+  }, [items.length, selectedIndex, onChange]);
+
+  return (
+    <View style={s.wrap}>
+      <View
+        style={[s.highlight, { borderColor: colors.greenBorder, backgroundColor: colors.greenFaint }]}
+        pointerEvents="none"
+      />
+      <LinearGradient colors={[colors.surface, colors.surface + '00']} style={[s.fade, { top: 0 }]}    pointerEvents="none" />
+      <LinearGradient colors={[colors.surface + '00', colors.surface]} style={[s.fade, { bottom: 0 }]} pointerEvents="none" />
+      <ScrollView
+        ref={scrollRef}
+        style={{ height: PICKER_H, width: '100%' }}
+        contentContainerStyle={{ paddingVertical: ITEM_H * 1 }}
+        showsVerticalScrollIndicator={false}
+        snapToInterval={ITEM_H}
+        decelerationRate="fast"
+        onMomentumScrollEnd={handleMomentumEnd}
+        onLayout={onLayout}
+        scrollEventThrottle={16}
+      >
+        {items.map((val, i) => (
+          <TouchableOpacity
+            key={i}
+            style={s.item}
+            activeOpacity={0.6}
+            onPress={() => onChange(i)}
+          >
+            {renderLabel(val, i === selectedIndex)}
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  wrap: { flex: 1, position: 'relative', overflow: 'hidden', height: PICKER_H },
+  highlight: {
+    position: 'absolute', top: ITEM_H * 1, left: 0, right: 0, height: ITEM_H,
+    borderTopWidth: 1, borderBottomWidth: 1, zIndex: 1, borderRadius: 8,
+  },
+  fade: { position: 'absolute', left: 0, right: 0, height: ITEM_H * 1.0, zIndex: 2 },
+  item: { height: ITEM_H, alignItems: 'center', justifyContent: 'center' },
+});

--- a/screens/MissionTimeScreen.jsx
+++ b/screens/MissionTimeScreen.jsx
@@ -1,18 +1,16 @@
-import React, { useState, useRef, useCallback, useMemo, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   View, Text, StyleSheet, TouchableOpacity,
-  ScrollView, Dimensions, Animated,
+  ScrollView, Dimensions,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useColors } from '../utils/useColors';
 import T from '../components/ThemedText';
+import WheelPicker from '../components/WheelPicker';
+import { pad } from '../utils/date';
 
 const F = 'Kkukkukk';
 const { width } = Dimensions.get('window');
-
-const ITEM_H  = 60;
-const VISIBLE = 3;
-const PICKER_H = ITEM_H * VISIBLE;
 
 const HOURS   = Array.from({ length: 24 }, (_, i) => i);
 const MINUTES = Array.from({ length: 12 }, (_, i) => i * 5); // 5분 단위
@@ -26,7 +24,6 @@ const PRESETS = [
   { label: '자정 전',  time: { h: 23, m: 0 } },
 ];
 
-function pad(n) { return String(n).padStart(2, '0'); }
 function ampmLabel(h) {
   if (h < 6)  return '새벽';
   if (h < 12) return '오전';
@@ -34,93 +31,21 @@ function ampmLabel(h) {
   return '밤';
 }
 
-function WheelPicker({ items, selectedIndex, onChange }) {
-  const C = useColors();
-  const wheel = useMemo(() => makeWheelStyles(C), [C]);
-  const scrollRef           = useRef(null);
-  const isProgrammatic      = useRef(false);
-  const selectedIndexRef    = useRef(selectedIndex);
-  selectedIndexRef.current  = selectedIndex; // 매 렌더마다 최신값 유지
-
-  // selectedIndex 변경 시 스크롤 위치 동기화
-  useEffect(() => {
-    isProgrammatic.current = true;
-    requestAnimationFrame(() => {
-      scrollRef.current?.scrollTo({ y: selectedIndex * ITEM_H, animated: false });
-      requestAnimationFrame(() => { isProgrammatic.current = false; });
-    });
-  }, [selectedIndex]);
-
-  // 초기 레이아웃 완료 후 위치 설정 (ref로 최신값 참조 → stale closure 방지)
-  const onLayout = useCallback(() => {
-    isProgrammatic.current = true;
-    scrollRef.current?.scrollTo({ y: selectedIndexRef.current * ITEM_H, animated: false });
-    requestAnimationFrame(() => { isProgrammatic.current = false; });
-  }, []);
-
-  // 사용자가 직접 스크롤했을 때만 onChange 호출
-  const handleMomentumEnd = useCallback((e) => {
-    if (isProgrammatic.current) return;
-    const idx = Math.round(e.nativeEvent.contentOffset.y / ITEM_H);
-    const clamped = Math.max(0, Math.min(idx, items.length - 1));
-    if (clamped !== selectedIndex) onChange(clamped);
-  }, [items.length, selectedIndex, onChange]);
-
-  return (
-    <View style={wheel.wrap}>
-      <View style={wheel.highlight} pointerEvents="none" />
-      <LinearGradient colors={[C.surface, C.surface + '00']} style={[wheel.fade, { top: 0 }]}    pointerEvents="none" />
-      <LinearGradient colors={[C.surface + '00', C.surface]} style={[wheel.fade, { bottom: 0 }]} pointerEvents="none" />
-      <ScrollView
-        ref={scrollRef}
-        style={{ height: PICKER_H, width: '100%' }}
-        contentContainerStyle={{ paddingVertical: ITEM_H * 1 }}
-        showsVerticalScrollIndicator={false}
-        snapToInterval={ITEM_H}
-        decelerationRate="fast"
-        onMomentumScrollEnd={handleMomentumEnd}
-        onLayout={onLayout}
-        scrollEventThrottle={16}
-      >
-        {items.map((val, i) => (
-          <TouchableOpacity
-            key={i}
-            style={wheel.item}
-            activeOpacity={0.6}
-            onPress={() => onChange(i)}
-          >
-            <T
-              v="sub"
-              size={i === selectedIndex ? 34 : 28}
-              color={i === selectedIndex ? C.text : (C.isDark ? C.textSub : C.green)}
-              style={{ opacity: i === selectedIndex ? 1 : 0.4 }}
-            >
-              {pad(val)}
-            </T>
-          </TouchableOpacity>
-        ))}
-      </ScrollView>
-    </View>
-  );
-}
-
-function makeWheelStyles(C) {
-  return StyleSheet.create({
-    wrap: { flex: 1, position: 'relative', overflow: 'hidden', height: PICKER_H },
-    highlight: {
-      position: 'absolute', top: ITEM_H * 1, left: 0, right: 0, height: ITEM_H,
-      borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.greenBorder,
-      backgroundColor: C.greenFaint, zIndex: 1, borderRadius: 8,
-    },
-    fade: { position: 'absolute', left: 0, right: 0, height: ITEM_H * 1.0, zIndex: 2 },
-    item: { height: ITEM_H, alignItems: 'center', justifyContent: 'center' },
-    itemTextSelected: { color: C.text, opacity: 1, fontSize: 34 },
-  });
-}
-
 export default function MissionTimeScreen({ onBack, onSave, initialTime = { hour: 8, minute: 0 } }) {
   const C = useColors();
   const styles = useMemo(() => makeStyles(C), [C]);
+
+  // 공용 WheelPicker 항목 텍스트 (기존 이 화면 전용 렌더링 그대로)
+  const renderWheelLabel = (val, selected) => (
+    <T
+      v="sub"
+      size={selected ? 34 : 28}
+      color={selected ? C.text : (C.isDark ? C.textSub : C.green)}
+      style={{ opacity: selected ? 1 : 0.4 }}
+    >
+      {pad(val)}
+    </T>
+  );
 
   const [hourIdx,   setHourIdx]   = useState(initialTime.hour);
   const [minuteIdx, setMinuteIdx] = useState(Math.round(initialTime.minute / 5));
@@ -156,12 +81,12 @@ export default function MissionTimeScreen({ onBack, onSave, initialTime = { hour
         <View style={styles.pickerRow}>
           <View style={styles.pickerBlock}>
             <T v="sub" style={{ marginBottom: 8, textAlign: 'center' }}>시</T>
-            <WheelPicker items={HOURS}   selectedIndex={hourIdx}   onChange={setHourIdx} />
+            <WheelPicker items={HOURS}   selectedIndex={hourIdx}   onChange={setHourIdx}   colors={C} renderLabel={renderWheelLabel} />
           </View>
           <T v="sub" size={36} style={{ marginTop: 16, paddingHorizontal: 8, opacity: 0.5 }}>:</T>
           <View style={styles.pickerBlock}>
             <T v="sub" style={{ marginBottom: 8, textAlign: 'center' }}>분</T>
-            <WheelPicker items={MINUTES} selectedIndex={minuteIdx} onChange={setMinuteIdx} />
+            <WheelPicker items={MINUTES} selectedIndex={minuteIdx} onChange={setMinuteIdx} colors={C} renderLabel={renderWheelLabel} />
           </View>
         </View>
 

--- a/screens/ProfileScreen.jsx
+++ b/screens/ProfileScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import {
-  View, Image, StyleSheet, ScrollView, RefreshControl, TouchableOpacity,
+  View, StyleSheet, ScrollView, RefreshControl, TouchableOpacity,
   Modal, TextInput, Keyboard, ActivityIndicator, Alert,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -14,6 +14,8 @@ import * as H from '../utils/haptics';
 import CharacterDecor from '../components/CharacterDecor';
 import { PARTS, isPartUnlocked, getCharacterSource } from '../constants/parts';
 import { usePagerBottomBarHeight } from '../components/PageIndicator';
+import AvatarImage from '../components/AvatarImage';
+import { pad } from '../utils/date';
 
 /**
  * GET /api/v1/parts/me 응답을 정적 카탈로그(PARTS)와 key로 병합.
@@ -45,8 +47,7 @@ function parseLocalDT(val) {
   return new Date(val);
 }
 
-function pad2(n) { return String(n).padStart(2, '0'); }
-function ymd(d) { return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`; }
+function ymd(d) { return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`; }
 
 function getMondayOfWeek(date) {
   const d = new Date(date);
@@ -59,7 +60,7 @@ function getMondayOfWeek(date) {
 function formatJoinDate(val) {
   const dt = parseLocalDT(val);
   if (!dt) return '';
-  return `${dt.getFullYear()}.${pad2(dt.getMonth() + 1)}.${pad2(dt.getDate())} 합류`;
+  return `${dt.getFullYear()}.${pad(dt.getMonth() + 1)}.${pad(dt.getDate())} 합류`;
 }
 
 /** 인증 히스토리 → 주간 활동용 최소 형태 */
@@ -94,12 +95,6 @@ function computeWeekData(history, joinDate) {
     else status = 'missed';                                  // 과거 + 가입 후 + 기록 없음 → 놓침
     return { day, status };
   });
-}
-
-/* ── 아바타 얼굴 이미지 렌더러 ───────────────────────── */
-function AvatarImage({ source, width = 72, height = 72 }) {
-  if (!source) return <View style={{ width, height }} />;
-  return <Image source={source} style={{ width, height }} resizeMode="contain" />;
 }
 
 /* ── 이번 주 활동 (웜) ───────────────────────────────── */

--- a/screens/ProofDetailScreen.jsx
+++ b/screens/ProofDetailScreen.jsx
@@ -10,6 +10,7 @@ import {
   RoomTopBar, MemberAvatar, ReactionBar, ProofStatusBadge, OutlineButton,
 } from '../components/RoomBits';
 import ReportReasonModal from '../components/ReportReasonModal';
+import { pad } from '../utils/date';
 
 function resolvePhoto(url) {
   if (!url) return null;
@@ -22,8 +23,7 @@ function timeLabel(createdAt) {
     ? new Date(createdAt[0], (createdAt[1] || 1) - 1, createdAt[2] || 1, createdAt[3] || 0, createdAt[4] || 0)
     : new Date(createdAt);
   if (isNaN(d.getTime())) return '';
-  const p = (n) => String(n).padStart(2, '0');
-  return `${p(d.getHours())}:${p(d.getMinutes())}`;
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
 export default function ProofDetailScreen({ roomId, proofId, missionTitle, isGroup = true, onBack, onChanged }) {

--- a/screens/RoomDetailScreen.jsx
+++ b/screens/RoomDetailScreen.jsx
@@ -12,6 +12,7 @@ import {
   ReactionBar, NudgeChip,
 } from '../components/RoomBits';
 import { roomIconEmoji } from '../constants/rooms';
+import { pad } from '../utils/date';
 
 function resolvePhoto(url) {
   if (!url) return null;
@@ -24,8 +25,7 @@ function timeLabel(createdAt) {
     ? new Date(createdAt[0], (createdAt[1] || 1) - 1, createdAt[2] || 1, createdAt[3] || 0, createdAt[4] || 0)
     : new Date(createdAt);
   if (isNaN(d.getTime())) return '';
-  const p = (n) => String(n).padStart(2, '0');
-  return `${p(d.getHours())}:${p(d.getMinutes())}`;
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
 function reactionTotal(proof) {

--- a/screens/RoomHistoryScreen.jsx
+++ b/screens/RoomHistoryScreen.jsx
@@ -8,6 +8,7 @@ import { api, BASE_URL } from '../utils/api';
 import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
 import { RoomTopBar, MemberAvatar, ProofStatusBadge, OutlineButton } from '../components/RoomBits';
+import { pad } from '../utils/date';
 
 const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -16,8 +17,7 @@ function resolvePhoto(url) {
   return url.startsWith('/') ? `${BASE_URL}${url}` : url;
 }
 
-function pad2(n) { return String(n).padStart(2, '0'); }
-function monthKey(d) { return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}`; }
+function monthKey(d) { return `${d.getFullYear()}-${pad(d.getMonth() + 1)}`; }
 function parseDate(str) {
   if (!str) return null;
   const [y, m, day] = String(str).split('-').map(Number);

--- a/screens/RoomVerifyScreen.jsx
+++ b/screens/RoomVerifyScreen.jsx
@@ -11,10 +11,10 @@ import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
 import { RoomTopBar, GreenButton } from '../components/RoomBits';
 import { roomIconEmoji } from '../constants/rooms';
+import { pad } from '../utils/date';
 
 const F = 'GmarketSansLight';
 
-function pad(n) { return String(n).padStart(2, '0'); }
 function nowLabel() {
   const d = new Date();
   return `${d.getFullYear()}.${pad(d.getMonth() + 1)}.${pad(d.getDate())}  ${pad(d.getHours())}:${pad(d.getMinutes())}`;

--- a/screens/SettingsScreen.jsx
+++ b/screens/SettingsScreen.jsx
@@ -13,6 +13,7 @@ import {
   scheduleReminderNotification, cancelReminderNotification,
 } from '../utils/notifications';
 import { usePagerBottomBarHeight } from '../components/PageIndicator';
+import { pad } from '../utils/date';
 
 const openLink = (url) =>
   Linking.openURL(url).catch(() =>
@@ -109,7 +110,6 @@ export default function SettingsScreen({
   const s = useMemo(() => makeStyles(C), [C]);
   const pagerBottom = usePagerBottomBarHeight(); // 플로팅 인디케이터+인셋 높이
 
-  const pad = (n) => String(n).padStart(2, '0');
   const { hour = 8, minute = 0 } = missionTime ?? {};
   const timeLabel = `${pad(hour)}:${pad(minute)}`;
 

--- a/screens/SignupScreen.jsx
+++ b/screens/SignupScreen.jsx
@@ -1,15 +1,17 @@
-import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
-  View, Image, StyleSheet, TouchableOpacity,
+  View, StyleSheet, TouchableOpacity,
   TextInput, Keyboard, ScrollView, Dimensions, KeyboardAvoidingView, Platform,
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
 import T from '../components/WarmText';
 import { W } from '../constants/warm';
 import PageIndicator from '../components/PageIndicator';
 import { GreenButton } from '../components/RoomBits';
 import * as H from '../utils/haptics';
 import { AVATAR_IDS, getAvatarDefaultSource } from '../utils/avatars';
+import AvatarImage from '../components/AvatarImage';
+import WheelPicker from '../components/WheelPicker';
+import { pad } from '../utils/date';
 
 const GL = 'GmarketSansLight';
 const { width } = Dimensions.get('window');
@@ -17,16 +19,7 @@ const { width } = Dimensions.get('window');
 // Figma(59:27) 프로필 설정 화면 — 아바타 얼굴 5종
 const PICKER_IDS = AVATAR_IDS;
 
-// ── 아바타 얼굴 이미지 렌더러 ──────────────────────────────
-function AvatarImage({ source, width = 80, height = 80 }) {
-  if (!source) return <View style={{ width, height }} />;
-  return <Image source={source} style={{ width, height }} resizeMode="contain" />;
-}
-
-// ── 시간 휠 피커 ──────────────────────────────────────────
-const ITEM_H  = 60;
-const VISIBLE = 3;
-const PICKER_H = ITEM_H * VISIBLE;
+// ── 시간 휠 피커 데이터 ───────────────────────────────────
 const HOURS   = Array.from({ length: 24 }, (_, i) => i);
 const MINUTES = Array.from({ length: 12 }, (_, i) => i * 5); // 5분 단위
 const PRESETS = [
@@ -37,7 +30,6 @@ const PRESETS = [
   { label: '밤',       h: 21, m: 0 },
 ];
 
-function pad(n) { return String(n).padStart(2, '0'); }
 function ampmLabel(h) {
   if (h < 6)  return '새벽';
   if (h < 12) return '오전';
@@ -45,72 +37,16 @@ function ampmLabel(h) {
   return '밤';
 }
 
-function WheelPicker({ items, selectedIndex, onChange }) {
-  const scrollRef          = useRef(null);
-  const isProgrammatic     = useRef(false);
-  const selectedIndexRef   = useRef(selectedIndex);
-  selectedIndexRef.current = selectedIndex;
-
-  useEffect(() => {
-    isProgrammatic.current = true;
-    requestAnimationFrame(() => {
-      scrollRef.current?.scrollTo({ y: selectedIndex * ITEM_H, animated: false });
-      requestAnimationFrame(() => { isProgrammatic.current = false; });
-    });
-  }, [selectedIndex]);
-
-  const onLayout = useCallback(() => {
-    isProgrammatic.current = true;
-    scrollRef.current?.scrollTo({ y: selectedIndexRef.current * ITEM_H, animated: false });
-    requestAnimationFrame(() => { isProgrammatic.current = false; });
-  }, []);
-
-  const handleMomentumEnd = useCallback((e) => {
-    if (isProgrammatic.current) return;
-    const idx = Math.round(e.nativeEvent.contentOffset.y / ITEM_H);
-    const clamped = Math.max(0, Math.min(idx, items.length - 1));
-    if (clamped !== selectedIndex) onChange(clamped);
-  }, [items.length, selectedIndex, onChange]);
-
+// 공용 WheelPicker 항목 텍스트 (기존 이 화면 전용 렌더링 그대로)
+function renderWheelLabel(val, selected) {
   return (
-    <View style={{ flex: 1, position: 'relative', overflow: 'hidden', height: PICKER_H }}>
-      {/* 선택 하이라이트 */}
-      <View style={{
-        position: 'absolute', top: ITEM_H * 1, left: 0, right: 0, height: ITEM_H,
-        borderTopWidth: 1, borderBottomWidth: 1, borderColor: W.greenBorder,
-        backgroundColor: W.greenFaint, zIndex: 1, borderRadius: 8,
-      }} pointerEvents="none" />
-      <LinearGradient colors={[W.surface, W.surface + '00']} style={{ position: 'absolute', left: 0, right: 0, top: 0, height: ITEM_H * 1.0, zIndex: 2 }} pointerEvents="none" />
-      <LinearGradient colors={[W.surface + '00', W.surface]} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: ITEM_H * 1.0, zIndex: 2 }} pointerEvents="none" />
-      <ScrollView
-        ref={scrollRef}
-        style={{ height: PICKER_H }}
-        contentContainerStyle={{ paddingVertical: ITEM_H * 1 }}
-        showsVerticalScrollIndicator={false}
-        snapToInterval={ITEM_H}
-        decelerationRate="fast"
-        onMomentumScrollEnd={handleMomentumEnd}
-        onLayout={onLayout}
-        scrollEventThrottle={16}
-      >
-        {items.map((val, i) => (
-          <TouchableOpacity
-            key={i}
-            style={{ height: ITEM_H, alignItems: 'center', justifyContent: 'center' }}
-            activeOpacity={0.6}
-            onPress={() => onChange(i)}
-          >
-            <T
-              size={i === selectedIndex ? 30 : 24}
-              color={i === selectedIndex ? W.text : W.green}
-              style={{ opacity: i === selectedIndex ? 1 : 0.4 }}
-            >
-              {pad(val)}
-            </T>
-          </TouchableOpacity>
-        ))}
-      </ScrollView>
-    </View>
+    <T
+      size={selected ? 30 : 24}
+      color={selected ? W.text : W.green}
+      style={{ opacity: selected ? 1 : 0.4 }}
+    >
+      {pad(val)}
+    </T>
   );
 }
 
@@ -272,12 +208,12 @@ export default function SignupScreen({ defaultName = '', onComplete }) {
         >
           <View style={{ flex: 1, alignItems: 'stretch' }}>
             <T v="sub" style={{ marginBottom: 8, textAlign: 'center' }}>시</T>
-            <WheelPicker items={HOURS}   selectedIndex={hourIdx}   onChange={setHourIdx} />
+            <WheelPicker items={HOURS}   selectedIndex={hourIdx}   onChange={setHourIdx}   colors={W} renderLabel={renderWheelLabel} />
           </View>
           <T size={32} color={W.textSub} style={{ marginTop: 12, paddingHorizontal: 8, opacity: 0.5 }}>:</T>
           <View style={{ flex: 1, alignItems: 'stretch' }}>
             <T v="sub" style={{ marginBottom: 8, textAlign: 'center' }}>분</T>
-            <WheelPicker items={MINUTES} selectedIndex={minuteIdx} onChange={setMinuteIdx} />
+            <WheelPicker items={MINUTES} selectedIndex={minuteIdx} onChange={setMinuteIdx} colors={W} renderLabel={renderWheelLabel} />
           </View>
         </View>
 

--- a/screens/VerifyScreen.jsx
+++ b/screens/VerifyScreen.jsx
@@ -9,6 +9,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useColors } from '../utils/useColors';
 import { api } from '../utils/api';
 import T from '../components/ThemedText';
+import { pad } from '../utils/date';
 
 const F = 'Kkukkukk';
 
@@ -17,7 +18,6 @@ const PHOTO_GRADS = [
   ['#ffd180', '#e65100'], ['#90caf9', '#1a3a6a'],
 ];
 
-function pad(n) { return String(n).padStart(2, '0'); }
 function nowLabel() {
   const d = new Date();
   return `${d.getFullYear()}.${pad(d.getMonth()+1)}.${pad(d.getDate())}  ${pad(d.getHours())}:${pad(d.getMinutes())}`;

--- a/utils/api.js
+++ b/utils/api.js
@@ -43,12 +43,19 @@ export const loadToken  = async () => { _token = await SecureStore.getItemAsync(
 export const getToken   = ()       => _token;
 export const clearToken = ()       => setToken(null);
 
+// 401(세션 만료) 전역 처리 — App.jsx가 로그아웃 핸들러를 등록한다.
+// 토큰이 있는 상태의 401만 세션 만료로 취급한다 (로그인 실패 401은 각 화면이 처리).
+let _onUnauthorized = null;
+export const setOnUnauthorized = (handler) => { _onUnauthorized = handler; };
+
 async function request(method, path, body, isFormData = false) {
   const headers = {};
   if (_token)       headers['Authorization'] = `Bearer ${_token}`;
   if (!isFormData)  headers['Content-Type']  = 'application/json';
   const url = `${BASE_URL}${path}`;
-  console.log(`[API] ${method} ${path} | token: ${_token ? _token.slice(0, 20) + '...' : 'NONE'}`);
+  if (__DEV__) {
+    console.log(`[API] ${method} ${path} | token: ${_token ? _token.slice(0, 20) + '...' : 'NONE'}`);
+  }
 
   let res;
   const controller = new AbortController();
@@ -87,7 +94,10 @@ async function request(method, path, body, isFormData = false) {
     console.info(`[API] ${method} ${url} -> ${res.status}`);
     if (!res.ok && data) console.warn('[API] error body', data);
   }
-  if (!res.ok) throw Object.assign(new Error(data?.message || text || `요청 실패 (${res.status})`), { status: res.status });
+  if (!res.ok) {
+    if (res.status === 401 && _token && _onUnauthorized) _onUnauthorized();
+    throw Object.assign(new Error(data?.message || text || `요청 실패 (${res.status})`), { status: res.status });
+  }
   return data;
 }
 

--- a/utils/date.js
+++ b/utils/date.js
@@ -1,0 +1,4 @@
+/* 공통 날짜/시간 유틸 */
+
+/** 2자리 zero-pad — 8 → '08' */
+export const pad = (n) => String(n).padStart(2, '0');

--- a/utils/reportMail.js
+++ b/utils/reportMail.js
@@ -1,4 +1,5 @@
 import { Alert, Linking } from 'react-native';
+import { pad } from './date';
 
 const DEFAULT_REPORT_EMAIL = 'calla20032@naver.com';
 export const REPORT_EMAIL = process.env.EXPO_PUBLIC_REPORT_EMAIL || DEFAULT_REPORT_EMAIL;
@@ -10,10 +11,6 @@ export const REPORT_REASONS = [
   { key: 'VIOLENCE',  label: '폭력적 / 위협적 콘텐츠',},
   { key: 'OTHER',     label: '기타',                  },
 ];
-
-function pad(n) {
-  return String(n).padStart(2, '0');
-}
 
 function nowStamp() {
   const d = new Date();

--- a/utils/useAuth.js
+++ b/utils/useAuth.js
@@ -1,0 +1,96 @@
+import { useState, useEffect } from 'react';
+import { signInWithApple, signInWithKakao } from './auth';
+import { api, loadToken, clearToken, setOnUnauthorized } from './api';
+import { cancelMissionNotification } from './notifications';
+
+/*
+ * 인증 상태머신 훅 — authStatus: 'loading' | 'unauthenticated' | 'signingUp' | 'authenticated'
+ *
+ * 자동 로그인·카카오/애플 로그인의 공통 후처리(프로필 세팅, 오늘 미션 로드, 알림 예약)는
+ * App.jsx가 applySession 으로 주입한다. 로그아웃 시 미션/프로필 상태 초기화는 resetSession.
+ * API가 401(세션 만료)을 반환하면 자동으로 로그아웃 처리한다.
+ */
+export default function useAuth({ applySession, resetSession }) {
+  const [authStatus, setAuthStatus]     = useState('loading');
+  const [authUser, setAuthUser]         = useState(null);
+  const [loginLoading, setLoginLoading] = useState(false);
+  const [loginError, setLoginError]     = useState('');
+
+  // ── 자동 로그인: 토큰 복원 → /users/me → 세션 적용
+  useEffect(() => {
+    loadToken().then(async (token) => {
+      if (!token) {
+        setAuthStatus('unauthenticated');
+        return;
+      }
+      try {
+        const user = await api.get('/api/v1/users/me');
+        await applySession(user);
+        setAuthStatus('authenticated');
+      } catch (e) {
+        console.warn('자동 로그인 실패:', e);
+        setAuthStatus('unauthenticated');
+      }
+    }).catch((e) => {
+      console.warn('자동 로그인 토큰 로드 실패:', e);
+      setAuthStatus('unauthenticated');
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const login = async (signIn, fallbackMessage) => {
+    setLoginLoading(true);
+    setLoginError('');
+    try {
+      const { user, isNew } = await signIn();
+      setAuthUser(user);
+      if (!isNew) await applySession(user);
+      setAuthStatus(isNew ? 'signingUp' : 'authenticated');
+    } catch (e) {
+      if (e?.code !== 'ERR_CANCELED') {
+        console.warn(e);
+        setLoginError(e?.message || fallbackMessage);
+      }
+    } finally {
+      setLoginLoading(false);
+    }
+  };
+
+  const handleKakaoLogin = () => login(signInWithKakao, '카카오 로그인에 실패했습니다.');
+  const handleAppleLogin = () => login(signInWithApple, 'Apple 로그인에 실패했습니다.');
+
+  const handleLogout = async () => {
+    await cancelMissionNotification();
+    await clearToken();
+    setAuthUser(null);
+    resetSession();
+    setAuthStatus('unauthenticated');
+  };
+
+  const handleDeleteAccount = async () => {
+    try {
+      await api.delete('/api/v1/users/me');
+    } catch (e) {
+      console.warn('회원탈퇴 실패:', e);
+    }
+    await handleLogout();
+  };
+
+  // ── 세션 만료(401) 전역 처리 — 항상 최신 핸들러가 등록되도록 매 렌더 갱신
+  useEffect(() => {
+    setOnUnauthorized(() => { handleLogout().catch(() => {}); });
+    return () => setOnUnauthorized(null);
+  });
+
+  return {
+    authStatus,
+    setAuthStatus,
+    authUser,
+    loginLoading,
+    loginError,
+    handleKakaoLogin,
+    handleAppleLogin,
+    handleLogout,
+    handleDeleteAccount,
+  };
+}

--- a/utils/useMissionRouletteTrigger.js
+++ b/utils/useMissionRouletteTrigger.js
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+
+/*
+ * 설정 시간 감지 → 미션 룰렛 트리거 훅.
+ *
+ * 정책 (CLAUDE.md "미션 룰렛 자동 트리거 정책"):
+ * - 같은 분(HH:MM) 안에 이미 트리거됐으면 재트리거하지 않는다
+ * - 오늘 미션이 이미 있으면(hasMission) 시간을 바꿔도 재트리거하지 않는다
+ */
+export default function useMissionRouletteTrigger(missionTime, hasMission, onTrigger) {
+  const lastTriggeredRef = useRef(null);
+  const onTriggerRef = useRef(onTrigger);
+  onTriggerRef.current = onTrigger;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const now = new Date();
+      const key = `${now.getHours()}:${now.getMinutes()}`;
+      if (
+        now.getHours()   === missionTime.hour &&
+        now.getMinutes() === missionTime.minute &&
+        lastTriggeredRef.current !== key &&
+        !hasMission   // 오늘 미션이 없을 때만 룰렛 트리거
+      ) {
+        lastTriggeredRef.current = key;
+        onTriggerRef.current();
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [missionTime, hasMission]);
+}


### PR DESCRIPTION
## 🔗 Issue

- close #141

---

## 📌 Summary

- **App.jsx 분해** (564→약 480줄, useState 15→11개): 인증 상태머신을 `utils/useAuth.js` 훅으로 추출 — 카카오/애플/자동로그인 3곳에 중복되던 프로필 세팅·오늘미션 로드·알림 예약 후처리를 `applySession` 하나로 통합. 룰렛 트리거 인터벌은 `utils/useMissionRouletteTrigger.js`로 분리 (같은 분 재트리거 방지·hasMission 정책 그대로)
- **api.js 보강**: ① 토큰 로깅이 `__DEV__` 가드 없이 항상 실행되던 것 수정(민감정보), ② `setOnUnauthorized` 콜백 추가 — 토큰 보유 상태의 401(세션 만료)만 전역 로그아웃 처리 (로그인 실패 401은 기존대로 화면별 처리)
- **중복 제거**: `pad` 10곳 → `utils/date.js`, `AvatarImage` 2곳 → `components/AvatarImage.jsx`, WheelPicker 2곳 → `components/WheelPicker.jsx` (색 토큰/라벨 렌더링은 prop으로 흡수, 룰렛 슬롯은 로직이 달라 제외)
- 동작 변경 의도 없음 — 수동 스택 12분기 라우트 맵 전환은 리스크 커서 보류 (백로그)

---

## ✅ Test

- [x] `npm run lint` 통과 — 62 → 61 warnings, 0 errors (미사용 import 제거로 1개 감소, 신규 경고 없음)
- [ ] 실기기 확인 필요: 카카오/애플 로그인·자동 로그인·로그아웃, 미션 시간 도달 시 룰렛, 시간 휠 피커(MissionTime·Signup 스냅/프리셋 동기화), 프로필/회원가입 아바타 크기, 세션 만료(401) 시 로그인 화면 전환