### PR TITLE
[Chore] #144 .claude/rules 경로 스코프 규칙 신설 + CLAUDE.md stale 갱신

### DIFF
--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - "backend/src/main/**/*.java"
+---
+
+# 백엔드 API 설계 규칙
+
+CLAUDE.md의 응답/에러 규칙에 더해, 코드 리뷰에서 반복 지적된 항목을 규칙화한 것.
+
+## 응답 (요약)
+
+- 성공: `ResponseEntity<DTO>` 직접 반환. 단건 없음 → 204, **빈 목록 → `[]` 200 (204 금지)**.
+- 에러: `ErrorStatus` enum 등록 → `BusinessException` throw. `ResponseStatusException`·임의 RuntimeException 금지.
+- 사용자 노출 메시지는 반드시 한국어 (프론트가 `data?.message`를 그대로 표시).
+
+## 동시성 — check-then-act 금지 패턴
+
+- **count/exists 조회 후 상태 전환·부수효과(레벨업, 뱃지, VERIFIED 전환)를 하는 쓰기 경로는 반드시 대상 행을 `@Lock(LockModeType.PESSIMISTIC_WRITE)` 조회로 직렬화한다.** 패턴: 리포지토리에 `findWithLockById` (`@Lock` + 명시 `@Query`) 추가, 쓰기 경로에서만 사용하고 읽기 경로에는 락을 섞지 않는다.
+  - 예: `VerificationRepository.findWithLockById`, `RoomProofRepository.findWithLockById` (confirm·리액션 토글에서 사용)
+- find-then-save 토글(리액션류)도 같은 락으로 감싼다 — UNIQUE 제약 위반 500 방지.
+- 그래도 새는 경합은 `GlobalExceptionHandler`의 `DataIntegrityViolationException` → 409 `COMMON_409` 방어선이 받는다. 이 핸들러가 있다고 락을 생략하지 않는다 (409는 마지막 방어선일 뿐, 부수효과 이중 실행은 락만 막는다).
+- `@Transactional(readOnly = true)` 트랜잭션에서 FOR UPDATE 금지.
+
+## N+1 — 루프 안 리포지토리 호출 금지
+
+- 컬렉션을 돌면서 건마다 `findBy...`/`countBy...`를 호출하지 않는다. id 리스트를 모아 **IN 배치 조회 + 애플리케이션 집계**로 바꾼다.
+  - 집계: `SELECT x.id, COUNT(x) ... WHERE x.id IN :ids GROUP BY x.id` → `Map<Long, Long>` 변환 (예: `RoomService.toCountMap`)
+  - 연관 로드: `JOIN FETCH` (예: `RoomMemberRepository.findWithUserByRoomIdOrderByJoinedAtAsc`, `RoomProofRepository.findWithUserByRoomMissionId`)
+- 응답 조립기(Assembler)도 단건 메서드를 루프로 부르지 말고 배치 메서드(`buildAll`)로 만들고 단건은 `buildAll(List.of(x))`로 위임한다 (예: `RoomProofAssembler`).
+- 모범 사례: `FeedService.getFeed`의 `findRowsByVerificationIdIn` 배치 집계.
+
+## 스키마
+
+- 엔티티 변경 시 Flyway 마이그레이션을 `db/migration/h2/`와 `db/migration/mysql/` **양쪽에 같은 버전 번호로** 동시 추가 (`/migration` 스킬 사용). `ddl-auto: validate`라 누락 시 부팅 실패.
+- 새 엔드포인트 추가 시 `SecurityConfig` permitAll/authenticated 목록 확인.

