### PR TITLE
[Fix] #170 미션 수신 시간 화면 웜크림 디자인 적용

### DIFF
--- a/screens/MissionTimeScreen.jsx
+++ b/screens/MissionTimeScreen.jsx
@@ -1,15 +1,17 @@
 import React, { useState, useMemo } from 'react';
 import {
-  View, Text, StyleSheet, TouchableOpacity,
+  View, StyleSheet, TouchableOpacity,
   ScrollView, Dimensions,
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { useColors } from '../utils/useColors';
-import T from '../components/ThemedText';
+import { Ionicons } from '@expo/vector-icons';
+import { W } from '../constants/warm';
+import WarmText from '../components/WarmText';
+import { GreenButton } from '../components/RoomBits';
 import WheelPicker from '../components/WheelPicker';
+import * as H from '../utils/haptics';
 import { pad } from '../utils/date';
 
-const F = 'Kkukkukk';
+const GL = 'GmarketSansLight';
 const { width } = Dimensions.get('window');
 
 const HOURS   = Array.from({ length: 24 }, (_, i) => i);
@@ -31,92 +33,94 @@ function ampmLabel(h) {
   return '밤';
 }
 
-export default function MissionTimeScreen({ onBack, onSave, initialTime = { hour: 8, minute: 0 } }) {
-  const C = useColors();
-  const styles = useMemo(() => makeStyles(C), [C]);
-
-  // 공용 WheelPicker 항목 텍스트 (기존 이 화면 전용 렌더링 그대로)
-  const renderWheelLabel = (val, selected) => (
-    <T
-      v="sub"
-      size={selected ? 34 : 28}
-      color={selected ? C.text : (C.isDark ? C.textSub : C.green)}
+// 웜 톤 휠 항목 (SignupScreen step2와 동일 규격)
+function renderWheelLabel(val, selected) {
+  return (
+    <WarmText
+      size={selected ? 30 : 24}
+      color={selected ? W.text : W.green}
       style={{ opacity: selected ? 1 : 0.4 }}
     >
       {pad(val)}
-    </T>
+    </WarmText>
   );
+}
+
+export default function MissionTimeScreen({ onBack, onSave, initialTime = { hour: 8, minute: 0 } }) {
+  const C = W;
+  const s = useMemo(() => makeStyles(C), [C]);
 
   const [hourIdx,   setHourIdx]   = useState(initialTime.hour);
   const [minuteIdx, setMinuteIdx] = useState(Math.round(initialTime.minute / 5));
   const h = HOURS[hourIdx];
   const m = MINUTES[minuteIdx];
-  
+
   const handleSave = () => {
+    H.success();
     onSave && onSave({ hour: h, minute: m });
     onBack && onBack();
   };
 
   return (
-    <View style={styles.screen}>
-      <View style={styles.header}>
-        <TouchableOpacity style={styles.backBtn} onPress={onBack} activeOpacity={0.7}>
-          <Text style={styles.backIcon}>←</Text>
+    <View style={s.screen}>
+      {/* 헤더 — SettingsScreen과 동일 규격 */}
+      <View style={s.header}>
+        <TouchableOpacity style={s.side} onPress={() => { H.tap(); onBack && onBack(); }} hitSlop={12} activeOpacity={0.7}>
+          <Ionicons name="chevron-back" size={24} color={C.text} />
         </TouchableOpacity>
-        <T v="section" size={17}>미션 수신 시간</T>
-        <View style={{ width: 40 }} />
+        <WarmText v="body" size={20}>미션 수신 시간</WarmText>
+        <View style={s.side} />
       </View>
 
-      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-        <T v="sub" style={{ lineHeight: 20, textAlign: 'center', marginTop: 8, marginBottom: 24 }}>
+      <ScrollView contentContainerStyle={s.content} showsVerticalScrollIndicator={false}>
+        <WarmText v="sub" style={{ textAlign: 'center', marginBottom: 24 }}>
           매일 이 시간에 오늘의 미션 알림을 받아요.{'\n'}스스로 지킬 수 있는 시간으로 정해보세요.
-        </T>
+        </WarmText>
 
-        <View style={styles.previewWrap}>
-          <T v="green" style={{ opacity: 0.8, marginBottom: 4, letterSpacing: 1 }}>{ampmLabel(h)}</T>
-          <T v="stat" size={56} style={{ letterSpacing: 2, lineHeight: 66 }}>{pad(h)} : {pad(m)}</T>
-          <T v="label" style={{ marginTop: 6 }}>매일 이 시간에 미션 도착</T>
+        {/* 시간 미리보기 */}
+        <View style={s.previewWrap}>
+          <WarmText v="body" color={C.green} style={{ opacity: 0.8, marginBottom: 4, letterSpacing: 1 }}>{ampmLabel(h)}</WarmText>
+          <WarmText color={C.text} size={52} style={{ letterSpacing: 2, lineHeight: 62, fontFamily: GL }}>{pad(h)} : {pad(m)}</WarmText>
+          <WarmText v="label" color={C.textSub} style={{ marginTop: 6 }}>매일 이 시간에 미션 도착</WarmText>
         </View>
 
-        <View style={styles.pickerRow}>
-          <View style={styles.pickerBlock}>
-            <T v="sub" style={{ marginBottom: 8, textAlign: 'center' }}>시</T>
+        {/* 휠 피커 */}
+        <View style={s.pickerRow}>
+          <View style={s.pickerBlock}>
+            <WarmText v="sub" style={{ marginBottom: 8, textAlign: 'center' }}>시</WarmText>
             <WheelPicker items={HOURS}   selectedIndex={hourIdx}   onChange={setHourIdx}   colors={C} renderLabel={renderWheelLabel} />
           </View>
-          <T v="sub" size={36} style={{ marginTop: 16, paddingHorizontal: 8, opacity: 0.5 }}>:</T>
-          <View style={styles.pickerBlock}>
-            <T v="sub" style={{ marginBottom: 8, textAlign: 'center' }}>분</T>
+          <WarmText size={32} color={C.textSub} style={{ marginTop: 12, paddingHorizontal: 8, opacity: 0.5 }}>:</WarmText>
+          <View style={s.pickerBlock}>
+            <WarmText v="sub" style={{ marginBottom: 8, textAlign: 'center' }}>분</WarmText>
             <WheelPicker items={MINUTES} selectedIndex={minuteIdx} onChange={setMinuteIdx} colors={C} renderLabel={renderWheelLabel} />
           </View>
         </View>
 
-        <T v="body" color={C.textSub} style={{ marginBottom: 12 }}>빠른 선택</T>
-        <View style={styles.presetGrid}>
+        {/* 빠른 선택 */}
+        <WarmText v="body" color={C.textSub} style={{ marginBottom: 12 }}>빠른 선택</WarmText>
+        <View style={s.presetGrid}>
           {PRESETS.map((p) => {
             const active = p.time.h === h && p.time.m === m;
             return (
               <TouchableOpacity
                 key={p.label}
-                style={[styles.presetChip, active && styles.presetChipActive]}
-                onPress={() => { setHourIdx(p.time.h); setMinuteIdx(p.time.m / 5); }}
+                style={[s.presetChip, active && s.presetChipActive]}
+                onPress={() => { H.tap(); setHourIdx(p.time.h); setMinuteIdx(p.time.m / 5); }}
                 activeOpacity={0.7}
               >
-                <T v="body" size={16} color={active ? C.green : C.textSub} style={{ marginBottom: 2 }}>
+                <WarmText v="body" size={15} color={active ? C.green : C.textSub} style={{ marginBottom: 2 }}>
                   {pad(p.time.h)}:{pad(p.time.m)}
-                </T>
-                <T v="caption" color={active ? C.green : C.textSub} style={{ opacity: active ? 1 : 0.7 }}>
+                </WarmText>
+                <WarmText v="caption" color={active ? C.green : C.textSub} style={{ opacity: active ? 1 : 0.7 }}>
                   {p.label}
-                </T>
+                </WarmText>
               </TouchableOpacity>
             );
           })}
         </View>
 
-        <TouchableOpacity onPress={handleSave} activeOpacity={0.85} style={{ marginTop: 8 }}>
-          <LinearGradient colors={['#26d67a', '#1ab065']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }} style={styles.saveBtn}>
-            <T v="btn">{pad(h)}:{pad(m)}으로 설정하기</T>
-          </LinearGradient>
-        </TouchableOpacity>
+        <GreenButton label={`${pad(h)}:${pad(m)}으로 설정하기`} onPress={handleSave} />
       </ScrollView>
     </View>
   );
@@ -124,27 +128,22 @@ export default function MissionTimeScreen({ onBack, onSave, initialTime = { hour
 
 function makeStyles(C) {
   return StyleSheet.create({
-    screen: { flex: 1, backgroundColor: C.bg },
-    header: {
+    screen:  { flex: 1, backgroundColor: C.bg },
+    header:  {
       flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-      paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8,
+      paddingHorizontal: 12, paddingTop: 16, paddingBottom: 12,
     },
-    backBtn: {
-      width: 40, height: 40, borderRadius: 12,
-      backgroundColor: C.surface, borderWidth: 1, borderColor: C.border,
-      alignItems: 'center', justifyContent: 'center',
-    },
-    backIcon:    { fontSize: 20, color: C.text },
-    content:     { paddingHorizontal: 20, paddingBottom: 40 },
+    side:    { width: 36, height: 36, alignItems: 'center', justifyContent: 'center' },
+    content: { paddingHorizontal: 20, paddingTop: 8, paddingBottom: 40 },
     previewWrap: {
       alignItems: 'center', backgroundColor: C.surface,
       borderRadius: 20, borderWidth: 1, borderColor: C.greenBorder,
-      paddingVertical: 24, marginBottom: 28,
+      paddingVertical: 20, marginBottom: 24,
     },
     pickerRow: {
       flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
       backgroundColor: C.surface, borderRadius: 20, borderWidth: 1, borderColor: C.border,
-      paddingHorizontal: 8, paddingVertical: 12, marginBottom: 28,
+      paddingHorizontal: 8, paddingVertical: 12, marginBottom: 24,
     },
     pickerBlock: { flex: 1, alignItems: 'stretch' },
     presetGrid:  { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 28 },
@@ -153,9 +152,6 @@ function makeStyles(C) {
       borderRadius: 12, paddingHorizontal: 14, paddingVertical: 10,
       alignItems: 'center', minWidth: (width - 40 - 16) / 3,
     },
-    presetChipActive:  { backgroundColor: C.greenFaint, borderColor: C.greenBorder },
-    presetTimeActive:  { color: C.green },
-    presetLabelActive: { color: C.green, opacity: 1 },
-    saveBtn:     { borderRadius: 16, paddingVertical: 17, alignItems: 'center' },
+    presetChipActive: { backgroundColor: C.greenFaint, borderColor: C.greenBorder },
   });
 }


### PR DESCRIPTION
## 🔗 Issue

- close #170

---

## 📌 Summary

- `MissionTimeScreen`의 팔레트를 `useColors()`(구 다크/라이트 테마) → 웜크림 `W` 고정으로 전환
- 텍스트 컴포넌트를 `<T>`(Kkukkukk) → `<WarmText>`(Gmarket Sans)로 교체
- 헤더를 `SettingsScreen`과 동일 규격(`Ionicons chevron-back` + 20pt 타이틀)으로 통일
- 저장 버튼을 `LinearGradient` 형광 그린 → 공용 `GreenButton`(딥그린)으로 교체
- 휠 숫자(30/24)·미리보기 시각(52pt) 크기를 회원가입 step2와 동일하게 정렬
- 프리셋 칩 탭 `H.tap()`, 저장 `H.success()` 햅틱 추가

---

## ✅ Test

- [x] `npx eslint .` 통과 (0 errors)
- [ ] 실기기 확인: 설정 → 알림 시간 진입 시 웜크림 톤으로 표시되는지 (dev client 리빌드 필요 — 아래 참고)

> 참고: 현재 시뮬레이터/기기 dev client가 #164 Meta SDK 이전 빌드라 `NativeEventEmitter` 오류로 앱이 뜨지 않습니다. 이 PR과 무관한 이슈이며 `npm run ios` 리빌드 후 확인 예정.