### PR TITLE
[Infra] #84 v0.6.0 배포

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -67,7 +67,7 @@ if (!__DEV__ && Platform.OS === 'ios') {
   }
 }
 import { api } from './utils/api';
-import { scheduleMissionNotification } from './utils/notifications';
+import { scheduleMissionNotification, registerPushToken } from './utils/notifications';
 import useAuth from './utils/useAuth';
 import useMissionRouletteTrigger from './utils/useMissionRouletteTrigger';
 
@@ -132,6 +132,7 @@ function AppInner() {
     if (user.autoRoulette != null) setAutoRoulette(user.autoRoulette);
     await loadTodayMission();
     scheduleMissionNotification(hour, minute);
+    registerPushToken();   // 원격 푸시(콕 찌르기) 수신용 — 실패해도 세션에는 영향 없음
   };
 
   // 로그아웃 시 세션 상태 초기화
@@ -166,6 +167,7 @@ function AppInner() {
     setMissionTime(mt);
     await loadTodayMission();
     scheduleMissionNotification(mt.hour, mt.minute);
+    registerPushToken();
     A.logRegistration(authProvider);   // Meta 광고 — 가입 완료 이벤트
     setShowOnboarding(true);   // 신규 유저: 인증 완료 후 온보딩 캐러셀 1회 노출
     setAuthStatus('authenticated');

--- a/app.json
+++ b/app.json
@@ -15,10 +15,12 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.minnnj.offmode",
-      "buildNumber": "1",
+      "buildNumber": "2",
       "appleTeamId": "SX5KZM28U5",
       "usesAppleSignIn": true,
-      "associatedDomains": ["applinks:offmodechallenge.com"],
+      "associatedDomains": [
+        "applinks:offmodechallenge.com"
+      ],
       "privacyPolicyUrl": "https://fuchsia-belief-040.notion.site/OFFMODE-34309a0b0e3e809b965bd62530627431"
     },
     "android": {
@@ -35,9 +37,16 @@
           "action": "VIEW",
           "autoVerify": true,
           "data": [
-            { "scheme": "https", "host": "offmodechallenge.com", "pathPrefix": "/invite" }
+            {
+              "scheme": "https",
+              "host": "offmodechallenge.com",
+              "pathPrefix": "/invite"
+            }
           ],
-          "category": ["BROWSABLE", "DEFAULT"]
+          "category": [
+            "BROWSABLE",
+            "DEFAULT"
+          ]
         }
       ]
     },