--- a/.claude/rules/backend-testing.md
+++ b/.claude/rules/backend-testing.md
@@ -1,0 +1,42 @@
+---
+paths:
+  - "backend/src/test/**/*.java"
+---
+
+# 백엔드 테스트 컨벤션
+
+테스트는 3계층으로 나뉜다. 새 테스트를 쓸 때는 아래 기준으로 계층을 고르고, 각 계층의 대표 파일 패턴을 그대로 따른다.
+
+## 1. 서비스 단위 테스트 — Mockito
+
+- 대상: 서비스 클래스의 분기/예외 로직. 도메인 서비스마다 1:1로 존재해야 한다.
+- 패턴: `@ExtendWith(MockitoExtension.class)` + `@Mock` 리포지토리/협력자, 생성자 직접 호출로 서비스 조립 (`service()` 팩토리 메서드).
+- 예외 검증은 `assertThatThrownBy(...).isInstanceOf(BusinessException.class).hasMessage("한국어 메시지 그대로")`.
+- 대표 파일: `room/service/RoomProofServiceTest.java`, `feed/service/FeedServiceTest.java`
+
+## 2. 컨트롤러 테스트 — @WebMvcTest
+
+- 대상: 요청 검증(@Valid)·인가·직렬화 경로.
+- 패턴: `@WebMvcTest(XxxController.class)` + `@Import({SecurityConfig, JwtAuthFilter})` + `@MockitoBean` 서비스/JwtProvider, `Bearer token` 헤더로 인증 유저 주입.
+- 필수 케이스: ① 정상 응답(아래 응답 규칙 준수 확인) ② @Valid 위반 400 ③ 서비스 BusinessException → `{isSuccess:false, code, message}` 포맷 + 한국어 메시지 문자열 비교 ④ 비인증 401 `COMMON_401`.
+- 응답 규칙: 일반 200 + DTO / 단건 없음 204 본문 없음 / **빈 목록은 204가 아니라 `[]` 200**.
+- 대표 파일: `feed/api/v1/FeedControllerTest.java`
+
+## 3. 통합·동시성 테스트 — @SpringBootTest + H2
+
+- 대상: 실제 DB가 필요한 검증 (Flyway 스키마, 트랜잭션 경계, 락/race condition).
+- 패턴: `@ActiveProfiles("dev")` + `@SpringBootTest` + `@TestPropertySource`로 **클래스별 고유 이름의 in-mem H2** 지정:
+  ```
+  spring.datasource.url=jdbc:h2:mem:<고유이름>;MODE=MySQL;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000
+  spring.jpa.hibernate.ddl-auto=validate
+  spring.flyway.locations=classpath:db/migration/h2
+  spring.sql.init.mode=never
+  ```
+- **동시성 테스트에는 절대 `@Transactional`을 붙이지 않는다** — 스레드 간 커밋 가시성이 사라져 테스트가 무의미해진다. 데이터 격리는 클래스별 고유 DB + 테스트별 고유 픽스처(providerId 등)로 한다.
+- 동시 실행은 `CountDownLatch`(ready/start 2단)로 같은 순간 출발시키고, `pool.shutdown()` + `awaitTermination` 대기, 각 스레드의 예외를 리스트로 수집해 assert한다.
+- 대표 파일: `room/service/RoomProofServiceConcurrencyTest.java`, `feed/service/FeedServiceConcurrencyTest.java`, `global/config/FlywayMigrationTest.java`
+
+## 공통
+
+- 검증 순서: `./gradlew spotlessApply` → `./gradlew test`. 커밋 전 spotlessCheck·test 통과 필수.
+- JaCoCo 리포트가 `test` 후 자동 생성된다 (`build/reports/jacoco/test/`). 커버리지 게이트는 없지만 새 서비스/컨트롤러에 테스트 없이 머지하지 않는다.

--- a/.claude/rules/frontend-conventions.md
+++ b/.claude/rules/frontend-conventions.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "screens/**/*.jsx"
+  - "components/**/*.jsx"
+  - "components/**/*.js"
+  - "utils/**/*.js"
+  - "App.jsx"
+---
+
+# 프론트 공통 모듈 재사용 규칙
+
+CLAUDE.md의 T 컴포넌트·색 토큰·makeStyles 규칙에 더해, 중복 정의 방지용 공통 모듈 안내.
+
+## 이미 있는 공통 모듈 — 새로 정의하지 말 것
+
+- **2자리 zero-pad**: `import { pad } from '../utils/date'` — 화면 안에 `pad`/`pad2`/인라인 padStart를 다시 만들지 않는다.
+- **아바타 이미지**: `import AvatarImage from '../components/AvatarImage'` — `source` 없으면 빈 자리 유지, 기본 72. 아바타는 PNG 기반(`utils/avatars.js`의 `getAvatarSource`), SVG 방식 아님.
+- **휠 피커(시간 선택 등)**: `import WheelPicker from '../components/WheelPicker'` — `colors`(surface/greenBorder/greenFaint 키)와 `renderLabel(value, selected)` prop으로 화면별 룩을 흡수한다. 룰렛 슬롯(MissionRouletteScreen)은 별개 구현.
+
+## 인증/세션
+
+- 인증 상태머신은 `utils/useAuth.js` 훅에 있다. 로그인 성공 후처리(프로필·미션시간·오늘미션·알림)는 App.jsx의 `applySession` **한 곳**만 수정하면 자동로그인·카카오·애플에 모두 반영된다.
+- API가 토큰 보유 상태에서 401을 반환하면 `utils/api.js`의 `setOnUnauthorized` 콜백으로 자동 로그아웃된다. 화면에서 401을 개별 처리할 필요 없음 (로그인 실패 401은 예외 — 화면별 처리).
+- 미션 룰렛 자동 트리거는 `utils/useMissionRouletteTrigger.js` — 정책(같은 분 재트리거 금지, hasMission이면 스킵)을 바꿀 때 이 파일만 본다.
+
+## 로깅
+
+- `console.*` 호출은 개발 정보성이면 `__DEV__` 가드로 감싼다. 토큰/개인정보는 프로덕션에서 절대 로그로 남기지 않는다.

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ backend/offmode-db*
 !.claude/skills/
 !.claude/agents/
 !.claude/hooks/
