### PR TITLE
[Feat] #178 메인 화면 오늘의 미션 카드 간소화 + 인증 사진 썸네일

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/SoloRoomSummaryResponse.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/dto/response/SoloRoomSummaryResponse.java
@@ -10,4 +10,5 @@ public record SoloRoomSummaryResponse(
     RoomType type,
     int memberCount,
     MiniMissionResponse todayMission,
-    boolean todayDone) {}
+    boolean todayDone,
+    String todayPhotoUrl) {}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
@@ -140,9 +140,15 @@ public class RoomService {
 
       if (room.getType() == RoomType.SOLO) {
         if (soloRoom != null) continue; // 첫 SOLO 방만 노출
+        // 오늘 내 인증을 한 번만 조회해 완료 여부와 사진(메인 화면 썸네일용)을 함께 얻는다.
+        RoomProof myProof =
+            todayMission == null
+                ? null
+                : proofRepository
+                    .findByRoomMissionIdAndUserId(todayMission.getId(), userId)
+                    .orElse(null);
         boolean done =
-            todayMission != null
-                && computeTodayStatus(todayMission.getId(), userId) == MemberTodayStatus.DONE;
+            myProof != null && toTodayStatus(myProof.getStatus()) == MemberTodayStatus.DONE;
         soloRoom =
             new SoloRoomSummaryResponse(
                 room.getId(),
@@ -151,7 +157,8 @@ public class RoomService {
                 room.getType(),
                 memberCounts.getOrDefault(room.getId(), 0L).intValue(),
                 mini,
-                done);
+                done,
+                done ? myProof.getPhotoUrl() : null);
       } else {
         int memberCount = memberCounts.getOrDefault(room.getId(), 0L).intValue();
         int verifiedCount =

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.offmode.boundedcontext.room.dto.request.JoinRoomRequest;
 import com.offmode.boundedcontext.room.dto.response.NudgeResponse;
+import com.offmode.boundedcontext.room.dto.response.RoomListResponse;
 import com.offmode.boundedcontext.room.entity.Room;
 import com.offmode.boundedcontext.room.entity.RoomMember;
 import com.offmode.boundedcontext.room.entity.RoomMission;
@@ -28,6 +29,8 @@ import com.offmode.boundedcontext.user.service.BlockService;
 import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.push.PushService;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -204,6 +207,63 @@ class RoomServiceTest {
 
     assertThat(res.nudged()).isTrue();
     verify(nudgeRepository, never()).save(any(RoomNudge.class));
+  }
+
+  private RoomMember soloMembership(Long roomId, Long userId) {
+    Room room =
+        Room.builder().id(roomId).name("나의 방").type(RoomType.SOLO).inviteCode("OFF000").build();
+    User user = User.builder().id(userId).provider("kakao").providerId("me").build();
+    return RoomMember.builder()
+        .id(10L)
+        .room(room)
+        .user(user)
+        .role(RoomRole.OWNER)
+        .joinedAt(LocalDateTime.of(2026, 7, 1, 9, 0))
+        .build();
+  }
+
+  @Test
+  void getMyRoomsIncludesTodayPhotoUrlWhenSoloVerified() {
+    RoomMember membership = soloMembership(2L, 1L);
+    RoomMission mission = RoomMission.builder().id(50L).room(membership.getRoom()).build();
+    RoomProof proof =
+        RoomProof.builder().status(ProofStatus.VERIFIED).photoUrl("/uploads/today.jpg").build();
+
+    when(memberRepository.findWithRoomByUserId(1L))
+        .thenReturn(new ArrayList<>(List.of(membership)));
+    when(missionRepository.findByRoomIdInAndDate(eq(List.of(2L)), any()))
+        .thenReturn(List.of(mission));
+    when(memberRepository.countRowsByRoomIdIn(List.of(2L)))
+        .thenReturn(List.<Object[]>of(new Object[] {2L, 1L}));
+    when(proofRepository.countRowsByRoomMissionIdInAndStatus(List.of(50L), ProofStatus.VERIFIED))
+        .thenReturn(List.of());
+    when(proofRepository.findByRoomMissionIdAndUserId(50L, 1L)).thenReturn(Optional.of(proof));
+
+    RoomListResponse res = service().getMyRooms(1L);
+
+    assertThat(res.soloRoom().todayDone()).isTrue();
+    assertThat(res.soloRoom().todayPhotoUrl()).isEqualTo("/uploads/today.jpg");
+  }
+
+  @Test
+  void getMyRoomsOmitsTodayPhotoUrlWhenNotVerified() {
+    RoomMember membership = soloMembership(2L, 1L);
+    RoomMission mission = RoomMission.builder().id(50L).room(membership.getRoom()).build();
+
+    when(memberRepository.findWithRoomByUserId(1L))
+        .thenReturn(new ArrayList<>(List.of(membership)));
+    when(missionRepository.findByRoomIdInAndDate(eq(List.of(2L)), any()))
+        .thenReturn(List.of(mission));
+    when(memberRepository.countRowsByRoomIdIn(List.of(2L)))
+        .thenReturn(List.<Object[]>of(new Object[] {2L, 1L}));
+    when(proofRepository.countRowsByRoomMissionIdInAndStatus(List.of(50L), ProofStatus.VERIFIED))
+        .thenReturn(List.of());
+    when(proofRepository.findByRoomMissionIdAndUserId(50L, 1L)).thenReturn(Optional.empty());
+
+    RoomListResponse res = service().getMyRooms(1L);
+
+    assertThat(res.soloRoom().todayDone()).isFalse();
+    assertThat(res.soloRoom().todayPhotoUrl()).isNull();
   }
 
   private JoinRoomRequest request(String inviteCode) {

--- a/screens/RoomListScreen.jsx
+++ b/screens/RoomListScreen.jsx
@@ -1,36 +1,36 @@
 import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import {
-  View, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, RefreshControl, Animated,
+  View, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, RefreshControl, Animated, Image,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { W } from '../constants/warm';
-import { api } from '../utils/api';
+import { api, BASE_URL } from '../utils/api';
 import WarmText from '../components/WarmText';
 import * as H from '../utils/haptics';
 import { RoomIcon, AvatarStack, ProgressBar, GreenButton, OutlineButton, SourceBadge } from '../components/RoomBits';
 import { usePagerBottomBarHeight } from '../components/PageIndicator';
 
-/* ── 방 카드 ───────────────────────────────────────────── */
-function RoomCard({ room, solo, onPress }) {
+/* ── 방 카드 (함께하는 방 전용) ─────────────────────────── */
+function RoomCard({ room, onPress }) {
   const C = W;
   const s = useMemo(() => makeStyles(C), [C]);
   const mission = room.todayMission;
 
   return (
-    <TouchableOpacity activeOpacity={0.85} onPress={onPress} style={[s.card, solo && s.cardSolo]}>
+    <TouchableOpacity activeOpacity={0.85} onPress={onPress} style={s.card}>
       <View style={s.cardTop}>
-        <RoomIcon iconKey={room.iconKey} size={30} accent={solo} />
+        <RoomIcon iconKey={room.iconKey} size={30} />
         <View style={{ flex: 1, gap: 3 }}>
           <View style={s.nameRow}>
             <WarmText v="section" size={16} numberOfLines={1} style={{ flexShrink: 1 }}>{room.name}</WarmText>
             {mission?.source ? <SourceBadge source={mission.source} /> : null}
           </View>
-          <WarmText v="caption" color={C.text}>{solo ? '혼자 하는 방' : `멤버 ${room.memberCount}명`}</WarmText>
+          <WarmText v="caption" color={C.text}>{`멤버 ${room.memberCount}명`}</WarmText>
         </View>
-        {!solo && room.members ? <AvatarStack members={room.members} /> : null}
+        {room.members ? <AvatarStack members={room.members} /> : null}
       </View>
 
-      <View style={[s.divider, solo && s.dividerSolo]} />
+      <View style={s.divider} />
 
       {mission ? (
         <View style={s.missionRow}>
@@ -44,19 +44,49 @@ function RoomCard({ room, solo, onPress }) {
         </View>
       )}
 
-      {solo && mission ? (
-        <View style={{ marginTop: 10 }}>
-          <WarmText v="caption" size={11} color={room.todayDone ? C.green : C.textSub}>
-            {room.todayDone ? '✓ 오늘 미션 인증 완료' : '아직 인증 전이에요'}
-          </WarmText>
-        </View>
-      ) : null}
-
-      {!solo && mission ? (
+      {mission ? (
         <View style={{ marginTop: 12 }}>
           <ProgressBar value={room.verifiedCount ?? 0} total={room.requiredCount ?? room.memberCount ?? 0} />
         </View>
       ) : null}
+    </TouchableOpacity>
+  );
+}
+
+/* ── 오늘의 미션 (나의 방 요약) ─────────────────────────────
+   지난 기록은 '내 기록' 탭에서 보므로, 여기서는 방 개념 없이
+   오늘 미션 제목 + 인증 여부만 간단히 보여준다 (셋로그 '내 log' 스타일). */
+function TodayMissionCard({ room, onPress }) {
+  const C = W;
+  const s = useMemo(() => makeStyles(C), [C]);
+  const mission = room.todayMission;
+  const done = !!room.todayDone;
+  // 인증 완료 시에만 오늘 사진 썸네일 노출 (지난 기록은 '내 기록' 탭 담당)
+  const photo = done && room.todayPhotoUrl
+    ? (room.todayPhotoUrl.startsWith('/') ? `${BASE_URL}${room.todayPhotoUrl}` : room.todayPhotoUrl)
+    : null;
+
+  return (
+    <TouchableOpacity activeOpacity={0.85} onPress={onPress} style={[s.card, s.cardSolo]}>
+      {mission ? (
+        <View style={s.todayRow}>
+          <View style={{ flex: 1 }}>
+            <View style={s.missionRow}>
+              <WarmText size={22}>{mission.icon}</WarmText>
+              <WarmText v="section" size={16} numberOfLines={1} style={{ flex: 1 }}>{mission.title}</WarmText>
+            </View>
+            <WarmText v="caption" size={12} color={done ? C.green : C.textSub} style={s.todayStatus}>
+              {done ? '✓ 오늘 미션 인증 완료' : '○ 아직 인증 전이에요'}
+            </WarmText>
+          </View>
+          {photo ? <Image source={{ uri: photo }} style={s.todayThumb} resizeMode="cover" /> : null}
+        </View>
+      ) : (
+        <View style={s.missionRow}>
+          <WarmText size={22}>💤</WarmText>
+          <WarmText v="sub" size={14} style={{ flex: 1 }}>아직 오늘 미션이 없어요</WarmText>
+        </View>
+      )}
     </TouchableOpacity>
   );
 }
@@ -179,8 +209,8 @@ export default function RoomListScreen({ onOpenRoom, onCreate, onJoin, onOpenNot
           <>
             {solo ? (
               <>
-                <WarmText v="label" color={C.green} style={s.sectionLabel}>나의 방</WarmText>
-                <RoomCard room={solo} solo onPress={() => { H.tap(); onOpenRoom?.(solo.id); }} />
+                <WarmText v="label" color={C.green} style={s.sectionLabel}>오늘의 미션</WarmText>
+                <TodayMissionCard room={solo} onPress={() => { H.tap(); onOpenRoom?.(solo.id); }} />
               </>
             ) : null}
 
@@ -225,8 +255,10 @@ function makeStyles(C) {
     cardTop:  { flexDirection: 'row', alignItems: 'center', gap: 10 },
     nameRow:  { flexDirection: 'row', alignItems: 'center', gap: 6 },
     divider:  { height: 1, backgroundColor: C.borderStrong, marginVertical: 12 },
-    dividerSolo: { backgroundColor: C.greenBorder },
     missionRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+    todayRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+    todayStatus: { marginTop: 8, marginLeft: 30 }, // 미션 아이콘 폭(22)+gap(8)만큼 들여쓰기
+    todayThumb: { width: 48, height: 48, borderRadius: 12, backgroundColor: C.surface2, borderWidth: 1, borderColor: C.greenBorder },
 
     empty:     { alignItems: 'center', paddingVertical: 70, paddingHorizontal: 40 },
     emptyIcon: { width: 84, height: 84, borderRadius: 42, backgroundColor: C.greenFaint, alignItems: 'center', justifyContent: 'center' },


### PR DESCRIPTION
## 🔗 Issue

- close #178

---

## 📌 Summary

- '나의 방' 카드를 '오늘의 미션' 카드로 교체 — 방 이름·"혼자 하는 방"·구분선 제거, 미션 아이콘+제목 / 인증 여부 한 줄만 표시 (지난 기록은 '내 기록' 탭 담당, #177)
- 인증 완료 시에만 카드 오른쪽에 48px 둥근 썸네일로 오늘 사진 노출 (인증 전에는 기존과 동일)
- `SoloRoomSummaryResponse`에 `todayPhotoUrl` 추가 — VERIFIED일 때만 값, 아니면 null. `getMyRooms`에서 proof 1회 조회로 완료 여부+사진 함께 획득 (기존 `computeTodayStatus` 조회를 대체, 추가 쿼리 없음)
- `RoomCard`는 함께하는 방 전용으로 정리 (solo 분기 제거)

---

## ✅ Test

- [x] `./gradlew spotlessCheck test` 통과 (이 브랜치 상태 기준)
- [x] 서비스 테스트 2케이스 추가: 인증 완료 시 `todayPhotoUrl` 포함 / 미인증 시 null
- [x] `npx eslint` 신규 에러 없음
- [ ] 실기기: 오늘의 미션 카드 표시·인증 후 썸네일 확인