### PR TITLE
[Feat] #177 내 기록 모아보기 탭 추가 (월별 내 인증 API + 달력 화면)

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -24,6 +24,7 @@ import RoomVerifyScreen from './screens/RoomVerifyScreen';
 import ProofDetailScreen from './screens/ProofDetailScreen';
 import RoomCompleteScreen from './screens/RoomCompleteScreen';
 import RoomHistoryScreen from './screens/RoomHistoryScreen';
+import MyHistoryScreen from './screens/MyHistoryScreen';
 import ProfileScreen from './screens/ProfileScreen';
 import MissionTimeScreen from './screens/MissionTimeScreen';
 import MissionRouletteScreen from './screens/MissionRouletteScreen';
@@ -73,8 +74,8 @@ import useMissionRouletteTrigger from './utils/useMissionRouletteTrigger';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
-// 최상위 3페이지 좌우 스와이프 순서 (Mission 가운데). Feed 탭은 RoomDetail로 흡수되어 제거됨.
-const PAGES = ['profile', 'mission', 'settings'];
+// 최상위 4페이지 좌우 스와이프 순서 (records 맨 왼쪽). Feed 탭은 RoomDetail로 흡수되어 제거됨.
+const PAGES = ['records', 'profile', 'mission', 'settings'];
 
 // 최상위 페이저 하단 여백 (홈 인디케이터 있으면 그 높이, 없으면 24px — useBottomInset).
 // SafeAreaProvider 하위에서 렌더돼야 훅이 동작하므로 별도 컴포넌트로 분리.
@@ -455,13 +456,14 @@ function AppInner() {
             </View>
           )}
 
-          {/* ── 최상위 3페이지 (좌우 스와이프: Profile | Mission | Settings) ── */}
+          {/* ── 최상위 4페이지 (좌우 스와이프: Records | Profile | Mission | Settings) ── */}
           <View
             style={[styles.screenWrap, currentStack && { opacity: 0 }]}
             pointerEvents={currentStack ? 'none' : 'auto'}
             {...pagerResponder.panHandlers}
           >
             <View style={{ flex: 1 }}>