+!.claude/rules/
 !.claude/settings.json
 .claude/settings.local.json
 .claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,12 +145,13 @@ push('myScreen')   // → currentStack === 'myScreen'
 | `signingUp` | `SignupScreen` | 로그인 응답의 `isNew === true` |
 | `authenticated` | 메인 탭 UI | 로그인 성공 + 프로필 로드 완료 |
 
-- 카카오·Apple 로그인 응답은 `{ token, user, isNew }` 형태. `isNew`로 신규/기존 분기.
-- 로그아웃 시 `cancelMissionNotification()` → `clearToken()` → 상태 초기화 → `setAuthStatus('unauthenticated')` 순서를 지킨다.
-- 자동 로그인 흐름은 `useEffect`에서 `loadToken()` → `/api/v1/users/me` → `loadTodayMission()` → `scheduleMissionNotification()`로 이어진다. 새 사용자 설정 필드가 생기면 이 자동 로그인 분기와 카카오/Apple 로그인 분기 두 군데를 동시에 손봐야 한다.
+- 상태머신 본체는 `utils/useAuth.js` 훅. 카카오·Apple 로그인 응답은 `{ token, user, isNew }` 형태이고 `isNew`로 신규/기존 분기.
+- 로그아웃 순서(`cancelMissionNotification()` → `clearToken()` → 상태 초기화 → `unauthenticated`)는 `useAuth`의 `handleLogout`이 보장한다.
+- 로그인/자동 로그인 성공 후처리(프로필·미션시간·오늘미션 로드·알림 예약)는 App.jsx의 `applySession` **한 곳**에 모여 있다. 새 사용자 설정 필드가 생기면 `applySession`(+로그아웃 초기화는 `resetSession`)만 수정하면 자동로그인·카카오·Apple에 모두 반영된다.
+- API가 토큰 보유 상태에서 401을 반환하면 `utils/api.js`의 `setOnUnauthorized`로 등록된 핸들러가 자동 로그아웃시킨다 (`useAuth` 내부에서 등록).
 
 ### 미션 룰렛 자동 트리거 정책
-`App.jsx`의 1초 간격 인터벌이 `missionTime` 도달을 감지해서 룰렛을 띄운다. 룰렛이 **다시 트리거되지 않는** 조건:
+`utils/useMissionRouletteTrigger.js` 훅의 1초 간격 인터벌이 `missionTime` 도달을 감지해서 룰렛을 띄운다 (App.jsx에서 사용). 룰렛이 **다시 트리거되지 않는** 조건:
 
 - 같은 분(`HH:MM`) 안에 이미 한 번 트리거됨 (`lastTriggeredRef`)
 - 오늘 미션이 이미 있음 (`hasMission === true`) — **시간을 변경해도 재트리거하지 않는다**
@@ -196,26 +197,20 @@ uri: photoUrl.startsWith('/') ? `${BASE_URL}${photoUrl}` : photoUrl
 ```
 
 ### 아바타 시스템
-아바타 ID는 `'01'`~`'06'` 문자열. `utils/avatars.js`에서 가져온다.
+아바타 ID는 `'01'`~`'05'` 문자열 (토끼·병아리·수달·펭귄·다람쥐). **PNG 이미지 기반**이며 `utils/avatars.js`에서 가져온다 (과거 SVG 방식 아님).
 
 ```jsx
-import { getAvatarSource, getAvatarDefaultSource, AVATAR_IDS } from '../utils/avatars';
+import { getAvatarSource, AVATAR_IDS } from '../utils/avatars';
+import AvatarImage from '../components/AvatarImage';
 
-// 실제 화면용 — 미션 상태에 따라 아바타 이미지가 바뀜
-const avatarSource = getAvatarSource(avatarId, currentMission?.status);
-// status: null | 'active' | 'pending' | 'done' | 'verified'
+// 아바타 얼굴 이미지 source (상태별 변형 없음 — 두 번째 인자는 호환용)
+const avatarSource = getAvatarSource(avatarId);
 