@@ -70,10 +79,10 @@
       [
         "react-native-fbsdk-next",
         {
-          "appID": "1650144739389762",
-          "clientToken": "05fe1003111565de48c6c708a5a4239b",
+          "appID": "2518223585358464",
+          "clientToken": "d5e76b8307a965b7389daf5a155b8de0",
           "displayName": "offmode",
-          "scheme": "fb1650144739389762",
+          "scheme": "fb2518223585358464",
           "isAutoInitEnabled": true,
           "autoLogAppEventsEnabled": true,
           "advertiserIDCollectionEnabled": true,

--- a/backend/src/main/java/com/offmode/OffmodeApplication.java
+++ b/backend/src/main/java/com/offmode/OffmodeApplication.java
@@ -2,7 +2,9 @@ package com.offmode;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class OffmodeApplication {
   public static void main(String[] args) {

--- a/backend/src/main/java/com/offmode/boundedcontext/room/api/v1/RoomController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/api/v1/RoomController.java
@@ -6,6 +6,7 @@ import com.offmode.boundedcontext.room.dto.request.RenameRoomRequest;
 import com.offmode.boundedcontext.room.dto.request.ReportRequest;
 import com.offmode.boundedcontext.room.dto.request.RoomReactRequest;
 import com.offmode.boundedcontext.room.dto.request.SetRoomMissionRequest;
+import com.offmode.boundedcontext.room.dto.request.UpdateRoomMissionTitleRequest;
 import com.offmode.boundedcontext.room.dto.response.ConfirmResponse;
 import com.offmode.boundedcontext.room.dto.response.MissionCandidateResponse;
 import com.offmode.boundedcontext.room.dto.response.NudgeResponse;
@@ -117,6 +118,16 @@ public class RoomController {
       @PathVariable Long roomId,
       @Valid @RequestBody SetRoomMissionRequest request) {
     return ResponseEntity.ok(roomMissionService.setTodayMission(userId, roomId, request));
+  }
+
+  // PATCH /api/v1/rooms/{roomId}/mission - 오늘 미션 제목 수정
+  @PatchMapping("/{roomId}/mission")
+  public ResponseEntity<RoomMissionResponse> updateTodayMissionTitle(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long roomId,
+      @Valid @RequestBody UpdateRoomMissionTitleRequest request) {
+    return ResponseEntity.ok(
+        roomMissionService.updateTodayMissionTitle(userId, roomId, request.getTitle()));
   }
 
   // ===== 인증/리액션 =====

--- a/backend/src/main/java/com/offmode/boundedcontext/room/dto/request/UpdateRoomMissionTitleRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/dto/request/UpdateRoomMissionTitleRequest.java
@@ -1,0 +1,13 @@
+package com.offmode.boundedcontext.room.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateRoomMissionTitleRequest {
+
+  @NotBlank
+  @Size(max = 100)
+  private String title;
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/NudgeSenderResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/NudgeSenderResponse.java
@@ -1,0 +1,4 @@
+package com.offmode.boundedcontext.room.dto.response;
+
+/** 오늘 나를 콕 찌른 사람 (방 상세에서 배너로 노출) */
+public record NudgeSenderResponse(Long userId, String nickname, String avatarId) {}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/RoomDetailResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/RoomDetailResponse.java
@@ -18,4 +18,7 @@ public record RoomDetailResponse(
     MemberTodayStatus myTodayStatus,
     ProgressResponse progress,
     List<RoomMemberResponse> members,
-    List<RoomProofResponse> proofs) {}
+    List<RoomProofResponse> proofs,
+    List<NudgeSenderResponse> receivedNudges,
+    // 인증이 하나라도 올라오면 false — 미션 이름 수정 잠금 여부를 서버가 판단해 내려준다
+    boolean missionEditable) {}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomNudgeRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomNudgeRepository.java
@@ -22,4 +22,12 @@ public interface RoomNudgeRepository extends JpaRepository<RoomNudge, Long> {
           + "where n.roomMission.id = :missionId and n.fromUser.id = :fromUserId")
   List<Long> findToUserIdsByMissionAndFromUser(
       @Param("missionId") Long missionId, @Param("fromUserId") Long fromUserId);
+
+  // 오늘 미션에서 내가 받은 콕 찌르기 (보낸 사람 정보까지 한 번에 로드)
+  @Query(
+      "select n from RoomNudge n join fetch n.fromUser "
+          + "where n.roomMission.id = :missionId and n.toUser.id = :toUserId "
+          + "order by n.createdAt asc")
+  List<RoomNudge> findWithFromUserByMissionAndToUser(
+      @Param("missionId") Long missionId, @Param("toUserId") Long toUserId);
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -57,6 +57,9 @@ public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
 
   boolean existsByRoomMissionIdAndUserId(Long roomMissionId, Long userId);
 
+  // 오늘 미션에 인증이 하나라도 올라왔는지 (인증 시작 후 미션 제목 수정 잠금용)
+  boolean existsByRoomMissionId(Long roomMissionId);
+
   List<RoomProof> findByRoomMissionIdInOrderByCreatedAtAsc(List<Long> roomMissionIds);
 
   // 방의 오늘 미션에 대해 VERIFIED 한 멤버(유저) 수

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomMissionService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomMissionService.java
@@ -9,6 +9,7 @@ import com.offmode.boundedcontext.room.dto.response.RoomMissionResponse;
 import com.offmode.boundedcontext.room.entity.Room;
 import com.offmode.boundedcontext.room.entity.RoomMission;
 import com.offmode.boundedcontext.room.repository.RoomMissionRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
 import com.offmode.boundedcontext.room.types.MissionSource;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.status.ErrorStatus;
@@ -29,6 +30,7 @@ public class RoomMissionService {
 
   private final RoomMissionRepository missionRepository;
   private final MissionRepository masterMissionRepository;
+  private final RoomProofRepository proofRepository;
   private final RoomService roomService;
 
   private static final int CANDIDATE_LIMIT = 7;
@@ -103,6 +105,35 @@ public class RoomMissionService {
                 .build());
 
     return RoomMissionResponse.from(saved);
+  }
+
+  /**
+   * 오늘 미션의 제목만 바꾼다. 미션을 정할 때와 같이 방 멤버라면 누구나 수정할 수 있지만, 인증이 하나라도 올라온 뒤에는 잠근다 — 먼저 인증한 사람이 다른 미션을 한
+   * 꼴이 되기 때문이다.
+   *
+   * <p>source·category 는 그대로 둔다 — 제목만 다듬은 랜덤 미션이 미분류로 바뀌어 레벨·배지 집계에서 빠지는 것을 막기 위해서다.
+   */
+  @Transactional
+  public RoomMissionResponse updateTodayMissionTitle(Long userId, Long roomId, String title) {
+    roomService.getRoomOrThrow(roomId);
+    roomService.getMembershipOrThrow(roomId, userId);
+
+    RoomMission todayMission =
+        missionRepository
+            .findByRoomIdAndDate(roomId, LocalDate.now())
+            .orElseThrow(() -> new BusinessException(ErrorStatus.ROOM_MISSION_NOT_SET));
+
+    if (proofRepository.existsByRoomMissionId(todayMission.getId())) {
+      throw new BusinessException(ErrorStatus.ROOM_MISSION_LOCKED);
+    }
+
+    String trimmed = title == null ? "" : title.trim();
+    if (trimmed.isEmpty()) {
+      throw new BusinessException(ErrorStatus.BAD_REQUEST);
+    }
+
+    todayMission.setTitle(trimmed);
+    return RoomMissionResponse.from(missionRepository.save(todayMission));
   }
 
   private Mission getMasterMissionOrThrow(Long missionId) {

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
@@ -5,6 +5,7 @@ import com.offmode.boundedcontext.room.dto.request.JoinRoomRequest;
 import com.offmode.boundedcontext.room.dto.response.GroupRoomSummaryResponse;
 import com.offmode.boundedcontext.room.dto.response.MiniMissionResponse;
 import com.offmode.boundedcontext.room.dto.response.NudgeResponse;
+import com.offmode.boundedcontext.room.dto.response.NudgeSenderResponse;
 import com.offmode.boundedcontext.room.dto.response.ProgressResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomDetailResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomListResponse;
@@ -30,6 +31,7 @@ import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.BlockService;
 import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
+import com.offmode.global.push.PushService;
 import com.offmode.global.status.ErrorStatus;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -61,6 +63,7 @@ public class RoomService {
   private final UserService userService;
   private final RoomProofAssembler proofAssembler;
   private final BlockService blockService;
+  private final PushService pushService;
 
   // ===== 방 생성/참여/목록 =====
 
@@ -239,6 +242,20 @@ public class RoomService {
     MemberTodayStatus myTodayStatus =
         missionId == null ? MemberTodayStatus.NONE : toTodayStatus(statusByUserId.get(userId));
 
+    // 오늘 나를 콕 찌른 사람 (이미 인증을 마쳤으면 재촉할 이유가 없으므로 숨긴다)
+    List<NudgeSenderResponse> receivedNudges =
+        (missionId == null || myTodayStatus == MemberTodayStatus.DONE)
+            ? List.of()
+            : nudgeRepository.findWithFromUserByMissionAndToUser(missionId, userId).stream()
+                .filter(nudge -> !blockedIds.contains(nudge.getFromUser().getId()))
+                .map(
+                    nudge ->
+                        new NudgeSenderResponse(
+                            nudge.getFromUser().getId(),
+                            nudge.getFromUser().getName(),
+                            nudge.getFromUser().getAvatar()))
+                .toList();
+
     return new RoomDetailResponse(
         room.getId(),
         room.getName(),
@@ -252,7 +269,10 @@ public class RoomService {
         myTodayStatus,
         new ProgressResponse(verifiedCount, memberCount),
         members,
-        proofs);
+        proofs,
+        receivedNudges,
+        // 차단으로 가려진 인증도 잠금 사유이므로 visibleProofs 가 아닌 전체 목록으로 판단한다
+        missionId != null && todayProofs.isEmpty());
   }
 
   // ===== 방 설정 =====
@@ -338,6 +358,14 @@ public class RoomService {
               .fromUser(myMembership.getUser())
               .toUser(target.getUser())
               .build());
+
+      // 멱등이라 중복 요청에는 다시 보내지 않는다. 발송 실패해도 콕 찌르기 자체는 성공 처리된다.
+      pushService.send(
+          targetUserId,
+          target.getUser().getExpoPushToken(),
+          "👉 " + myMembership.getUser().getName() + "님이 콕 찔렀어요",
+          todayMission.getTitle() + " — 아직 인증 전이에요!",
+          Map.of("type", "nudge", "roomId", roomId));
     }
 
     return new NudgeResponse(memberId, true);

--- a/backend/src/main/java/com/offmode/boundedcontext/user/api/v1/UserController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/api/v1/UserController.java
@@ -1,5 +1,6 @@
 package com.offmode.boundedcontext.user.api.v1;
 
+import com.offmode.boundedcontext.user.dto.request.UpdatePushTokenRequest;
 import com.offmode.boundedcontext.user.dto.request.UpdateUserProfileRequest;
 import com.offmode.boundedcontext.user.dto.response.BlockResponse;
 import com.offmode.boundedcontext.user.dto.response.BlockedUserResponse;
@@ -56,6 +57,15 @@ public class UserController {
             request.getMissionMinute(),
             request.getAutoRoulette());
     return ResponseEntity.ok(updated);
+  }
+
+  // PUT /api/v1/users/me/push-token
+  // body: { "token": "ExponentPushToken[...]" }  — token 이 비어 있으면 해제
+  @PutMapping("/me/push-token")
+  public ResponseEntity<Void> updatePushToken(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody UpdatePushTokenRequest request) {
+    userService.updatePushToken(userId, request.getToken());
+    return ResponseEntity.noContent().build();
   }
 
   // POST /api/v1/users/{userId}/block  (userId = 차단 대상)

--- a/backend/src/main/java/com/offmode/boundedcontext/user/dto/request/UpdatePushTokenRequest.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/dto/request/UpdatePushTokenRequest.java
@@ -1,0 +1,12 @@
+package com.offmode.boundedcontext.user.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdatePushTokenRequest {
+
+  /** Expo 푸시 토큰. null/빈 값이면 해제(로그아웃 등)로 처리한다. */
+  @Size(max = 255)
+  private String token;
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/user/entity/User.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.offmode.boundedcontext.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
@@ -45,6 +46,11 @@ public class User {
   @Builder.Default private Integer missionMinute = 0;
 
   @Builder.Default private Boolean autoRoulette = true;
+
+  // Expo 푸시 토큰 (ExponentPushToken[...]) — 응답으로 내보내지 않는다
+  @JsonIgnore
+  @Column(name = "expo_push_token")
+  private String expoPushToken;
 
   @CreationTimestamp private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/repository/UserRepository.java
@@ -3,7 +3,17 @@ package com.offmode.boundedcontext.user.repository;
 import com.offmode.boundedcontext.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+  // 같은 기기 토큰이 다른 계정에 남아 있으면 떼어낸다 (기기 공유·계정 전환 시 오배송 방지)
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "UPDATE User u SET u.expoPushToken = null "
+          + "WHERE u.expoPushToken = :token AND u.id <> :userId")
+  void clearPushTokenForOtherUsers(@Param("token") String token, @Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
@@ -74,6 +74,19 @@ public class UserService {
     return userRepository.save(user);
   }
 
+  /** Expo 푸시 토큰을 등록/해제한다. 같은 토큰이 다른 계정에 남아 있으면(기기 공유·재로그인) 먼저 떼어내 한 기기가 한 계정에만 매핑되게 한다. */
+  @Transactional
+  public void updatePushToken(Long userId, String token) {
+    User user = getById(userId);
+    String normalized = (token == null || token.isBlank()) ? null : token.trim();
+
+    if (normalized != null) {
+      userRepository.clearPushTokenForOtherUsers(normalized, userId);
+    }
+    user.setExpoPushToken(normalized);
+    userRepository.save(user);
+  }
+
   @Transactional
   public void levelUp(Long userId, int verifiedCount) {
     User user = getById(userId);

--- a/backend/src/main/java/com/offmode/global/push/PushService.java
+++ b/backend/src/main/java/com/offmode/global/push/PushService.java
@@ -1,0 +1,103 @@
+package com.offmode.global.push;
+
+import com.offmode.boundedcontext.user.repository.UserRepository;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Expo Push Service로 원격 푸시를 보낸다.
+ *
+ * <p>발송은 별도 스레드에서 이뤄지고 실패해도 예외를 밖으로 던지지 않는다 — 푸시가 실패해도 호출부(콕 찌르기 등)의 본래 동작은 성공한다. 토큰이 만료된
+ * 경우(DeviceNotRegistered) 저장된 토큰을 지운다.
+ *
+ * <p>LazyInitializationException 을 피하기 위해 엔티티가 아니라 스칼라 값(userId, token)만 받는다.
+ */
+@Slf4j
+@Service
+public class PushService {
+
+  private static final String EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
+  private static final String TOKEN_PREFIX = "ExponentPushToken[";
+  private static final String ANDROID_CHANNEL_ID = "offmode-silent-notifications";
+
+  private final RestClient restClient;
+  private final UserRepository userRepository;
+
+  public PushService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(Duration.ofSeconds(3));
+    factory.setReadTimeout(Duration.ofSeconds(5));
+
+    this.restClient = RestClient.builder().requestFactory(factory).build();
+  }
+
+  /** 토큰이 없거나 형식이 다르면 조용히 건너뛴다. */
+  @Async
+  public void send(Long userId, String token, String title, String body, Map<String, Object> data) {
+    if (token == null || token.isBlank() || !token.startsWith(TOKEN_PREFIX)) {
+      log.debug("푸시 토큰 없음 — 발송 생략 (userId={})", userId);
+      return;
+    }
+
+    // Map.of 는 null 값을 허용하지 않는다. sound=null 이 Expo 의 무음 발송 규약이라 HashMap 을 쓴다.
+    Map<String, Object> message = new HashMap<>();
+    message.put("to", token);
+    message.put("title", title);
+    message.put("body", body);
+    message.put("data", data == null ? Map.of() : data);
+    // TODO: 효과음 정식 도입 시 "default" 로 바꾼다 (프론트 notifications.js 의 TODO 와 동시에).
+    message.put("sound", null);
+    message.put("channelId", ANDROID_CHANNEL_ID);
+
+    try {
+      ExpoPushResponse response =
+          restClient
+              .post()
+              .uri(EXPO_PUSH_URL)
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(List.of(message))
+              .retrieve()
+              .body(ExpoPushResponse.class);
+
+      handleResponse(userId, response);
+    } catch (Exception e) {
+      log.warn("푸시 발송 실패 (userId={}): {}", userId, e.getMessage());
+    }
+  }
+
+  private void handleResponse(Long userId, ExpoPushResponse response) {
+    if (response == null || response.data() == null || response.data().isEmpty()) return;
+
+    ExpoPushTicket ticket = response.data().get(0);
+    if ("ok".equals(ticket.status())) return;
+
+    log.warn("푸시 티켓 오류 (userId={}): {}", userId, ticket.message());
+
+    String errorCode = ticket.details() == null ? null : ticket.details().error();
+    if ("DeviceNotRegistered".equals(errorCode)) {
+      userRepository
+          .findById(userId)
+          .ifPresent(
+              user -> {
+                user.setExpoPushToken(null);
+                userRepository.save(user);
+              });
+    }
+  }
+
+  record ExpoPushResponse(List<ExpoPushTicket> data) {}
+
+  record ExpoPushTicket(String status, String message, ExpoPushTicketDetails details) {}
+
+  record ExpoPushTicketDetails(String error) {}
+}

--- a/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
+++ b/backend/src/main/java/com/offmode/global/status/ErrorStatus.java
@@ -57,6 +57,7 @@ public enum ErrorStatus {
   ROOM_NUDGE_TARGET_DONE(HttpStatus.BAD_REQUEST, "ROOM_400_003", "이미 인증을 완료한 멤버입니다."),
   ROOM_SELF_REPORT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "ROOM_400_004", "본인 인증은 신고할 수 없습니다."),
   ROOM_ALREADY_REPORTED(HttpStatus.CONFLICT, "ROOM_409_004", "이미 신고한 콘텐츠입니다."),
+  ROOM_MISSION_LOCKED(HttpStatus.CONFLICT, "ROOM_409_005", "이미 인증이 시작돼 미션 이름을 바꿀 수 없습니다."),
 
   // File
   FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE_400_001", "업로드할 파일이 비어있습니다."),

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -23,9 +23,8 @@ spring:
     locations:
       - classpath:db/migration/h2
 
-apple:
-  # dev 실기기 빌드의 번들 ID는 .dev 접미사가 붙는다 (ios PRODUCT_BUNDLE_IDENTIFIER=com.minnnj.offmode.dev)
-  bundle-id: com.minnnj.offmode.dev
+# apple.bundle-id 는 application.yml 의 com.minnnj.offmode 를 그대로 쓴다.
+# (dev 빌드도 같은 번들 ID 를 쓰므로 .dev 접미사 오버라이드를 두면 Apple 로그인 aud 검증이 실패한다)
 
 offmode:
   security:

--- a/backend/src/main/resources/db/migration/h2/V12__add_user_push_token.sql
+++ b/backend/src/main/resources/db/migration/h2/V12__add_user_push_token.sql
@@ -1,0 +1,2 @@
+-- 사용자별 Expo 푸시 토큰 (콕 찌르기 등 원격 알림 발송용)
+ALTER TABLE users ADD COLUMN expo_push_token VARCHAR(255);

--- a/backend/src/main/resources/db/migration/mysql/V12__add_user_push_token.sql
+++ b/backend/src/main/resources/db/migration/mysql/V12__add_user_push_token.sql
@@ -1,0 +1,2 @@
+-- 사용자별 Expo 푸시 토큰 (콕 찌르기 등 원격 알림 발송용)
+ALTER TABLE users ADD COLUMN expo_push_token VARCHAR(255) NULL;

--- a/backend/src/test/java/com/offmode/boundedcontext/room/api/v1/RoomControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/api/v1/RoomControllerTest.java
@@ -66,7 +66,9 @@ class RoomControllerTest {
         MemberTodayStatus.NONE,
         null,
         List.of(),
-        List.of());
+        List.of(),
+        List.of(),
+        true);
   }
 
   @Test

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomMissionServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomMissionServiceTest.java
@@ -16,6 +16,7 @@ import com.offmode.boundedcontext.room.entity.Room;
 import com.offmode.boundedcontext.room.entity.RoomMember;
 import com.offmode.boundedcontext.room.entity.RoomMission;
 import com.offmode.boundedcontext.room.repository.RoomMissionRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
 import com.offmode.boundedcontext.room.types.MissionSource;
 import com.offmode.global.exception.BusinessException;
 import java.util.List;
@@ -31,10 +32,12 @@ class RoomMissionServiceTest {
 
   @Mock private RoomMissionRepository missionRepository;
   @Mock private MissionRepository masterMissionRepository;
+  @Mock private RoomProofRepository proofRepository;
   @Mock private RoomService roomService;
 
   private RoomMissionService service() {
-    return new RoomMissionService(missionRepository, masterMissionRepository, roomService);
+    return new RoomMissionService(
+        missionRepository, masterMissionRepository, proofRepository, roomService);
   }
 
   @Test
@@ -142,6 +145,43 @@ class RoomMissionServiceTest {
     ArgumentCaptor<RoomMission> captor = ArgumentCaptor.forClass(RoomMission.class);
     verify(missionRepository).save(captor.capture());
     assertThat(captor.getValue().getCategory()).isNull();
+  }
+
+  @Test
+  void updateTodayMissionTitleRenamesWhenNoProofYet() {
+    RoomMission mission =
+        RoomMission.builder()
+            .id(7L)
+            .title("원래 미션")
+            .icon("🎲")
+            .source(MissionSource.RANDOM)
+            .category(MissionCategory.VITALITY)
+            .build();
+    when(roomService.getRoomOrThrow(2L)).thenReturn(Room.builder().id(2L).build());
+    when(roomService.getMembershipOrThrow(eq(2L), eq(1L))).thenReturn(RoomMember.builder().build());
+    when(missionRepository.findByRoomIdAndDate(eq(2L), any())).thenReturn(Optional.of(mission));
+    when(proofRepository.existsByRoomMissionId(7L)).thenReturn(false);
+    when(missionRepository.save(any(RoomMission.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    RoomMissionResponse response = service().updateTodayMissionTitle(1L, 2L, "  다듬은 미션  ");
+
+    assertThat(response.title()).isEqualTo("다듬은 미션"); // 앞뒤 공백 제거
+    // 제목만 바꾸고 source·category 는 유지한다 (레벨·배지 집계에서 빠지지 않도록)
+    assertThat(response.source()).isEqualTo(MissionSource.RANDOM);
+    assertThat(mission.getCategory()).isEqualTo(MissionCategory.VITALITY);
+  }
+
+  @Test
+  void updateTodayMissionTitleRejectsAfterFirstProof() {
+    RoomMission mission = RoomMission.builder().id(7L).title("원래 미션").build();
+    when(roomService.getRoomOrThrow(2L)).thenReturn(Room.builder().id(2L).build());
+    when(roomService.getMembershipOrThrow(eq(2L), eq(1L))).thenReturn(RoomMember.builder().build());
+    when(missionRepository.findByRoomIdAndDate(eq(2L), any())).thenReturn(Optional.of(mission));
+    when(proofRepository.existsByRoomMissionId(7L)).thenReturn(true);
+
+    assertThatThrownBy(() -> service().updateTodayMissionTitle(1L, 2L, "바꾼 미션"))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage("이미 인증이 시작돼 미션 이름을 바꿀 수 없습니다.");
   }
 
   private SetRoomMissionRequest request(

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomServiceTest.java
@@ -27,6 +27,7 @@ import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.BlockService;
 import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
+import com.offmode.global.push.PushService;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,7 @@ class RoomServiceTest {
   @Mock private UserService userService;
   @Mock private RoomProofAssembler proofAssembler;
   @Mock private BlockService blockService;
+  @Mock private PushService pushService;
 
   private RoomService service() {
     return new RoomService(
@@ -56,7 +58,8 @@ class RoomServiceTest {
         nudgeRepository,
         userService,
         proofAssembler,
-        blockService);
+        blockService,
+        pushService);
   }
 
   @Test

--- a/components/EditMissionTitleModal.jsx
+++ b/components/EditMissionTitleModal.jsx
@@ -1,0 +1,100 @@
+import React, { useMemo, useState, useEffect } from 'react';
+import {
+  Modal, View, StyleSheet, TouchableOpacity, TextInput,
+  KeyboardAvoidingView, Platform,
+} from 'react-native';
+import { W } from '../constants/warm';
+import WarmText from './WarmText';
+import * as H from '../utils/haptics';
+import { GreenButton } from './RoomBits';
+
+/**
+ * 오늘 미션 이름 수정 바텀시트.
+ * 저장은 부모가 백엔드 API로 처리(onSubmit) — 방 멤버라면 누구나 수정할 수 있다.
+ */
+export default function EditMissionTitleModal({
+  visible, icon, initialTitle = '', submitting = false, error = '', onClose, onSubmit,
+}) {
+  const C = W;
+  const s = useMemo(() => makeStyles(C), [C]);
+  const [title, setTitle] = useState(initialTitle);
+
+  // 열릴 때마다 현재 미션 제목으로 되돌린다 (이전 입력이 남지 않도록)
+  useEffect(() => { if (visible) setTitle(initialTitle); }, [visible, initialTitle]);
+
+  const trimmed = title.trim();
+  const canSave = trimmed.length > 0 && trimmed !== initialTitle && !submitting;
+
+  return (
+    <Modal transparent visible={visible} animationType="slide" onRequestClose={onClose}>
+      <TouchableOpacity style={s.backdrop} activeOpacity={1} onPress={onClose} />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={s.kvWrap}
+        pointerEvents="box-none"
+      >
+        <View style={s.sheet}>
+          <View style={s.handle} />
+          <View style={s.header}>
+            <WarmText v="section" size={18}>미션 이름 수정</WarmText>
+            <TouchableOpacity onPress={onClose} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+              <WarmText v="sub" size={14} color={C.textSub}>닫기</WarmText>
+            </TouchableOpacity>
+          </View>
+
+          <View style={s.inputRow}>
+            {icon ? <WarmText size={22}>{icon}</WarmText> : null}
+            <TextInput
+              style={s.input}
+              value={title}
+              onChangeText={setTitle}
+              placeholder="오늘의 미션을 적어주세요"
+              placeholderTextColor={C.textSub}
+              maxLength={100}
+              autoFocus
+              returnKeyType="done"
+              onSubmitEditing={() => { if (canSave) onSubmit?.(trimmed); }}
+            />
+          </View>
+
+          <GreenButton
+            label={submitting ? '저장 중…' : '저장하기'}
+            disabled={!canSave}
+            onPress={() => { H.success(); onSubmit?.(trimmed); }}
+            style={{ marginTop: 14 }}
+          />
+
+          {error ? (
+            <WarmText v="sub" size={13} color={C.coral} style={{ textAlign: 'center', marginTop: 10 }}>{error}</WarmText>
+          ) : (
+            <WarmText v="caption" size={12} color={C.textSub} style={{ textAlign: 'center', marginTop: 10 }}>
+              방 멤버 모두에게 바뀐 이름이 보여요.
+            </WarmText>
+          )}
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+function makeStyles(C) {
+  return StyleSheet.create({
+    backdrop: { ...StyleSheet.absoluteFillObject, backgroundColor: 'rgba(0,0,0,0.5)' },
+    kvWrap:   { flex: 1, justifyContent: 'flex-end' },
+    sheet: {
+      backgroundColor: C.surface, borderTopLeftRadius: 24, borderTopRightRadius: 24,
+      borderTopWidth: 1, borderColor: C.greenBorder,
+      paddingHorizontal: 20, paddingTop: 12, paddingBottom: 32,
+    },
+    handle: { alignSelf: 'center', width: 40, height: 4, borderRadius: 2, backgroundColor: C.border, marginBottom: 14 },
+    header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 },
+    inputRow: {
+      flexDirection: 'row', alignItems: 'center', gap: 10,
+      borderRadius: 12, borderWidth: 1, borderColor: C.border, backgroundColor: C.surface2,
+      paddingHorizontal: 14, paddingVertical: 12,
+    },
+    input: {
+      flex: 1, color: C.text, fontFamily: 'GmarketSansLight', fontSize: 15, padding: 0,
+    },
+  });
+}

--- a/ios/offmode.xcodeproj/project.pbxproj
+++ b/ios/offmode.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = offmode/offmode.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = SX5KZM28U5;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -387,11 +387,11 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.minnnj.offmode;
-				PRODUCT_NAME = offmode;
+				PRODUCT_NAME = "offmode";
 				SWIFT_OBJC_BRIDGING_HEADER = "offmode/offmode-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -403,7 +403,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = offmode/offmode.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = SX5KZM28U5;
 				INFOPLIST_FILE = offmode/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -419,10 +419,10 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.minnnj.offmode;
-				PRODUCT_NAME = offmode;
+				PRODUCT_NAME = "offmode";
 				SWIFT_OBJC_BRIDGING_HEADER = "offmode/offmode-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/ios/offmode/Info.plist
+++ b/ios/offmode/Info.plist
@@ -42,7 +42,7 @@
       <dict>
         <key>CFBundleURLSchemes</key>
         <array>
-          <string>fb1650144739389762</string>
+          <string>fb2518223585358464</string>
         </array>
       </dict>
       <dict>
@@ -53,17 +53,17 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
     <key>FacebookAdvertiserIDCollectionEnabled</key>
     <true/>
     <key>FacebookAppID</key>
-    <string>1650144739389762</string>
+    <string>2518223585358464</string>
     <key>FacebookAutoInitEnabled</key>
     <true/>
     <key>FacebookAutoLogAppEventsEnabled</key>
     <true/>
     <key>FacebookClientToken</key>
-    <string>05fe1003111565de48c6c708a5a4239b</string>
+    <string>d5e76b8307a965b7389daf5a155b8de0</string>
     <key>FacebookDisplayName</key>
     <string>offmode</string>
     <key>KAKAO_APP_KEY</key>

--- a/screens/RoomDetailScreen.jsx
+++ b/screens/RoomDetailScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import {
-  View, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, Image,
+  View, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, Image, Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { W } from '../constants/warm';
@@ -8,9 +8,10 @@ import { api, BASE_URL } from '../utils/api';
 import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
 import {
-  RoomTopBar, MemberAvatar, SourceBadge, GreenButton, OutlineButton,
+  RoomTopBar, MemberAvatar, GreenButton, OutlineButton,
   ReactionBar, NudgeChip,
 } from '../components/RoomBits';
+import EditMissionTitleModal from '../components/EditMissionTitleModal';
 import { roomIconEmoji } from '../constants/rooms';
 import { pad } from '../utils/date';
 import MissionRouletteScreen from './MissionRouletteScreen';
@@ -27,6 +28,12 @@ function timeLabel(createdAt) {
     : new Date(createdAt);
   if (isNaN(d.getTime())) return '';
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function nudgeLabel(nudges) {
+  const [first, ...rest] = nudges;
+  const others = rest.length > 0 ? ` 외 ${rest.length}명` : '';
+  return `👉 ${first.nickname}님${others}이 콕 찔렀어요`;
 }
 
 function reactionTotal(proof) {
@@ -182,6 +189,9 @@ export default function RoomDetailScreen({
   const [filter, setFilter] = useState('all');
   const [nudgedIds, setNudgedIds] = useState(() => new Set());
   const [rouletteOpen, setRouletteOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editSubmitting, setEditSubmitting] = useState(false);
+  const [editError, setEditError] = useState('');
 
   const load = useCallback(async () => {
     setError('');
@@ -220,6 +230,24 @@ export default function RoomDetailScreen({
     }
   }, [roomId, load, onChanged]);
 
+  const handleEditTitle = useCallback(async (title) => {
+    if (editSubmitting) return;
+    setEditSubmitting(true);
+    setEditError('');
+    try {
+      const updated = await api.patch(`/api/v1/rooms/${roomId}/mission`, { title });
+      // 응답(갱신된 미션)으로 미션 바만 부분 갱신
+      setRoom(prev => prev ? { ...prev, todayMission: updated ?? prev.todayMission } : prev);
+      setEditOpen(false);
+      onChanged?.();   // 방 목록의 미션 요약도 갱신
+    } catch (e) {
+      console.warn('미션 이름 수정 실패:', e);
+      setEditError(e?.message || '미션 이름을 수정하지 못했어요.');
+    } finally {
+      setEditSubmitting(false);
+    }
+  }, [roomId, onChanged, editSubmitting]);
+
   const handleReact = useCallback(async (proofId, emoji) => {
     try {
       const updated = await api.post(`/api/v1/rooms/${roomId}/proofs/${proofId}/reactions`, { emoji });
@@ -251,6 +279,7 @@ export default function RoomDetailScreen({
     } catch (e) {
       console.warn('콕 찌르기 실패:', e);
       setNudgedIds(prev => { const next = new Set(prev); next.delete(memberId); return next; });
+      Alert.alert('콕 찌르기에 실패했어요', e?.message || '잠시 후 다시 시도해주세요.');
     }
   }, [roomId]);
 
@@ -282,6 +311,7 @@ export default function RoomDetailScreen({
     ? (status === 'DONE' ? 100 : 0)
     : (prog.requiredCount > 0 ? Math.min(100, (prog.verifiedCount / prog.requiredCount) * 100) : 0);
 
+  const receivedNudges = room.receivedNudges ?? [];
   const pendingMembers = (room.members ?? []).filter(m => m.todayStatus !== 'DONE');
   const proofs = room.proofs ?? [];
   const filtered = filter === 'all' ? proofs : proofs.filter(p => p.status === filter);
@@ -314,7 +344,16 @@ export default function RoomDetailScreen({
               <View style={s.missionRow}>
                 <WarmText size={18}>{mission.icon}</WarmText>
                 <WarmText v="body" size={17} numberOfLines={1} style={{ flex: 1 }}>{mission.title}</WarmText>
-                <SourceBadge source={mission.source} />
+                {/* 인증이 하나라도 올라오면 잠긴다 (서버가 missionEditable 로 판단) */}
+                {room.missionEditable ? (
+                  <TouchableOpacity
+                    activeOpacity={0.7}
+                    hitSlop={8}
+                    onPress={() => { H.tap(); setEditError(''); setEditOpen(true); }}
+                  >
+                    <Ionicons name="create-outline" size={18} color={C.textSub} />
+                  </TouchableOpacity>
+                ) : null}
                 {!solo ? (
                   <TouchableOpacity
                     activeOpacity={0.7}
@@ -340,6 +379,21 @@ export default function RoomDetailScreen({
               )}
             </View>
 
+            {/* 오늘 나를 콕 찌른 사람 (인증 완료 시 백엔드가 빈 배열로 내려준다) */}
+            {receivedNudges.length > 0 ? (
+              <View style={s.nudgeBanner}>
+                <View style={s.nudgeAvatars}>
+                  {receivedNudges.slice(0, 3).map(n => (
+                    <MemberAvatar key={n.userId} avatarId={n.avatarId} size={26} />
+                  ))}
+                </View>
+                <View style={{ flex: 1, gap: 2 }}>
+                  <WarmText v="section" size={14} color={C.coral}>{nudgeLabel(receivedNudges)}</WarmText>
+                  <WarmText v="caption" size={12} color={C.brown}>얼른 인증하고 화답해볼까요?</WarmText>
+                </View>
+              </View>
+            ) : null}
+
             {/* 인증하기 버튼 / 상태 배너 */}
             {status === 'DONE' || status === 'PENDING' ? (
               <View style={s.doneBanner}>
@@ -364,7 +418,8 @@ export default function RoomDetailScreen({
                 <View style={{ gap: 12 }}>
                   {pendingMembers.map(m => {
                     // 아직 미션을 시작하지 않은(NONE) 다른 멤버만 콕 찌를 수 있다
-                    const canNudge = !m.isMe && m.todayStatus !== 'PENDING';
+                    // (백엔드도 인증 완료 멤버는 ROOM_NUDGE_TARGET_DONE 으로 거절한다)
+                    const canNudge = !m.isMe && m.todayStatus === 'NONE';
                     const nudged = m.nudgedByMe || nudgedIds.has(m.memberId);
                     return (
                       <View key={m.memberId} style={s.pendingRow}>
@@ -480,6 +535,16 @@ export default function RoomDetailScreen({
         )}
       </ScrollView>
 
+      <EditMissionTitleModal
+        visible={editOpen}
+        icon={mission?.icon}
+        initialTitle={mission?.title ?? ''}
+        submitting={editSubmitting}
+        error={editError}
+        onClose={() => setEditOpen(false)}
+        onSubmit={handleEditTitle}
+      />
+
       {rouletteOpen && (
         <View style={StyleSheet.absoluteFillObject}>
           <MissionRouletteScreen
@@ -510,6 +575,10 @@ function makeStyles(C) {
 
     verifyBtn:  { marginHorizontal: 20, marginTop: 16, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, backgroundColor: C.green, borderRadius: 14, paddingVertical: 15 },
     doneBanner: { marginHorizontal: 20, marginTop: 16, borderWidth: 1, borderColor: C.greenBorder, backgroundColor: C.greenFaint, borderRadius: 14, paddingVertical: 15, alignItems: 'center' },
+
+    // 받은 콕 배너 (코랄 틴트 — 재촉이라 그린 계열과 구분)
+    nudgeBanner:  { marginHorizontal: 20, marginTop: 16, flexDirection: 'row', alignItems: 'center', gap: 10, backgroundColor: C.coralFaint, borderWidth: 1, borderColor: C.coralBorder, borderRadius: 16, paddingHorizontal: 14, paddingVertical: 12 },
+    nudgeAvatars: { flexDirection: 'row', gap: 4 },
 
     // 수행 중 (피그마 PendingStrip: greenFaint / greenBorder / r20 / p16)
     pendingStrip: { marginHorizontal: 20, marginTop: 16, backgroundColor: C.greenFaint, borderWidth: 1, borderColor: C.greenBorder, borderRadius: 20, padding: 16 },

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
+import { api } from './api';
 
 const SILENT_NOTIFICATION_CHANNEL_ID = 'offmode-silent-notifications';
 
@@ -82,4 +83,38 @@ export async function scheduleReminderNotification() {
 
 export async function cancelReminderNotification() {
   await Notifications.cancelScheduledNotificationAsync('daily-reminder');
+}
+
+/* ── 원격 푸시 (콕 찌르기 등 서버 발송) ───────────────────── */
+
+/**
+ * Expo 푸시 토큰을 발급받아 서버에 등록한다.
+ * 시뮬레이터·권한 거부 등으로 실패하면 조용히 넘어간다 (원격 푸시는 실기기에서만 동작).
+ * projectId 는 expo-notifications 가 app.json 의 extra.eas.projectId 에서 알아서 읽는다.
+ */
+export async function registerPushToken() {
+  try {
+    const granted = await requestNotificationPermission();
+    if (!granted) return null;
+    await ensureSilentNotificationChannel();
+
+    const { data: token } = await Notifications.getExpoPushTokenAsync();
+    if (!token) return null;
+
+    await api.put('/api/v1/users/me/push-token', { token });
+    return token;
+  } catch (e) {
+    if (__DEV__) console.warn('푸시 토큰 등록 실패:', e?.message ?? e);
+    return null;
+  }
+}
+
+/** 로그아웃 시 서버에 등록된 토큰을 해제해 다른 계정으로 오배송되지 않게 한다. */
+export async function unregisterPushToken() {
+  try {
+    await api.put('/api/v1/users/me/push-token', { token: null });
+  } catch (e) {
+    // 401은 세션이 이미 만료된 경우(자동 로그인 실패 등) — 해제할 등록도 없으므로 조용히 넘어간다
+    if (__DEV__ && e?.status !== 401) console.warn('푸시 토큰 해제 실패:', e?.message ?? e);
+  }
 }

--- a/utils/useAuth.js
+++ b/utils/useAuth.js
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { signInWithApple, signInWithKakao } from './auth';
 import { api, loadToken, clearToken, setOnUnauthorized } from './api';
-import { cancelMissionNotification } from './notifications';
+import { cancelMissionNotification, unregisterPushToken } from './notifications';
 
 /*
  * 인증 상태머신 훅 — authStatus: 'loading' | 'unauthenticated' | 'signingUp' | 'authenticated'
@@ -61,13 +61,23 @@ export default function useAuth({ applySession, resetSession }) {
   const handleKakaoLogin = () => login(signInWithKakao, '카카오 로그인에 실패했습니다.', 'kakao');
   const handleAppleLogin = () => login(signInWithApple, 'Apple 로그인에 실패했습니다.', 'apple');
 
+  // 401 경로에서 unregisterPushToken 이 다시 401을 받아 재진입하는 것을 막는다
+  const loggingOutRef = useRef(false);
+
   const handleLogout = async () => {
-    await cancelMissionNotification();
-    await clearToken();
-    setAuthUser(null);
-    setAuthProvider(null);
-    resetSession();
-    setAuthStatus('unauthenticated');
+    if (loggingOutRef.current) return;
+    loggingOutRef.current = true;
+    try {
+      await unregisterPushToken();   // 토큰을 지우기 전에 서버 등록 해제 (다른 계정 오배송 방지)
+      await cancelMissionNotification();
+      await clearToken();
+      setAuthUser(null);
+      setAuthProvider(null);
+      resetSession();
+      setAuthStatus('unauthenticated');
+    } finally {
+      loggingOutRef.current = false;
+    }
   };
 
   const handleDeleteAccount = async () => {


### PR DESCRIPTION
## 🔗 Issue

- Ref #84

---

## 📌 Summary

- 콕 찌르기 알림 전달 (#173) — Expo 원격 푸시 발송 경로 신설
  - `users.expo_push_token` 컬럼 추가 (V12, H2/MySQL 양쪽), 푸시 토큰 등록 API
  - `PushService` (`@Async`, 발송 실패해도 본래 동작은 성공 / `DeviceNotRegistered` 시 토큰 정리)
  - 인증 완료(DONE) 멤버에게 콕 찌르기 칩이 노출되던 프론트 조건 오류 수정
  - 방 상세에 '오늘 나를 콕 찌른 사람' 배너 추가 (`receivedNudges`)
- 오늘 미션 이름 수정 (#173)
  - `PATCH /api/v1/rooms/{roomId}/mission` 신설 — 제목만 변경, `source`·`category` 유지
  - 인증이 하나라도 올라오면 잠금. 잠금 판단은 서버가 `missionEditable` 로 내려준다
- dev 프로파일 `apple.bundle-id` 가 실제 번들 ID와 달라 Apple 로그인이 401 로 실패하던 문제 수정
- Meta 광고 SDK 세팅 반영 (buildNumber 2, FB appID 교체)

---

## ✅ Test

- [x] develop CI 초록 (#174: build / frontend-lint / validate-title 전부 success)
- [x] Flyway V12 MySQL 8.0 도커에서 V1~V12 순차 적용 검증 — `users.expo_push_token` 정상 생성
- [ ] 태그 push 후 `https://api.offmodechallenge.com/api/v1/health` 200 확인
- [ ] 콕 찌르기 푸시 수신 / 미션 이름 수정 실기기 확인