+              {tab === 'records' && <MyHistoryScreen />}
               {tab === 'mission' && (
                 <RoomListScreen
                   version={roomVersion}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/api/v1/RoomController.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/api/v1/RoomController.java
@@ -9,6 +9,7 @@ import com.offmode.boundedcontext.room.dto.request.SetRoomMissionRequest;
 import com.offmode.boundedcontext.room.dto.request.UpdateRoomMissionTitleRequest;
 import com.offmode.boundedcontext.room.dto.response.ConfirmResponse;
 import com.offmode.boundedcontext.room.dto.response.MissionCandidateResponse;
+import com.offmode.boundedcontext.room.dto.response.MyHistoryResponse;
 import com.offmode.boundedcontext.room.dto.response.NudgeResponse;
 import com.offmode.boundedcontext.room.dto.response.ProofReportResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomDetailResponse;
@@ -179,6 +180,13 @@ public class RoomController {
   }
 
   // ===== 기록 =====
+
+  // GET /api/v1/rooms/me/history?month=YYYY-MM - 내 기록 모아보기 (모든 방)
+  @GetMapping("/me/history")
+  public ResponseEntity<List<MyHistoryResponse>> getMyHistory(
+      @AuthenticationPrincipal Long userId, @RequestParam(required = false) String month) {
+    return ResponseEntity.ok(roomProofService.getMyHistory(userId, month));
+  }
 
   // GET /api/v1/rooms/{roomId}/history?month=YYYY-MM - 지난 기록
   @GetMapping("/{roomId}/history")

--- a/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/MyHistoryProofResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/MyHistoryProofResponse.java
@@ -1,0 +1,12 @@
+package com.offmode.boundedcontext.room.dto.response;
+
+import com.offmode.boundedcontext.room.types.ProofStatus;
+import com.offmode.boundedcontext.room.types.RoomIconKey;
+
+public record MyHistoryProofResponse(
+    String time,
+    String roomName,
+    RoomIconKey roomIconKey,
+    MiniMissionResponse mission,
+    String photoUrl,
+    ProofStatus status) {}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/MyHistoryResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/MyHistoryResponse.java
@@ -1,0 +1,6 @@
+package com.offmode.boundedcontext.room.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record MyHistoryResponse(LocalDate date, List<MyHistoryProofResponse> proofs) {}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -82,6 +82,20 @@ public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
     """)
   List<RoomProof> findHistoryByUser(@Param("userId") Long userId, Pageable pageable);
 
+  // 내 기록 모아보기용: 기간 내 유저가 올린 방 인증 (모든 방).
+  // roomMission·room 을 fetch join 으로 함께 로드해 건당 추가 쿼리(N+1) 없이 사용한다.
+  @Query(
+      """
+        SELECT p
+        FROM RoomProof p
+        JOIN FETCH p.roomMission rm
+        JOIN FETCH rm.room
+        WHERE p.user.id = :userId AND rm.date BETWEEN :start AND :end
+        ORDER BY rm.date DESC, p.createdAt ASC
+    """)
+  List<RoomProof> findMyHistoryBetween(
+      @Param("userId") Long userId, @Param("start") LocalDate start, @Param("end") LocalDate end);
+
   // 카테고리별 방 인증 수 (WALKER/BEAUTY_CURATOR/LOCAL_HIPSTER 배지 + 카테고리 통계용).
   // roomMission.category 가 null 인 인증은 어떤 카테고리에도 잡히지 않는다.
   long countByUserIdAndStatusAndRoomMissionCategory(

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofService.java
@@ -4,6 +4,8 @@ import com.offmode.boundedcontext.badge.service.BadgeService;
 import com.offmode.boundedcontext.room.dto.response.ConfirmResponse;
 import com.offmode.boundedcontext.room.dto.response.HistoryProofResponse;
 import com.offmode.boundedcontext.room.dto.response.MiniMissionResponse;
+import com.offmode.boundedcontext.room.dto.response.MyHistoryProofResponse;
+import com.offmode.boundedcontext.room.dto.response.MyHistoryResponse;
 import com.offmode.boundedcontext.room.dto.response.ProofReportResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomHistoryResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomProofResponse;
@@ -30,6 +32,7 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -219,6 +222,44 @@ public class RoomProofService {
               new MiniMissionResponse(mission.getIcon(), mission.getTitle()),
               proofResponses));
     }
+    return result;
+  }
+
+  // ===== 내 기록 (월별, 모든 방) =====
+
+  @Transactional(readOnly = true)
+  public List<MyHistoryResponse> getMyHistory(Long userId, String month) {
+    YearMonth yearMonth =
+        month == null || month.isBlank() ? YearMonth.now() : YearMonth.parse(month);
+    List<RoomProof> proofs =
+        proofRepository.findMyHistoryBetween(userId, yearMonth.atDay(1), yearMonth.atEndOfMonth());
+
+    // 쿼리 정렬(날짜 내림차순, 업로드 오름차순)을 그대로 유지하며 날짜별로 묶는다.
+    Map<LocalDate, List<RoomProof>> byDate = new LinkedHashMap<>();
+    for (RoomProof proof : proofs) {
+      byDate.computeIfAbsent(proof.getRoomMission().getDate(), d -> new ArrayList<>()).add(proof);
+    }
+
+    List<MyHistoryResponse> result = new ArrayList<>();
+    byDate.forEach(
+        (date, dayProofs) -> {
+          List<MyHistoryProofResponse> items =
+              dayProofs.stream()
+                  .map(
+                      p -> {
+                        RoomMission rm = p.getRoomMission();
+                        Room room = rm.getRoom();
+                        return new MyHistoryProofResponse(
+                            p.getCreatedAt() == null ? null : p.getCreatedAt().format(TIME_FORMAT),
+                            room.getName(),
+                            room.getIconKey(),
+                            new MiniMissionResponse(rm.getIcon(), rm.getTitle()),
+                            p.getPhotoUrl(),
+                            p.getStatus());
+                      })
+                  .toList();
+          result.add(new MyHistoryResponse(date, items));
+        });
     return result;
   }
 

--- a/backend/src/test/java/com/offmode/boundedcontext/room/api/v1/RoomControllerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/api/v1/RoomControllerTest.java
@@ -12,6 +12,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.offmode.boundedcontext.room.dto.request.CreateRoomRequest;
 import com.offmode.boundedcontext.room.dto.request.JoinRoomRequest;
 import com.offmode.boundedcontext.room.dto.response.ConfirmResponse;
+import com.offmode.boundedcontext.room.dto.response.MiniMissionResponse;
+import com.offmode.boundedcontext.room.dto.response.MyHistoryProofResponse;
+import com.offmode.boundedcontext.room.dto.response.MyHistoryResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomDetailResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomListResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomReactionSummaryResponse;
@@ -27,6 +30,7 @@ import com.offmode.global.exception.BusinessException;
 import com.offmode.global.jwt.JwtAuthFilter;
 import com.offmode.global.jwt.JwtProvider;
 import com.offmode.global.status.ErrorStatus;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -193,6 +197,55 @@ class RoomControllerTest {
         .andExpect(jsonPath("$[0].emoji").value("🔥"))
         .andExpect(jsonPath("$[0].count").value(3))
         .andExpect(jsonPath("$[0].mine").value(true));
+  }
+
+  @Test
+  void getMyHistoryReturnsGroupedRecords() throws Exception {
+    authenticate();
+    when(roomProofService.getMyHistory(1L, "2026-07"))
+        .thenReturn(
+            List.of(
+                new MyHistoryResponse(
+                    LocalDate.of(2026, 7, 25),
+                    List.of(
+                        new MyHistoryProofResponse(
+                            "08:10",
+                            "아침 산책방",
+                            RoomIconKey.FIRE,
+                            new MiniMissionResponse("🚶", "산책하기"),
+                            "/uploads/p.jpg",
+                            ProofStatus.VERIFIED)))));
+
+    mockMvc
+        .perform(
+            get("/api/v1/rooms/me/history?month=2026-07").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].date").value("2026-07-25"))
+        .andExpect(jsonPath("$[0].proofs[0].roomName").value("아침 산책방"))
+        .andExpect(jsonPath("$[0].proofs[0].roomIconKey").value("FIRE"))
+        .andExpect(jsonPath("$[0].proofs[0].mission.title").value("산책하기"))
+        .andExpect(jsonPath("$[0].proofs[0].status").value("VERIFIED"));
+  }
+
+  @Test
+  void getMyHistoryReturnsEmptyArrayWhenNoRecords() throws Exception {
+    authenticate();
+    when(roomProofService.getMyHistory(eq(1L), any())).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/v1/rooms/me/history").header("Authorization", "Bearer token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+
+  @Test
+  void getMyHistoryWithoutTokenReturnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/rooms/me/history"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("COMMON_401"));
   }
 
   @Test

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.offmode.boundedcontext.badge.service.BadgeService;
 import com.offmode.boundedcontext.room.dto.response.ConfirmResponse;
+import com.offmode.boundedcontext.room.dto.response.MyHistoryResponse;
 import com.offmode.boundedcontext.room.dto.response.ProofReportResponse;
 import com.offmode.boundedcontext.room.entity.Room;
 import com.offmode.boundedcontext.room.entity.RoomMember;
@@ -24,11 +25,15 @@ import com.offmode.boundedcontext.room.repository.RoomProofRepository;
 import com.offmode.boundedcontext.room.repository.RoomReactionRepository;
 import com.offmode.boundedcontext.room.types.ProofReportReason;
 import com.offmode.boundedcontext.room.types.ProofStatus;
+import com.offmode.boundedcontext.room.types.RoomIconKey;
 import com.offmode.boundedcontext.room.types.RoomType;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.file.ImageUploadService;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -225,5 +230,51 @@ class RoomProofServiceTest {
 
     assertThat(response.reportId()).isEqualTo(555L);
     verify(reportRepository).save(any(RoomProofReport.class));
+  }
+
+  private RoomProof myProofOf(String roomName, LocalDate date, String time, ProofStatus status) {
+    Room room = Room.builder().id(2L).name(roomName).iconKey(RoomIconKey.FIRE).build();
+    RoomMission mission =
+        RoomMission.builder().id(10L).room(room).date(date).icon("🚶").title("산책하기").build();
+    User me = User.builder().id(1L).provider("kakao").providerId("me").build();
+    return RoomProof.builder()
+        .id(100L)
+        .roomMission(mission)
+        .user(me)
+        .status(status)
+        .photoUrl("/uploads/p.jpg")
+        .createdAt(LocalDate.parse(date.toString()).atTime(LocalTime.parse(time)))
+        .build();
+  }
+
+  @Test
+  void getMyHistoryGroupsProofsByDate() {
+    LocalDate d1 = LocalDate.of(2026, 7, 25);
+    LocalDate d2 = LocalDate.of(2026, 7, 24);
+    when(proofRepository.findMyHistoryBetween(
+            1L, LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31)))
+        .thenReturn(
+            List.of(
+                myProofOf("아침 산책방", d1, "08:10", ProofStatus.VERIFIED),
+                myProofOf("독서방", d1, "21:30", ProofStatus.PENDING),
+                myProofOf("아침 산책방", d2, "08:05", ProofStatus.VERIFIED)));
+
+    List<MyHistoryResponse> result = service().getMyHistory(1L, "2026-07");
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).date()).isEqualTo(d1);
+    assertThat(result.get(0).proofs()).hasSize(2);
+    assertThat(result.get(0).proofs().get(0).roomName()).isEqualTo("아침 산책방");
+    assertThat(result.get(0).proofs().get(0).time()).isEqualTo("08:10");
+    assertThat(result.get(0).proofs().get(0).mission().title()).isEqualTo("산책하기");
+    assertThat(result.get(1).date()).isEqualTo(d2);
+    assertThat(result.get(1).proofs()).hasSize(1);
+  }
+
+  @Test
+  void getMyHistoryReturnsEmptyListWhenNoProofs() {
+    when(proofRepository.findMyHistoryBetween(anyLong(), any(), any())).thenReturn(List.of());
+
+    assertThat(service().getMyHistory(1L, "2026-06")).isEmpty();
   }
 }

--- a/screens/MyHistoryScreen.jsx
+++ b/screens/MyHistoryScreen.jsx
@@ -1,0 +1,272 @@
+import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
+import {
+  View, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, Image,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { W } from '../constants/warm';
+import { api, BASE_URL } from '../utils/api';
+import WarmText from '../components/WarmText';
+import * as H from '../utils/haptics';
+import { RoomIcon, ProofStatusBadge } from '../components/RoomBits';
+import { usePagerBottomBarHeight } from '../components/PageIndicator';
+import { pad } from '../utils/date';
+
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+const MONTHS_BACK = 6; // 조회 가능한 과거 개월 수
+
+function resolvePhoto(url) {
+  if (!url) return null;
+  return url.startsWith('/') ? `${BASE_URL}${url}` : url;
+}
+
+function parseDate(str) {
+  if (!str) return null;
+  const [y, m, day] = String(str).split('-').map(Number);
+  return new Date(y, (m || 1) - 1, day || 1);
+}
+
+function startOfDay(d) { return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
+function dateStr(d) { return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`; }
+function mkOf(ds) { return ds.slice(0, 7); } // 'YYYY-MM'
+function mkStr(y, m0) { return `${y}-${pad(m0 + 1)}`; } // m0 = 0-based month
+
+// 해당 월의 달력 그리드 생성 — 일요일 시작, 주(7칸) 단위 행. 월 밖 칸은 null.
+function buildMonthGrid(year, m0) {
+  const first = new Date(year, m0, 1);
+  const daysInMonth = new Date(year, m0 + 1, 0).getDate();
+  const weeks = [];
+  let week = new Array(first.getDay()).fill(null);
+  for (let day = 1; day <= daysInMonth; day++) {
+    week.push(dateStr(new Date(year, m0, day)));
+    if (week.length === 7) { weeks.push(week); week = []; }
+  }
+  if (week.length) weeks.push([...week, ...new Array(7 - week.length).fill(null)]);
+  return weeks;
+}
+
+function emptyRecord(date) {
+  return { date, proofs: [] };
+}
+
+export default function MyHistoryScreen() {
+  const C = W;
+  const pagerBottom = usePagerBottomBarHeight(); // 플로팅 인디케이터+인셋 높이
+
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const todayStr = useMemo(() => dateStr(today), [today]);
+
+  // 표시 중인 월 (0 = 이번 달, 커질수록 과거)
+  const [monthBack, setMonthBack] = useState(0);
+  const [selected, setSelected] = useState(todayStr);
+  const [recordsByMonth, setRecordsByMonth] = useState({}); // { 'YYYY-MM': { 'YYYY-MM-DD': record } }
+  const loadedRef = useRef(new Set()); // 로드 시도한 월 (중복 요청 방지)
+
+  const s = useMemo(() => makeStyles(C), [C]);
+
+  const viewDate = useMemo(
+    () => new Date(today.getFullYear(), today.getMonth() - monthBack, 1),
+    [today, monthBack],
+  );
+  const viewMk = mkStr(viewDate.getFullYear(), viewDate.getMonth());
+  const grid = useMemo(
+    () => buildMonthGrid(viewDate.getFullYear(), viewDate.getMonth()),
+    [viewDate],
+  );
+
+  const ensureMonth = useCallback(async (mk) => {
+    if (loadedRef.current.has(mk)) return;
+    loadedRef.current.add(mk);
+    try {
+      const res = await api.get(`/api/v1/rooms/me/history?month=${mk}`);
+      const arr = Array.isArray(res) ? res : [];
+      const map = {};
+      arr.forEach((r) => { map[r.date] = r; });
+      setRecordsByMonth((prev) => ({ ...prev, [mk]: map }));
+    } catch (e) {
+      if (__DEV__) console.warn('내 기록 월 로딩 실패:', mk, e?.message);
+      setRecordsByMonth((prev) => ({ ...prev, [mk]: prev[mk] ?? {} })); // 빈 값으로 확정
+    }
+  }, []);
+
+  // 표시 중인 월 로드
+  useEffect(() => { ensureMonth(viewMk); }, [viewMk, ensureMonth]);
+
+  const canGoPrev = monthBack < MONTHS_BACK;
+  const canGoNext = monthBack > 0;
+
+  const moveMonth = (delta) => {
+    const next = monthBack - delta; // delta +1 = 다음 달(미래 방향)
+    if (next < 0 || next > MONTHS_BACK) return;
+    H.tap();
+    setMonthBack(next);
+    // 선택일이 새 월 밖이면: 이번 달이면 오늘, 과거 달이면 1일 선택
+    const nd = new Date(today.getFullYear(), today.getMonth() - next, 1);
+    const nmk = mkStr(nd.getFullYear(), nd.getMonth());
+    setSelected((prev) => (mkOf(prev) === nmk ? prev : next === 0 ? todayStr : dateStr(nd)));
+  };
+
+  const selMk = mkOf(selected);
+  const selMonthReady = recordsByMonth[selMk] !== undefined;
+  const selectedDay = selMonthReady ? (recordsByMonth[selMk][selected] ?? emptyRecord(selected)) : null;
+
+  return (
+    <View style={s.screen}>
+      <View style={s.header}>
+        <WarmText v="title" size={20}>내 기록</WarmText>
+        <WarmText v="sub" size={13} color={C.brown} style={{ marginTop: 4 }}>
+          내가 인증한 순간들을 모아봤어요
+        </WarmText>
+      </View>
+
+      <View style={s.monthRow}>
+        <TouchableOpacity
+          onPress={() => moveMonth(-1)}
+          disabled={!canGoPrev}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          style={[s.monthBtn, !canGoPrev && { opacity: 0.25 }]}
+        >
+          <Ionicons name="chevron-back" size={18} color={C.text} />
+        </TouchableOpacity>
+        <WarmText v="title" size={16} style={s.monthLabel}>
+          {viewDate.getFullYear()}년 {viewDate.getMonth() + 1}월
+        </WarmText>
+        <TouchableOpacity
+          onPress={() => moveMonth(1)}
+          disabled={!canGoNext}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          style={[s.monthBtn, !canGoNext && { opacity: 0.25 }]}
+        >
+          <Ionicons name="chevron-forward" size={18} color={C.text} />
+        </TouchableOpacity>
+      </View>
+
+      <View style={s.calendar}>
+        <View style={s.weekRow}>
+          {WEEKDAYS.map((w) => (
+            <View key={w} style={s.cell}>
+              <WarmText v="caption" size={11} color={C.textSub}>{w}</WarmText>
+            </View>
+          ))}
+        </View>
+        {grid.map((week, wi) => (
+          <View key={wi} style={s.weekRow}>
+            {week.map((ds, di) => {
+              if (!ds) return <View key={di} style={s.cell} />;
+              const future = ds > todayStr;
+              const active = selected === ds;
+              const rec = recordsByMonth[mkOf(ds)]?.[ds];
+              const hasRecord = !!rec?.proofs?.length;
+              const fg = active ? C.green : future ? C.textSub : C.text;
+              return (
+                <View key={ds} style={s.cell}>
+                  <TouchableOpacity
+                    activeOpacity={0.8}
+                    disabled={future}
+                    onPress={() => { H.tap(); setSelected(ds); }}
+                    style={[s.dayChip, active && s.dayChipActive, future && { opacity: 0.35 }]}
+                  >
+                    <WarmText v="section" size={14} color={fg}>{parseDate(ds).getDate()}</WarmText>
+                  </TouchableOpacity>
+                  <View style={[s.recDot, hasRecord && { backgroundColor: C.green }]} />
+                </View>
+              );
+            })}
+          </View>
+        ))}
+      </View>
+
+      <ScrollView
+        style={s.contentScroll}
+        contentContainerStyle={[s.content, { paddingBottom: 40 + pagerBottom }]}
+        showsVerticalScrollIndicator={false}
+      >
+        {!selMonthReady ? (
+          <View style={s.detailLoading}><ActivityIndicator color={C.green} /></View>
+        ) : selectedDay ? (
+          <>
+            <View style={s.dayHead}>
+              <WarmText v="section" size={15}>
+                {parseDate(selectedDay.date)?.getMonth() + 1}월 {parseDate(selectedDay.date)?.getDate()}일 ({WEEKDAYS[parseDate(selectedDay.date)?.getDay()]})
+              </WarmText>
+              <WarmText v="caption" size={12}>인증 {selectedDay.proofs?.length ?? 0}개</WarmText>
+            </View>
+
+            {(selectedDay.proofs ?? []).length === 0 ? (
+              <WarmText v="sub" size={13} color={C.textSub} style={{ marginTop: 12 }}>
+                이날은 인증 기록이 없어요.
+              </WarmText>
+            ) : (
+              <View style={{ marginTop: 12 }}>
+                {(selectedDay.proofs ?? []).map((p, i, arr) => {
+                  const photo = resolvePhoto(p.photoUrl);
+                  const isLast = i === arr.length - 1;
+                  return (
+                    <View key={i} style={s.timelineRow}>
+                      <View style={s.timeCol}>
+                        <WarmText v="caption" size={12}>{p.time}</WarmText>
+                      </View>
+                      <View style={s.dotCol}>
+                        <View style={[s.dot, { backgroundColor: p.status === 'VERIFIED' ? C.green : C.textSub }]} />
+                        {!isLast ? <View style={s.dotLine} /> : null}
+                      </View>
+                      <View style={[s.entryBody, !isLast && { paddingBottom: 18 }]}>
+                        {photo ? (
+                          <Image source={{ uri: photo }} style={s.thumb} resizeMode="cover" />
+                        ) : (
+                          <View style={[s.thumb, s.thumbEmpty]}><WarmText size={28}>📷</WarmText></View>
+                        )}
+                        <View style={{ flex: 1, gap: 8 }}>
+                          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                            <RoomIcon iconKey={p.roomIconKey} size={24} />
+                            <WarmText v="body" size={13} numberOfLines={1} style={{ flexShrink: 1 }}>{p.roomName}</WarmText>
+                          </View>
+                          {p.mission ? (
+                            <WarmText v="caption" size={12} color={C.brown} numberOfLines={1}>
+                              {p.mission.icon} {p.mission.title}
+                            </WarmText>
+                          ) : null}
+                          <View style={{ alignSelf: 'flex-start' }}><ProofStatusBadge status={p.status} /></View>
+                        </View>
+                      </View>
+                    </View>
+                  );
+                })}
+              </View>
+            )}
+          </>
+        ) : null}
+      </ScrollView>
+    </View>
+  );
+}
+
+function makeStyles(C) {
+  return StyleSheet.create({
+    screen:  { flex: 1, backgroundColor: C.bg },
+    header:  { paddingHorizontal: 20, paddingTop: 18, paddingBottom: 4 },
+    contentScroll: { flex: 1 },
+    content: { paddingHorizontal: 20, paddingTop: 8 },
+    detailLoading: { paddingVertical: 40, alignItems: 'center' },
+
+    monthRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 4, paddingHorizontal: 20, paddingTop: 10, paddingBottom: 10 },
+    monthLabel: { minWidth: 110, textAlign: 'center' },
+    monthBtn: { width: 32, height: 32, borderRadius: 10, borderWidth: 1, borderColor: C.borderStrong, backgroundColor: C.neutralFaint, alignItems: 'center', justifyContent: 'center' },
+
+    calendar: { paddingHorizontal: 12, paddingBottom: 6 },
+    weekRow: { flexDirection: 'row' },
+    cell: { flex: 1, alignItems: 'center', paddingVertical: 2 },
+    dayChip: { width: 36, height: 36, borderRadius: 12, borderWidth: 1, borderColor: 'transparent', alignItems: 'center', justifyContent: 'center' },
+    dayChipActive: { borderColor: C.greenBorderStrong, backgroundColor: C.greenFaint },
+    recDot: { width: 5, height: 5, borderRadius: 2.5, backgroundColor: 'transparent' },
+
+    dayHead: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 8 },
+    timelineRow: { flexDirection: 'row', gap: 10 },
+    timeCol: { width: 46 },
+    dotCol: { width: 16, alignItems: 'center', paddingTop: 2, gap: 4 },
+    dot: { width: 11, height: 11, borderRadius: 5.5 },
+    dotLine: { flex: 1, width: 2, borderRadius: 1, backgroundColor: C.border },
+    entryBody: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 12 },
+    thumb: { width: 150, height: 112, borderRadius: 12, backgroundColor: C.surface2 },
+    thumbEmpty: { alignItems: 'center', justifyContent: 'center' },
+  });
+}


### PR DESCRIPTION
## 🔗 Issue

- close #177

---

## 📌 Summary

- **백엔드**: `GET /api/v1/rooms/me/history?month=YYYY-MM` 추가 — 모든 방에서 내가 올린 인증을 날짜별로 그룹핑해 반환 (`time`·`roomName`·`roomIconKey`·`mission`·`photoUrl`·`status`). `findMyHistoryBetween`은 roomMission·room fetch join으로 N+1 없음. 리터럴 경로(`/me/history`)가 `/{roomId}/history`보다 우선 매칭되어 충돌 없음
- **프론트**: `MyHistoryScreen` 신규 — ‹ › 버튼으로 월 이동(과거 6개월), 월 달력 그리드에 기록 있는 날 초록 점, 날짜 탭 시 타임라인(시간·방·미션·사진·상태). 스크롤 없는 그리드라 최상위 페이저 좌우 스와이프와 충돌하지 않음
- **탭 연결**: `PAGES = ['records', 'profile', 'mission', 'settings']` — 맨 왼쪽에 내 기록 탭 추가, 인디케이터 4개 자동 반영

---

## ✅ Test

- [x] `./gradlew spotlessCheck test` 통과 (이 브랜치 상태 기준)
- [x] 서비스 테스트: 날짜별 그룹핑·빈 목록 2케이스 / 컨트롤러 테스트: 정상 응답·빈 배열 200·비인증 401 3케이스 추가
- [x] `npx eslint` 신규 에러 없음
- [ ] 실기기: 월 이동·날짜 탭·타임라인 표시 확인