-// 피커/편집 화면용 — 항상 default 이미지
-const avatarSource = getAvatarDefaultSource(avatarId);
-
-// SVG 렌더링 (ProfileScreen, SignupScreen 참고)
-function AvatarSvg({ source: SvgComponent, width = 80, height = 80 }) {
-  if (!SvgComponent) return <View style={{ width, height }} />;
-  return <SvgComponent width={width} height={height} />;
-}
+// 렌더링 — 공통 컴포넌트 사용 (source 없으면 빈 자리 유지, 기본 72)
+<AvatarImage source={avatarSource} width={80} height={80} />
 ```
 
-`AvatarSvg`는 현재 `ProfileScreen`·`SignupScreen`에 중복 정의됨 → 추후 `components/`로 이전 예정.
+전신 몸통(프로필 꾸미기 캔버스)은 `constants/parts.js`의 `getCharacterSource()`로 연결된다.
 
 ### 미션 상태값
 ```
@@ -373,5 +368,5 @@ throw new BusinessException(ErrorStatus.MISSION_NOT_FOUND);
 - 새 API 엔드포인트 추가 시 `SecurityConfig`의 permitAll/authenticated 목록 확인
 - 백엔드 엔티티 변경 시 dev/prod 모두 `ddl-auto: validate`이므로 자동 반영되지 않는다. `backend/src/main/resources/db/migration/{h2,mysql}/V*__*.sql`에 Flyway 마이그레이션을 동시에 추가한다 (H2/MySQL 양쪽 모두)
 - 개발 API 주소는 `.env`의 `EXPO_PUBLIC_*` 변수로 설정하고 `utils/api.js`에 로컬 IP를 하드코딩하지 않음
-- `AvatarSvg` 컴포넌트가 `ProfileScreen`·`SignupScreen`에 중복 정의됨 → `components/AvatarSvg.jsx`로 분리 예정
-- `BADGE_IMAGE_MAP`이 `MissionScreen`·`ProfileScreen`에 중복 정의됨 → `constants/badges.js`로 분리 예정
+- 공통 모듈을 재사용한다: `pad`는 `utils/date.js`, 아바타 렌더링은 `components/AvatarImage.jsx`, 휠 피커는 `components/WheelPicker.jsx` — 화면 안에 다시 정의하지 않는다
+- 경로별 상세 규칙은 `.claude/rules/`(backend-testing, api-design, frontend-conventions) 참고 — 해당 경로 파일 작업 시 자동 로드됨


### PR DESCRIPTION
## 🔗 Issue

- close #144

---

## 📌 Summary

- **`.claude/rules/` 신설** (paths frontmatter로 해당 경로 파일 작업 시에만 로드 → 세션 컨텍스트 절약):
  - `backend-testing.md` — 3계층 테스트 컨벤션: Mockito 단위 / `@WebMvcTest` 컨트롤러(#143에서 확립) / `@SpringBootTest`+H2 동시성 통합(#139에서 확립, **동시성 테스트 `@Transactional` 금지** 규칙 포함)
  - `api-design.md` — 응답 200/204/빈배열 규칙 + check-then-act 쓰기 경로의 행 락(`findWithLockById`) 의무화 + 루프 안 리포지토리 호출 금지(IN 배치 패턴)
  - `frontend-conventions.md` — 공통 모듈(`utils/date.js`·`AvatarImage`·`WheelPicker`, #142에서 신설) 재사용 규칙 + 401 전역 처리 + `__DEV__` 로깅 가드
- **CLAUDE.md stale 갱신**: 아바타 섹션 SVG→PNG 현실 반영('01'~'05', `AvatarImage` 사용), 이미 제거된 `BADGE_IMAGE_MAP`·`AvatarSvg` 항목 삭제, 인증 상태머신·룰렛 트리거 설명을 `useAuth`/`applySession`·`useMissionRouletteTrigger` 기준으로 갱신
- `.gitignore`에 `!.claude/rules/` 화이트리스트 추가

⚠️ CLAUDE.md·rules의 일부 내용(#142의 useAuth·공통 모듈, #143의 컨트롤러 테스트, #139의 락 패턴)을 참조하므로 **#139 → #142/#143 → 이 PR 순서로 머지**하는 것이 맞습니다.

---

## ✅ Test

- [x] 문서/설정 변경만 — 코드 변경 없음 (CI: 프론트 lint·백엔드 build에 영향 없음)
- [x] rules 파일 paths frontmatter는 Claude Code 공식 스펙(`.claude/rules/*.md` + `paths` glob) 확인