### PR TITLE
[Chore] #159 사용자 대면 문구 톤앤매너 통일 (다이얼로그·라벨·안내문)

### DIFF
--- a/components/CharacterDecor.jsx
+++ b/components/CharacterDecor.jsx
@@ -161,7 +161,7 @@ export default function CharacterDecor({ parts, characterSource = CHARACTER_BASE
       Alert.alert(
         '아직 잠긴 파츠예요',
         part.unlockThreshold != null
-          ? `누적 인증 ${part.unlockThreshold}회 달성 시 열려요`
+          ? `인증을 ${part.unlockThreshold}번 모으면 열려요`
           : '준비 중이에요',
       );
       return;
@@ -250,7 +250,7 @@ export default function CharacterDecor({ parts, characterSource = CHARACTER_BASE
       ) : (
         <View style={s.guide}>
           <WarmText v="sub" style={s.guideLine}>
-            아래 파츠를 눌러 캐릭터 위에 올려 보세요
+            아래 파츠를 눌러 캐릭터 위에 올려보세요
           </WarmText>
           <WarmText v="sub" style={s.guideLine}>
             드래그로 이동 · 두 손가락으로 크기·회전

--- a/components/ReportReasonModal.jsx
+++ b/components/ReportReasonModal.jsx
@@ -53,7 +53,7 @@ export default function ReportReasonModal({ visible, targetUser, submitting = fa
 
           {targetUser ? (
             <WarmText v="sub" size={14} color={C.textSub} style={{ marginBottom: 14 }}>
-              <WarmText v="sub" size={14} color={C.text}>{targetUser}</WarmText>님의 인증을 신고합니다.
+              <WarmText v="sub" size={14} color={C.text}>{targetUser}</WarmText>님의 인증을 신고해요.
             </WarmText>
           ) : null}
 

--- a/screens/BlockedUsersScreen.jsx
+++ b/screens/BlockedUsersScreen.jsx
@@ -55,7 +55,7 @@ export default function BlockedUsersScreen({ onBack }) {
       ) : error ? (
         <View style={s.center}>
           <WarmText v="sub" style={{ textAlign: 'center', marginBottom: 12 }}>{error}</WarmText>
-          <OutlineButton label="다시 시도" onPress={() => { setLoading(true); load().finally(() => setLoading(false)); }} />
+          <OutlineButton label="다시 시도하기" onPress={() => { setLoading(true); load().finally(() => setLoading(false)); }} />
         </View>
       ) : users.length === 0 ? (
         <View style={s.center}>

--- a/screens/JoinRoomScreen.jsx
+++ b/screens/JoinRoomScreen.jsx
@@ -31,7 +31,7 @@ export default function JoinRoomScreen({ onBack, onJoined, initialCode }) {
       onJoined?.(room);
     } catch (e) {
       console.warn('방 참여 실패:', e);
-      setError(e?.message || '해당 코드의 방을 찾을 수 없어요.');
+      setError(e?.message || '이 코드로 방을 찾지 못했어요. 코드를 다시 확인해주세요.');
     } finally {
       setSubmitting(false);
     }
@@ -53,7 +53,7 @@ export default function JoinRoomScreen({ onBack, onJoined, initialCode }) {
             maxLength={8}
             style={[s.input, { letterSpacing: 2 }]}
           />
-          <WarmText v="caption" color={C.text} style={{ marginTop: 4 }}>친구에게 받은 6자리 코드를 입력하세요 (예: RUN777, BOOK10)</WarmText>
+          <WarmText v="caption" color={C.text} style={{ marginTop: 4 }}>친구에게 받은 6자리 코드를 입력해주세요</WarmText>
         </View>
 
         {error ? (

--- a/screens/LoginScreen.jsx
+++ b/screens/LoginScreen.jsx
@@ -39,7 +39,7 @@ export default function LoginScreen({ onKakaoLogin, onAppleLogin, loading, error
         >
           <WarmText size={20}>💬</WarmText>
           <WarmText v="body" size={16} style={s.kakaoText}>
-            {loading ? '로그인 중...' : '카카오로 시작하기'}
+            {loading ? '로그인 중…' : '카카오로 시작하기'}
           </WarmText>
           <View style={{ width: 24 }} />
         </TouchableOpacity>
@@ -54,7 +54,7 @@ export default function LoginScreen({ onKakaoLogin, onAppleLogin, loading, error
           >
             <WarmText size={18} color="#000000"></WarmText>
             <WarmText v="body" size={16} style={s.appleText}>
-              {loading ? '로그인 중...' : 'Apple로 시작하기'}
+              {loading ? '로그인 중…' : 'Apple로 시작하기'}
             </WarmText>
             <View style={{ width: 24 }} />
           </TouchableOpacity>

--- a/screens/MissionTimeScreen.jsx
+++ b/screens/MissionTimeScreen.jsx
@@ -69,7 +69,7 @@ export default function MissionTimeScreen({ onBack, onSave, initialTime = { hour
 
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <T v="sub" style={{ lineHeight: 20, textAlign: 'center', marginTop: 8, marginBottom: 24 }}>
-          매일 이 시간에 오늘의 미션 알림을 받아요.{'\n'}스스로 지킬 수 있는 시간으로 설정하세요.
+          매일 이 시간에 오늘의 미션 알림을 받아요.{'\n'}스스로 지킬 수 있는 시간으로 정해보세요.
         </T>
 
         <View style={styles.previewWrap}>
@@ -114,7 +114,7 @@ export default function MissionTimeScreen({ onBack, onSave, initialTime = { hour
 
         <TouchableOpacity onPress={handleSave} activeOpacity={0.85} style={{ marginTop: 8 }}>
           <LinearGradient colors={['#26d67a', '#1ab065']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }} style={styles.saveBtn}>
-            <T v="btn">{pad(h)}:{pad(m)} 으로 설정하기</T>
+            <T v="btn">{pad(h)}:{pad(m)}으로 설정하기</T>
           </LinearGradient>
         </TouchableOpacity>
       </ScrollView>

--- a/screens/OnboardingScreen.jsx
+++ b/screens/OnboardingScreen.jsx
@@ -34,7 +34,7 @@ const SLIDES = [
     key: 'proof',
     hero: HeroProofCard,
     title: '함께라서 더 꾸준히',
-    subtitle: '서로 인증해주고 🔥 리액션,\n안 한 친구는 콕 찔러 재촉해요',
+    subtitle: '서로 인증해주고 🔥 리액션,\n안 한 친구는 콕 찔러 응원해요',
   },
 ];
 
@@ -204,7 +204,7 @@ function HeroProofCard({ C }) {
             <WarmText size={10} color="rgba(255,255,255,0.6)">🕐 19:02 미션 완료</WarmText>
           </View>
           <View style={[heroStyles.statusBadge, { backgroundColor: C.textSub, borderColor: C.brown }]}>
-            <WarmText size={9} color={C.text}>✓ 인증완료</WarmText>
+            <WarmText size={9} color={C.text}>✓ 인증 완료</WarmText>
           </View>
         </View>
       </View>

--- a/screens/ProofDetailScreen.jsx
+++ b/screens/ProofDetailScreen.jsx
@@ -82,7 +82,7 @@ export default function ProofDetailScreen({ roomId, proofId, missionTitle, isGro
     try {
       await api.post(`/api/v1/rooms/${roomId}/proofs/${proofId}/report`, { reason: reasonKey, detail: detail?.trim() || null });
       setReportOpen(false);
-      Alert.alert('신고 접수', '신고가 접수되었어요.\n운영자가 확인 후 조치할게요.');
+      Alert.alert('신고 접수', '신고가 접수됐어요.\n운영자가 확인 후 조치할게요.');
     } catch (e) {
       Alert.alert('신고 실패', e?.message || '신고를 접수하지 못했어요. 잠시 후 다시 시도해주세요.');
     } finally {
@@ -100,7 +100,7 @@ export default function ProofDetailScreen({ roomId, proofId, missionTitle, isGro
     try {
       await api.post(`/api/v1/users/${proof.authorUserId}/block`);
       H.success();
-      Alert.alert('차단했어요', '이 사용자의 인증이 보이지 않아요.');
+      Alert.alert('차단했어요', '이제 이 사용자의 인증이 보이지 않아요.');
       onChanged?.();
       onBack?.();
     } catch (e) {
@@ -152,7 +152,7 @@ export default function ProofDetailScreen({ roomId, proofId, missionTitle, isGro
       ) : error || !proof ? (
         <View style={s.center}>
           <WarmText v="sub" style={{ textAlign: 'center', marginBottom: 12 }}>{error || '인증을 찾을 수 없어요.'}</WarmText>
-          <OutlineButton label="다시 시도" onPress={() => { setLoading(true); load().finally(() => setLoading(false)); }} />
+          <OutlineButton label="다시 시도하기" onPress={() => { setLoading(true); load().finally(() => setLoading(false)); }} />
         </View>
       ) : (
         <ScrollView contentContainerStyle={s.content} showsVerticalScrollIndicator={false}>

--- a/screens/RoomDetailScreen.jsx
+++ b/screens/RoomDetailScreen.jsx
@@ -42,7 +42,7 @@ function OverlayStatusBadge({ status }) {
       backgroundColor: C.borderStrong, borderWidth: 1, borderColor: C.brown,
       borderRadius: 5, paddingHorizontal: 6, paddingVertical: 4,
     }}>
-      <WarmText v="caption" size={11} color={C.text}>{verified ? 'V 인증완료' : '대기 중'}</WarmText>
+      <WarmText v="caption" size={11} color={C.text}>{verified ? '✓ 인증 완료' : '대기 중'}</WarmText>
     </View>
   );
 }
@@ -139,7 +139,7 @@ function GridProofCard({ proof, onReact, onPeerVerify, onOpen }) {
         <View style={s.gridBottomOverlay}>
           <WarmText v="caption" size={11} color={C.bg}>{timeLabel(proof.createdAt)}</WarmText>
           <WarmText v="caption" size={11} color={C.bg} numberOfLines={1} style={{ flex: 1 }}>미션 완료</WarmText>
-          <WarmText v="caption" size={11} color={C.bg}>{proof.status === 'VERIFIED' ? 'V' : '대기'}</WarmText>
+          <WarmText v="caption" size={11} color={C.bg}>{proof.status === 'VERIFIED' ? '✓' : '대기'}</WarmText>
         </View>
       </View>
 
@@ -268,7 +268,7 @@ export default function RoomDetailScreen({
         <RoomTopBar title="방" onBack={onBack} />
         <View style={s.center}>
           <WarmText v="sub" style={{ textAlign: 'center', marginBottom: 12 }}>{error || '방 정보를 찾을 수 없어요.'}</WarmText>
-          <OutlineButton label="다시 시도" onPress={() => { setLoading(true); load().finally(() => setLoading(false)); }} />
+          <OutlineButton label="다시 시도하기" onPress={() => { setLoading(true); load().finally(() => setLoading(false)); }} />
         </View>
       </View>
     );
@@ -374,7 +374,7 @@ export default function RoomDetailScreen({
                           <NudgeChip nudged={nudged} onPress={() => handleNudge(m.memberId)} />
                         ) : (
                           <WarmText v="caption" size={11} color={m.todayStatus === 'PENDING' ? C.green : C.textSub}>
-                            {m.todayStatus === 'PENDING' ? '인증 대기' : '미인증'}
+                            {m.todayStatus === 'PENDING' ? '인증 대기' : '인증 전'}
                           </WarmText>
                         )}
                       </View>

--- a/screens/RoomHistoryScreen.jsx
+++ b/screens/RoomHistoryScreen.jsx
@@ -175,7 +175,7 @@ export default function RoomHistoryScreen({ roomId, onBack }) {
 
             {(selectedDay.proofs ?? []).length === 0 ? (
               <WarmText v="sub" size={13} color={C.textSub} style={{ marginTop: 12 }}>
-                이 날은 인증 기록이 없어요.
+                이날은 인증 기록이 없어요.
               </WarmText>
             ) : (
               <View style={{ marginTop: 12 }}>

--- a/screens/RoomListScreen.jsx
+++ b/screens/RoomListScreen.jsx
@@ -25,7 +25,7 @@ function RoomCard({ room, solo, onPress }) {
             <WarmText v="section" size={16} numberOfLines={1} style={{ flexShrink: 1 }}>{room.name}</WarmText>
             {mission?.source ? <SourceBadge source={mission.source} /> : null}
           </View>
-          <WarmText v="caption" color={C.text}>{solo ? '혼자 수행하는 방' : `멤버 ${room.memberCount}명`}</WarmText>
+          <WarmText v="caption" color={C.text}>{solo ? '혼자 하는 방' : `멤버 ${room.memberCount}명`}</WarmText>
         </View>
         {!solo && room.members ? <AvatarStack members={room.members} /> : null}
       </View>
@@ -171,7 +171,7 @@ export default function RoomListScreen({ onOpenRoom, onCreate, onJoin, onOpenNot
         ) : error ? (
           <View style={s.center}>
             <WarmText v="sub" style={{ textAlign: 'center', marginBottom: 12 }}>{error}</WarmText>
-            <OutlineButton label="다시 시도" onPress={() => { setLoading(true); load().finally(() => setLoading(false)); }} />
+            <OutlineButton label="다시 시도하기" onPress={() => { setLoading(true); load().finally(() => setLoading(false)); }} />
           </View>
         ) : isEmpty ? (
           <EmptyState />

--- a/screens/RoomSettingsScreen.jsx
+++ b/screens/RoomSettingsScreen.jsx
@@ -54,7 +54,7 @@ export default function RoomSettingsScreen({ roomId, onBack, onLeft, onChanged }
   };
 
   const kick = (member) => {
-    Alert.alert(`${member.nickname}님을 내보낼까요?`, '이 방에서 빠지게 됩니다.', [
+    Alert.alert(`${member.nickname}님을 내보낼까요?`, '이 방에서 나가게 돼요.', [
       { text: '취소', style: 'cancel' },
       {
         text: '내보내기', style: 'destructive',
@@ -74,7 +74,7 @@ export default function RoomSettingsScreen({ roomId, onBack, onLeft, onChanged }
   const leave = () => {
     Alert.alert(
       solo ? '방을 나갈까요?' : '방을 나갈까요?',
-      solo ? '오늘 미션과 인증 기록에서 빠지게 됩니다.' : '이 방의 인증 기록에서 빠지게 됩니다.',
+      solo ? '오늘 미션과 인증 기록에서 빠지게 돼요.' : '이 방의 인증 기록에서 빠지게 돼요.',
       [
         { text: '취소', style: 'cancel' },
         {
@@ -144,7 +144,7 @@ export default function RoomSettingsScreen({ roomId, onBack, onLeft, onChanged }
         ) : (
           <View style={s.soloInfo}>
             <WarmText size={26} style={{ marginBottom: 6 }}>{roomIconEmoji(room?.iconKey)}</WarmText>
-            <WarmText v="sub" style={{ textAlign: 'center' }}>혼자 수행하는 방이에요</WarmText>
+            <WarmText v="sub" style={{ textAlign: 'center' }}>혼자 하는 방이에요</WarmText>
           </View>
         )}
 

--- a/screens/RoomVerifyScreen.jsx
+++ b/screens/RoomVerifyScreen.jsx
@@ -149,7 +149,7 @@ export default function RoomVerifyScreen({ room, onBack, onVerified }) {
               <WarmText v="label">한마디 남기기 (선택)</WarmText>
               <TextInput
                 style={s.captionInput}
-                placeholder="오늘 미션 어떠셨나요?"
+                placeholder="오늘 미션 어땠어요?"
                 placeholderTextColor={C.textSub}
                 value={caption}
                 onChangeText={setCaption}

--- a/screens/SettingsScreen.jsx
+++ b/screens/SettingsScreen.jsx
@@ -18,7 +18,7 @@ import { pad } from '../utils/date';
 
 const openLink = (url) =>
   Linking.openURL(url).catch(() =>
-    Alert.alert('오류', '페이지를 열 수 없어요. 잠시 후 다시 시도해주세요.')
+    Alert.alert('페이지를 열 수 없어요', '잠시 후 다시 시도해주세요.')
   );
 
 /* ── 웜 토글 (Figma 46×28 pill) ──────────────────────── */
@@ -138,7 +138,7 @@ export default function SettingsScreen({
       const granted = await requestNotificationPermission();
       if (!granted) {
         Alert.alert(
-          '알림 권한 필요',
+          '알림 권한이 필요해요',
           '설정 > offmode > 알림에서 권한을 허용해주세요.',
           [
             { text: '취소', style: 'cancel' },
@@ -161,7 +161,7 @@ export default function SettingsScreen({
       const granted = await requestNotificationPermission();
       if (!granted) {
         Alert.alert(
-          '알림 권한 필요',
+          '알림 권한이 필요해요',
           '설정 > offmode > 알림에서 권한을 허용해주세요.',
           [
             { text: '취소', style: 'cancel' },
@@ -224,7 +224,7 @@ export default function SettingsScreen({
           />
           <SettingRow
             icon="🎲"
-            label="시간되면 자동으로 돌리기"
+            label="시간이 되면 자동으로 돌리기"
             sub="설정 시간에 룰렛 자동 시작"
             right={<WarmToggle value={autoRoulette} onValueChange={onSetAutoRoulette} />}
             last
@@ -242,7 +242,7 @@ export default function SettingsScreen({
           <SettingRow
             icon="🌙"
             label="일일 리마인더"
-            sub="미완료 미션 저녁 알림 (21:00)"
+            sub="미션을 아직 안 했다면 저녁에 알려요 (21:00)"
             right={<WarmToggle value={reminder} onValueChange={handleReminder} />}
             last
           />
@@ -313,7 +313,7 @@ export default function SettingsScreen({
             onPress={() => {
               Alert.alert(
                 '회원 탈퇴',
-                '탈퇴하면 모든 미션 기록과 배지가 삭제됩니다.\n정말 탈퇴하시겠어요?',
+                '탈퇴하면 모든 미션 기록이 사라져요.\n정말 탈퇴할까요?',
                 [
                   { text: '취소', style: 'cancel' },
                   { text: '탈퇴', style: 'destructive', onPress: onDeleteAccount },

--- a/screens/SignupScreen.jsx
+++ b/screens/SignupScreen.jsx
@@ -186,7 +186,7 @@ export default function SignupScreen({ defaultName = '', onComplete }) {
           <T v="logo" size={20} style={{ letterSpacing: 4, marginBottom: 10, fontFamily: GL }}>OFFMODE</T>
           <T v="title" size={22} color={W.green} style={{ marginBottom: 10 }}>미션 시간을 정해요</T>
           <T v="sub" style={{ textAlign: 'center' }}>
-            매일 이 시간에 오늘의 미션을 받아요.{'\n'}스스로 지킬 수 있는 시간으로 설정하세요.
+            매일 이 시간에 오늘의 미션을 받아요.{'\n'}스스로 지킬 수 있는 시간으로 정해보세요.
           </T>
         </View>
 

--- a/screens/VerifyScreen.jsx
+++ b/screens/VerifyScreen.jsx
@@ -230,7 +230,7 @@ export default function VerifyScreen({ mission, userMissionId, onBack, onVerifie
               <T v="label">한마디 남기기 (선택)</T>
               <TextInput
                 style={styles.captionInput}
-                placeholder="오늘 미션 어떠셨나요?"
+                placeholder="오늘 미션 어땠어요?"
                 placeholderTextColor={C.textSub}
                 value={caption}
                 onChangeText={setCaption}


### PR DESCRIPTION
## 🔗 Issue

- close #159

---

## 📌 Summary

- 앱 전반 사용자 대면 한국어 문구를 톤 가이드에 맞춰 통일 (16개 파일, 문구만 교체 / 구조 변경 없음)
- **어미**: `~됩니다/되었어요` → `~돼요/됐어요` 축약 존댓말체
- **다이얼로그**: 제목 "~할까요?" 질문형 통일 (탈퇴/방 나가기 등)
- **CTA**: `다시 시도` → `다시 시도하기` (`~하기` 동사형, 4곳)
- **오타/맞춤법**: `V 인증완료` → `✓ 인증 완료`, `시간되면`→`시간이 되면`, `이 날`→`이날`, 조사 붙임, 말줄임표 `...`→`…`
- **한자어 완화**: `미인증`→`인증 전`, `수행`→`하는`, `달성 시`→`모으면`
- **죽은 기능 정리**: 회원탈퇴 문구의 미사용 '배지' 단어 제거
- 보류(제외): 약관 '간주됩니다'(법률 문구), `인증함→인증했어요`(칩 폭 확인 필요), 외부 초대 공유 메시지, 샘플 데이터

---

## ✅ Test

- [x] `npm run lint` 0 errors (기존 warning 외 신규 없음)
- [x] diff 1:1 문구 교체(34줄) 확인 — 구조/컴포넌트/색 변경 없음
- [x] 보류 4종 미변경 확인 (약관·인증함 3곳·초대메시지)
- [ ] 실기기: `✓` 아이콘·`✓ 인증 완료` 칩 폭, `로그인 중…` 렌더 확인 (리뷰어)