### PR TITLE
[Test] #140 도메인 컨트롤러 테스트 6종 + JaCoCo 커버리지 리포트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,11 @@ jobs:
           name: test-report
           path: backend/build/reports/tests/test/
 
+      - name: JaCoCo 커버리지 리포트 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: backend/build/reports/jacoco/
+
       - name: 빌드 실행 (Build)
         run: ./gradlew build -x test

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.5.14'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '6.25.0'
@@ -70,4 +71,13 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy tasks.named('jacocoTestReport')
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn tasks.named('test')
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }

--- a/backend/src/test/java/com/offmode/boundedcontext/auth/api/v1/AuthControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/auth/api/v1/AuthControllerTest.java
@@ -1,0 +1,113 @@
+package com.offmode.boundedcontext.auth.api.v1;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.boundedcontext.auth.dto.response.AuthResponse;
+import com.offmode.boundedcontext.auth.service.AuthService;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.global.config.SecurityConfig;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import com.offmode.global.status.ErrorStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class AuthControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private AuthService authService;
+  @MockitoBean private JwtProvider jwtProvider;
+
+  private User user(String name) {
+    return User.builder().id(1L).provider("kakao").providerId("p1").name(name).build();
+  }
+
+  @Test
+  void kakaoLoginReturnsAuthResponseWithoutAuthentication() throws Exception {
+    when(authService.kakaoLogin("kakao-access-token"))
+        .thenReturn(new AuthResponse("jwt-token", user("오프모더"), true));
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/kakao")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accessToken\":\"kakao-access-token\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.token").value("jwt-token"))
+        .andExpect(jsonPath("$.isNew").value(true))
+        .andExpect(jsonPath("$.user.name").value("오프모더"));
+  }
+
+  @Test
+  void appleLoginReturnsAuthResponse() throws Exception {
+    when(authService.appleLogin("identity-token", "홍길동"))
+        .thenReturn(new AuthResponse("jwt-token", user("홍길동"), false));
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/apple")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"identityToken\":\"identity-token\",\"fullName\":\"홍길동\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.token").value("jwt-token"))
+        .andExpect(jsonPath("$.isNew").value(false))
+        .andExpect(jsonPath("$.user.name").value("홍길동"));
+  }
+
+  @Test
+  void kakaoLoginFailureReturnsUnauthorizedApiResponse() throws Exception {
+    when(authService.kakaoLogin("bad-token"))
+        .thenThrow(new BusinessException(ErrorStatus.AUTH_OAUTH_FAILED));
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/kakao")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accessToken\":\"bad-token\"}"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("AUTH_401_001"))
+        .andExpect(jsonPath("$.message").value("OAuth 인증에 실패했습니다."));
+  }
+
+  @Test
+  void appleLoginWithInvalidTokenReturnsUnauthorizedApiResponse() throws Exception {
+    when(authService.appleLogin("expired-token", null))
+        .thenThrow(new BusinessException(ErrorStatus.AUTH_APPLE_INVALID_TOKEN));
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/apple")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"identityToken\":\"expired-token\"}"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("AUTH_401_002"))
+        .andExpect(jsonPath("$.message").value("Apple 인증 토큰이 유효하지 않습니다."));
+  }
+
+  @Test
+  void malformedJsonReturnsBadRequestApiResponse() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/auth/kakao")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("not-a-json"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("COMMON_400"))
+        .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/badge/api/v1/BadgeControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/badge/api/v1/BadgeControllerTest.java
@@ -1,0 +1,93 @@
+package com.offmode.boundedcontext.badge.api.v1;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.boundedcontext.badge.dto.response.BadgeResponse;
+import com.offmode.boundedcontext.badge.entity.UserBadge;
+import com.offmode.boundedcontext.badge.service.BadgeService;
+import com.offmode.boundedcontext.badge.types.BadgeDefinition;
+import com.offmode.global.config.SecurityConfig;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import com.offmode.global.status.ErrorStatus;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = BadgeController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class BadgeControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private BadgeService badgeService;
+  @MockitoBean private JwtProvider jwtProvider;
+
+  private void authenticate() {
+    when(jwtProvider.isValid("token")).thenReturn(true);
+    when(jwtProvider.getUserId("token")).thenReturn(1L);
+  }
+
+  @Test
+  void getMyBadgesReturnsBadgeList() throws Exception {
+    authenticate();
+    when(badgeService.getUserBadges(1L))
+        .thenReturn(
+            List.of(
+                new BadgeResponse(BadgeDefinition.EXPLORER_LV01, new UserBadge()),
+                new BadgeResponse(BadgeDefinition.WALKER, null)));
+
+    mockMvc
+        .perform(get("/api/v1/badges/me").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].key").value("explorer_lv01"))
+        .andExpect(jsonPath("$[0].earned").value(true))
+        .andExpect(jsonPath("$[1].key").value("activity_walker"))
+        .andExpect(jsonPath("$[1].earned").value(false));
+  }
+
+  @Test
+  void getMyBadgesReturnsEmptyArrayWith200() throws Exception {
+    authenticate();
+    when(badgeService.getUserBadges(1L)).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/v1/badges/me").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
+  }
+
+  @Test
+  void getMyBadgesWithUnknownUserReturnsNotFoundApiResponse() throws Exception {
+    authenticate();
+    when(badgeService.getUserBadges(1L))
+        .thenThrow(new BusinessException(ErrorStatus.USER_NOT_FOUND));
+
+    mockMvc
+        .perform(get("/api/v1/badges/me").header("Authorization", "Bearer token"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("USER_404_001"))
+        .andExpect(jsonPath("$.message").value("해당 사용자를 찾을 수 없습니다."));
+  }
+
+  @Test
+  void getMyBadgesWithoutTokenReturnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/badges/me"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("COMMON_401"))
+        .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/mission/api/v1/MissionControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/mission/api/v1/MissionControllerTest.java
@@ -1,0 +1,156 @@
+package com.offmode.boundedcontext.mission.api.v1;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.boundedcontext.mission.dto.response.UserMissionResponse;
+import com.offmode.boundedcontext.mission.entity.UserMission;
+import com.offmode.boundedcontext.mission.service.MissionService;
+import com.offmode.boundedcontext.mission.types.MissionCategory;
+import com.offmode.boundedcontext.mission.types.MissionStatus;
+import com.offmode.global.config.SecurityConfig;
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MissionController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class MissionControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private MissionService missionService;
+  @MockitoBean private JwtProvider jwtProvider;
+
+  private void authenticate() {
+    when(jwtProvider.isValid("token")).thenReturn(true);
+    when(jwtProvider.getUserId("token")).thenReturn(1L);
+  }
+
+  @Test
+  void todayReturnsMissionResponse() throws Exception {
+    authenticate();
+    when(missionService.getTodayMissionResponse(1L))
+        .thenReturn(
+            new UserMissionResponse(
+                5L,
+                "🚶",
+                "동네 한 바퀴 산책하기",
+                MissionCategory.VITALITY,
+                MissionStatus.PENDING,
+                LocalDateTime.of(2026, 7, 7, 8, 0),
+                null,
+                null,
+                null));
+
+    mockMvc
+        .perform(get("/api/v1/missions/today").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(5L))
+        .andExpect(jsonPath("$.missionText").value("동네 한 바퀴 산책하기"))
+        .andExpect(jsonPath("$.missionCategory").value("Vitality"))
+        .andExpect(jsonPath("$.status").value("pending"));
+  }
+
+  @Test
+  void todayReturnsNoContentWhenMissionNotAssigned() throws Exception {
+    authenticate();
+    when(missionService.getTodayMissionResponse(1L)).thenReturn(null);
+
+    mockMvc
+        .perform(get("/api/v1/missions/today").header("Authorization", "Bearer token"))
+        .andExpect(status().isNoContent())
+        .andExpect(content().string(""));
+  }
+
+  @Test
+  void setTodayReturnsUserMissionWithoutUserAssociation() throws Exception {
+    authenticate();
+    when(missionService.setTodayMission(1L, "🚶", "동네 한 바퀴 산책하기", MissionCategory.VITALITY))
+        .thenReturn(
+            UserMission.builder()
+                .id(7L)
+                .missionIcon("🚶")
+                .missionText("동네 한 바퀴 산책하기")
+                .missionCategory(MissionCategory.VITALITY)
+                .status(MissionStatus.PENDING)
+                .build());
+
+    mockMvc
+        .perform(
+            post("/api/v1/missions/today")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"icon\":\"🚶\",\"text\":\"동네 한 바퀴 산책하기\",\"category\":\"Vitality\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(7L))
+        .andExpect(jsonPath("$.missionText").value("동네 한 바퀴 산책하기"))
+        .andExpect(jsonPath("$", not(hasKey("user"))));
+  }
+
+  @Test
+  void setTodayWithBlankIconReturnsValidationError() throws Exception {
+    authenticate();
+
+    mockMvc
+        .perform(
+            post("/api/v1/missions/today")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"icon\":\"\",\"text\":\"산책하기\",\"category\":\"Vitality\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("VALID_400_001"))
+        .andExpect(jsonPath("$.message").value("입력값이 올바르지 않습니다."));
+  }
+
+  @Test
+  void setTodayWithUnknownCategoryReturnsValidationError() throws Exception {
+    authenticate();
+
+    mockMvc
+        .perform(
+            post("/api/v1/missions/today")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"icon\":\"🚶\",\"text\":\"산책하기\",\"category\":\"Chaos\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("VALID_400_001"));
+  }
+
+  @Test
+  void historyReturnsEmptyArrayWith200() throws Exception {
+    authenticate();
+    when(missionService.getHistory(1L)).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/v1/missions/history").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
+  }
+
+  @Test
+  void poolWithoutTokenReturnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/missions/pool"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("COMMON_401"))
+        .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/part/api/v1/PartControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/part/api/v1/PartControllerTest.java
@@ -1,0 +1,144 @@
+package com.offmode.boundedcontext.part.api.v1;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.boundedcontext.part.dto.response.PartResponse;
+import com.offmode.boundedcontext.part.service.PartService;
+import com.offmode.boundedcontext.part.types.PartDefinition;
+import com.offmode.global.config.SecurityConfig;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import com.offmode.global.status.ErrorStatus;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = PartController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class PartControllerTest {
+
+  private static final String LAYOUT_BODY =
+      "{\"placements\":[{\"key\":\"leaf\",\"x\":0.5,\"y\":0.5,\"scale\":1.0,\"rotation\":0,\"z\":1}]}";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PartService partService;
+  @MockitoBean private JwtProvider jwtProvider;
+
+  private void authenticate() {
+    when(jwtProvider.isValid("token")).thenReturn(true);
+    when(jwtProvider.getUserId("token")).thenReturn(1L);
+  }
+
+  @Test
+  void getMyPartsReturnsPartList() throws Exception {
+    authenticate();
+    when(partService.getUserParts(1L))
+        .thenReturn(
+            List.of(
+                new PartResponse(
+                    PartDefinition.LEAF,
+                    true,
+                    new PartResponse.PlacementResponse(0.5, 0.5, 1.0, 0, 1)),
+                new PartResponse(PartDefinition.CROWN, false, null)));
+
+    mockMvc
+        .perform(get("/api/v1/parts/me").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].key").value("leaf"))
+        .andExpect(jsonPath("$[0].unlocked").value(true))
+        .andExpect(jsonPath("$[0].placement.x").value(0.5))
+        .andExpect(jsonPath("$[1].key").value("crown"))
+        .andExpect(jsonPath("$[1].unlocked").value(false));
+  }
+
+  @Test
+  void getMyPartsReturnsEmptyArrayWith200() throws Exception {
+    authenticate();
+    when(partService.getUserParts(1L)).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/v1/parts/me").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
+  }
+
+  @Test
+  void saveLayoutReturnsUpdatedParts() throws Exception {
+    authenticate();
+    when(partService.saveLayout(eq(1L), anyList()))
+        .thenReturn(
+            List.of(
+                new PartResponse(
+                    PartDefinition.LEAF,
+                    true,
+                    new PartResponse.PlacementResponse(0.5, 0.5, 1.0, 0, 1))));
+
+    mockMvc
+        .perform(
+            put("/api/v1/parts/layout")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(LAYOUT_BODY))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].key").value("leaf"))
+        .andExpect(jsonPath("$[0].placement.z").value(1));
+  }
+
+  @Test
+  void saveLayoutWithoutPlacementsReturnsValidationError() throws Exception {
+    authenticate();
+
+    mockMvc
+        .perform(
+            put("/api/v1/parts/layout")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("VALID_400_001"))
+        .andExpect(jsonPath("$.message").value("입력값이 올바르지 않습니다."));
+  }
+
+  @Test
+  void saveLayoutWithLockedPartReturnsBadRequestApiResponse() throws Exception {
+    authenticate();
+    when(partService.saveLayout(eq(1L), anyList()))
+        .thenThrow(new BusinessException(ErrorStatus.PART_NOT_UNLOCKED));
+
+    mockMvc
+        .perform(
+            put("/api/v1/parts/layout")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(LAYOUT_BODY))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("PART_400_001"))
+        .andExpect(jsonPath("$.message").value("아직 해금되지 않은 파츠입니다."));
+  }
+
+  @Test
+  void getMyPartsWithoutTokenReturnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/parts/me"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("COMMON_401"));
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/room/api/v1/RoomControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/api/v1/RoomControllerTest.java
@@ -1,0 +1,205 @@
+package com.offmode.boundedcontext.room.api.v1;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.boundedcontext.room.dto.request.CreateRoomRequest;
+import com.offmode.boundedcontext.room.dto.request.JoinRoomRequest;
+import com.offmode.boundedcontext.room.dto.response.ConfirmResponse;
+import com.offmode.boundedcontext.room.dto.response.RoomDetailResponse;
+import com.offmode.boundedcontext.room.dto.response.RoomListResponse;
+import com.offmode.boundedcontext.room.dto.response.RoomReactionSummaryResponse;
+import com.offmode.boundedcontext.room.service.RoomMissionService;
+import com.offmode.boundedcontext.room.service.RoomProofService;
+import com.offmode.boundedcontext.room.service.RoomService;
+import com.offmode.boundedcontext.room.types.MemberTodayStatus;
+import com.offmode.boundedcontext.room.types.ProofStatus;
+import com.offmode.boundedcontext.room.types.RoomIconKey;
+import com.offmode.boundedcontext.room.types.RoomType;
+import com.offmode.global.config.SecurityConfig;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import com.offmode.global.status.ErrorStatus;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = RoomController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class RoomControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private RoomService roomService;
+  @MockitoBean private RoomMissionService roomMissionService;
+  @MockitoBean private RoomProofService roomProofService;
+  @MockitoBean private JwtProvider jwtProvider;
+
+  private void authenticate() {
+    when(jwtProvider.isValid("token")).thenReturn(true);
+    when(jwtProvider.getUserId("token")).thenReturn(1L);
+  }
+
+  private RoomDetailResponse detail(Long id, String name) {
+    return new RoomDetailResponse(
+        id,
+        name,
+        RoomIconKey.FIRE,
+        RoomType.GROUP,
+        "INVITE",
+        3,
+        2,
+        true,
+        null,
+        MemberTodayStatus.NONE,
+        null,
+        List.of(),
+        List.of());
+  }
+
+  @Test
+  void getMyRoomsReturnsRoomListWithEmptyGroupRooms() throws Exception {
+    authenticate();
+    when(roomService.getMyRooms(1L)).thenReturn(new RoomListResponse(null, List.of()));
+
+    mockMvc
+        .perform(get("/api/v1/rooms").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.soloRoom").value(nullValue()))
+        .andExpect(jsonPath("$.groupRooms").isArray())
+        .andExpect(jsonPath("$.groupRooms.length()").value(0));
+  }
+
+  @Test
+  void getDetailReturnsRoomDetail() throws Exception {
+    authenticate();
+    when(roomService.getDetail(1L, 10L)).thenReturn(detail(10L, "아침 산책방"));
+
+    mockMvc
+        .perform(get("/api/v1/rooms/10").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(10L))
+        .andExpect(jsonPath("$.name").value("아침 산책방"))
+        .andExpect(jsonPath("$.iconKey").value("FIRE"))
+        .andExpect(jsonPath("$.isOwner").value(true));
+  }
+
+  @Test
+  void getDetailWithUnknownRoomReturnsNotFoundApiResponse() throws Exception {
+    authenticate();
+    when(roomService.getDetail(1L, 99L))
+        .thenThrow(new BusinessException(ErrorStatus.ROOM_NOT_FOUND));
+
+    mockMvc
+        .perform(get("/api/v1/rooms/99").header("Authorization", "Bearer token"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("ROOM_404_001"))
+        .andExpect(jsonPath("$.message").value("방을 찾을 수 없습니다."));
+  }
+
+  @Test
+  void createRoomReturnsRoomDetail() throws Exception {
+    authenticate();
+    when(roomService.createRoom(eq(1L), any(CreateRoomRequest.class)))
+        .thenReturn(detail(11L, "새 방"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/rooms")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"새 방\",\"iconKey\":\"FIRE\",\"type\":\"GROUP\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(11L))
+        .andExpect(jsonPath("$.name").value("새 방"));
+  }
+
+  @Test
+  void createRoomWithBlankNameReturnsValidationError() throws Exception {
+    authenticate();
+
+    mockMvc
+        .perform(
+            post("/api/v1/rooms")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"\",\"iconKey\":\"FIRE\",\"type\":\"GROUP\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("VALID_400_001"))
+        .andExpect(jsonPath("$.message").value("입력값이 올바르지 않습니다."));
+  }
+
+  @Test
+  void joinAlreadyJoinedRoomReturnsConflictApiResponse() throws Exception {
+    authenticate();
+    when(roomService.join(eq(1L), any(JoinRoomRequest.class)))
+        .thenThrow(new BusinessException(ErrorStatus.ROOM_ALREADY_JOINED));
+
+    mockMvc
+        .perform(
+            post("/api/v1/rooms/join")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"inviteCode\":\"INVITE\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("ROOM_409_001"))
+        .andExpect(jsonPath("$.message").value("이미 참여한 방입니다."));
+  }
+
+  @Test
+  void confirmReturnsConfirmResponse() throws Exception {
+    authenticate();
+    when(roomProofService.confirm(1L, 10L, 20L))
+        .thenReturn(new ConfirmResponse(2, 2, ProofStatus.VERIFIED));
+
+    mockMvc
+        .perform(post("/api/v1/rooms/10/proofs/20/confirm").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.confirmCount").value(2))
+        .andExpect(jsonPath("$.requiredConfirm").value(2))
+        .andExpect(jsonPath("$.status").value("VERIFIED"));
+  }
+
+  @Test
+  void toggleReactionReturnsReactionSummaries() throws Exception {
+    authenticate();
+    when(roomProofService.toggleReaction(1L, 10L, 20L, "🔥"))
+        .thenReturn(List.of(new RoomReactionSummaryResponse("🔥", 3, true)));
+
+    mockMvc
+        .perform(
+            post("/api/v1/rooms/10/proofs/20/reactions")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"emoji\":\"🔥\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].emoji").value("🔥"))
+        .andExpect(jsonPath("$[0].count").value(3))
+        .andExpect(jsonPath("$[0].mine").value(true));
+  }
+
+  @Test
+  void getMyRoomsWithoutTokenReturnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/rooms"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("COMMON_401"))
+        .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/user/api/v1/UserControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/user/api/v1/UserControllerTest.java
@@ -1,0 +1,148 @@
+package com.offmode.boundedcontext.user.api.v1;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.offmode.boundedcontext.user.dto.response.UserStatsResponse;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.service.UserService;
+import com.offmode.global.config.SecurityConfig;
+import com.offmode.global.exception.BusinessException;
+import com.offmode.global.jwt.JwtAuthFilter;
+import com.offmode.global.jwt.JwtProvider;
+import com.offmode.global.status.ErrorStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = UserController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+class UserControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private UserService userService;
+  @MockitoBean private JwtProvider jwtProvider;
+
+  private void authenticate() {
+    when(jwtProvider.isValid("token")).thenReturn(true);
+    when(jwtProvider.getUserId("token")).thenReturn(1L);
+  }
+
+  private User user() {
+    return User.builder()
+        .id(1L)
+        .provider("kakao")
+        .providerId("p1")
+        .name("오프모더")
+        .avatar("01")
+        .missionHour(8)
+        .missionMinute(0)
+        .autoRoulette(true)
+        .build();
+  }
+
+  @Test
+  void getMeReturnsUser() throws Exception {
+    authenticate();
+    when(userService.getById(1L)).thenReturn(user());
+
+    mockMvc
+        .perform(get("/api/v1/users/me").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.name").value("오프모더"))
+        .andExpect(jsonPath("$.avatar").value("01"));
+  }
+
+  @Test
+  void getMeWithUnknownUserReturnsNotFoundApiResponse() throws Exception {
+    authenticate();
+    when(userService.getById(1L)).thenThrow(new BusinessException(ErrorStatus.USER_NOT_FOUND));
+
+    mockMvc
+        .perform(get("/api/v1/users/me").header("Authorization", "Bearer token"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("USER_404_001"))
+        .andExpect(jsonPath("$.message").value("해당 사용자를 찾을 수 없습니다."));
+  }
+
+  @Test
+  void getStatsReturnsUserStats() throws Exception {
+    authenticate();
+    when(userService.getStats(1L)).thenReturn(new UserStatsResponse(10, 7, 3, 40, 2, 20, 1, 60, 3));
+
+    mockMvc
+        .perform(get("/api/v1/users/me/stats").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalMissions").value(10))
+        .andExpect(jsonPath("$.totalVerified").value(7))
+        .andExpect(jsonPath("$.streak").value(3))
+        .andExpect(jsonPath("$.vitalityLevel").value(3));
+  }
+
+  @Test
+  void updateMeReturnsUpdatedUser() throws Exception {
+    authenticate();
+    when(userService.updateProfile(1L, "새이름", "02", 9, 30, false)).thenReturn(user());
+
+    mockMvc
+        .perform(
+            put("/api/v1/users/me")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"name\":\"새이름\",\"avatar\":\"02\",\"missionHour\":9,"
+                        + "\"missionMinute\":30,\"autoRoulette\":false}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L));
+  }
+
+  @Test
+  void updateMeWithInvalidMissionHourReturnsValidationError() throws Exception {
+    authenticate();
+
+    mockMvc
+        .perform(
+            put("/api/v1/users/me")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"missionHour\":25}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("VALID_400_001"))
+        .andExpect(jsonPath("$.message").value("입력값이 올바르지 않습니다."));
+  }
+
+  @Test
+  void deleteMeReturnsNoContent() throws Exception {
+    authenticate();
+    doNothing().when(userService).deleteAccount(1L);
+
+    mockMvc
+        .perform(delete("/api/v1/users/me").header("Authorization", "Bearer token"))
+        .andExpect(status().isNoContent())
+        .andExpect(content().string(""));
+  }
+
+  @Test
+  void getMeWithoutTokenReturnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/users/me"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("COMMON_401"))
+        .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+  }
+}


### PR DESCRIPTION
## 🔗 Issue

- close #140

---

## 📌 Summary

- 컨트롤러 계층 테스트가 `FeedControllerTest` 하나뿐이던 공백을 해소 — **Auth·Badge·Mission·Part·Room·User 컨트롤러 `@WebMvcTest` 38케이스** 신설 (기존 패턴인 `@Import({SecurityConfig, JwtAuthFilter})` + `@MockitoBean` 그대로 복제)
- 케이스 구성: 정상 200 + DTO / 데이터 없음 204(오늘 미션 미배정, 회원 탈퇴) / 빈 목록은 204가 아닌 `[]` 200 / `@Valid` 위반 400 / BusinessException → `{isSuccess,code,message}` 포맷 + 한국어 메시지 검증 / 비인증 401 `COMMON_401`
- `POST /missions/today`는 엔티티 직접 반환 구조라 LAZY `user` 필드가 JSON에 노출되지 않는 것(@JsonIgnore)도 함께 검증
- **JaCoCo 도입**: `build.gradle`에 플러그인 + `test finalizedBy jacocoTestReport`(xml+html), `ci.yml` build 잡에 `jacoco-report` 아티팩트 업로드 추가. 커버리지 게이트는 강제하지 않음(리포트만)

---

## ✅ Test

- [x] `./gradlew spotlessCheck && ./gradlew test && ./gradlew build -x test` 전체 통과 (CI 로컬 재현)
- [x] 신규 38케이스 전부 통과, `backend/build/reports/jacoco/test/`에 xml+html 리포트 생성 확인
- [x] Room 컨트롤러는 대표 엔드포인트 위주 커버(목록/상세/생성/참여/confirm/리액션) — rename/kick/nudge/신고 등은 후속