### PR TITLE
[Fix] #184 운영 JVM 타임존 KST 고정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,13 @@ WORKDIR /app
 
 COPY --from=build /app/build/libs/*.jar app.jar
 
+# 기준 시각을 KST로 고정한다. alpine 기본값은 UTC 라서 그대로 두면
+# 한국시간 00:00~09:00 구간에 LocalDate.now() 가 '어제'를 가리킨다.
+# TZ 는 로그 타임스탬프용, -Duser.timezone 은 OS tzdata 유무와 무관하게
+# JDK 내장 tzdb 로 해석되므로 JVM 기본 타임존을 확정적으로 잡아준다.
+ENV TZ=Asia/Seoul
+
 # Railway가 PORT 환경변수를 주입하면 Spring이 이걸 읽음
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]

--- a/backend/src/main/java/com/offmode/global/config/TimeZoneConfig.java
+++ b/backend/src/main/java/com/offmode/global/config/TimeZoneConfig.java
@@ -1,0 +1,32 @@
+package com.offmode.global.config;
+
+import jakarta.annotation.PostConstruct;
+import java.time.ZoneId;
+import java.util.TimeZone;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 서비스 기준 시각을 한국 시간(KST)으로 고정한다.
+ *
+ * <p>미션·인증·스트릭은 모두 "오늘이 며칠인가"로 판정하고, 그 판정은 {@code LocalDate.now()} 등 JVM 기본 타임존에 기댄다. 운영
+ * 컨테이너(alpine JRE)의 기본값은 UTC 라서 고정하지 않으면 한국시간 00:00~09:00 구간 동안 서버가 '어제'로 동작한다 — 새벽에 정한 방 미션이 전날
+ * 날짜로 저장되고, 인증이 어제 미션에 붙고, 스트릭·월별 기록이 하루씩 밀린다.
+ *
+ * <p>{@code Dockerfile} 에서 {@code -Duser.timezone} 으로도 넘기지만, 로컬·CI·테스트까지 같은 기준으로 돌도록 애플리케이션 레벨에서 한
+ * 번 더 못 박는다.
+ */
+@Slf4j
+@Configuration
+public class TimeZoneConfig {
+
+  /** 서비스 기준 타임존. 날짜 경계가 필요한 곳에서 명시적으로 참조할 수 있도록 공개한다. */
+  public static final ZoneId SERVICE_ZONE = ZoneId.of("Asia/Seoul");
+
+  @PostConstruct
+  void applyServiceTimeZone() {
+    TimeZone before = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone(SERVICE_ZONE));
+    log.info("서비스 기본 타임존 고정: {} -> {}", before.getID(), SERVICE_ZONE);
+  }
+}

--- a/backend/src/test/java/com/offmode/global/config/TimeZoneConfigIntegrationTest.java
+++ b/backend/src/test/java/com/offmode/global/config/TimeZoneConfigIntegrationTest.java
@@ -1,0 +1,37 @@
+package com.offmode.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.TimeZone;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * 스프링 컨텍스트가 실제로 기동될 때 기본 타임존이 KST 로 고정되는지 확인한다.
+ *
+ * <p>로컬(KST)에서는 자명하게 통과하지만, JVM 기본값이 UTC 인 CI·운영 컨테이너에서 회귀를 잡아내는 것이 이 테스트의 목적이다.
+ */
+@ActiveProfiles("dev")
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:timezone-config-test;MODE=MySQL;DB_CLOSE_DELAY=-1",
+      "spring.jpa.hibernate.ddl-auto=validate",
+      "spring.flyway.locations=classpath:db/migration/h2",
+      "spring.sql.init.mode=never"
+    })
+class TimeZoneConfigIntegrationTest {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  @Test
+  void springContextFixesDefaultTimeZoneToKst() {
+    assertThat(TimeZone.getDefault().toZoneId()).isEqualTo(KST);
+    // 도메인 로직이 쓰는 LocalDate.now() 가 한국 날짜와 같은지 — 이 테스트의 실질적 목적
+    assertThat(LocalDate.now()).isEqualTo(LocalDate.now(KST));
+  }
+}

--- a/backend/src/test/java/com/offmode/global/config/TimeZoneConfigTest.java
+++ b/backend/src/test/java/com/offmode/global/config/TimeZoneConfigTest.java
@@ -1,0 +1,55 @@
+package com.offmode.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.TimeZone;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TimeZoneConfigTest {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private TimeZone originalTimeZone;
+
+  @BeforeEach
+  void rememberOriginalTimeZone() {
+    originalTimeZone = TimeZone.getDefault();
+  }
+
+  @AfterEach
+  void restoreOriginalTimeZone() {
+    TimeZone.setDefault(originalTimeZone);
+  }
+
+  @Test
+  void appliesKstEvenWhenJvmDefaultsToUtc() {
+    // 운영 컨테이너(alpine)의 기본 상태를 재현한다
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+    new TimeZoneConfig().applyServiceTimeZone();
+
+    assertThat(TimeZone.getDefault().toZoneId()).isEqualTo(KST);
+  }
+
+  @Test
+  void makesNowFollowKoreanCalendarDate() {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+    new TimeZoneConfig().applyServiceTimeZone();
+
+    // 한국시간 00:00~09:00 구간에서 UTC 는 아직 '어제'다. 고정 후에는 두 값이 항상 같아야 한다.
+    assertThat(LocalDate.now()).isEqualTo(LocalDate.now(KST));
+    assertThat(TimeZone.getDefault().getRawOffset())
+        .isEqualTo((int) Duration.ofHours(9).toMillis());
+  }
+
+  @Test
+  void exposesServiceZoneAsKst() {
+    assertThat(TimeZoneConfig.SERVICE_ZONE).isEqualTo(KST);
+  }
+}


### PR DESCRIPTION
## 🔗 Issue

- close #184

---

## 📌 Summary

- 운영 컨테이너(alpine JRE)의 기본 타임존이 UTC 라서 한국시간 **00:00~09:00** 구간 동안 서버가 '어제'로 동작했습니다. 새벽에 정한 방 미션이 전날 날짜로 저장되고(어제 미션이 이미 있으면 `ROOM_MISSION_ALREADY_SET` 으로 설정 자체가 불가), 인증이 어제 미션에 붙고, 스트릭·월별 기록·배지 시간대 판정이 하루씩 밀렸습니다.
- `TimeZoneConfig` 추가 — `@PostConstruct` 로 JVM 기본 타임존을 `Asia/Seoul` 로 고정합니다. 로컬·CI·도커가 모두 같은 기준으로 돌도록 애플리케이션 레벨에서 보장합니다.
- `Dockerfile` 에 `ENV TZ` 와 `-Duser.timezone` 추가. 후자는 OS tzdata 유무와 무관하게 JDK 내장 tzdb 로 해석돼 JVM 기본 타임존을 확정합니다. 배포 워크플로의 `docker run` 은 손대지 않았습니다 — Dockerfile `ENV` 가 롤백 경로까지 함께 적용되어 중복입니다.

---

## ✅ Test

- [x] 단위 테스트 3개(`TimeZoneConfigTest`) — JVM 기본값이 UTC 여도 KST 로 고정되는지, `LocalDate.now()` 가 한국 날짜를 따르는지 검증
- [x] 통합 테스트 1개(`TimeZoneConfigIntegrationTest`) — 실제 스프링 컨텍스트 기동 후 기본 타임존이 KST 인지 검증
- [x] `TZ=UTC ./gradlew spotlessCheck test` — 운영·CI와 동일한 UTC 환경을 재현해 전체 통과
- [x] 역검증 — `@Configuration` 을 뗀 상태에서 UTC 로 돌리면 통합 테스트가 FAILED 되는 것까지 확인 (테스트가 실제로 이 설정을 검증함)

> 배포 후 컨테이너 로그에 `서비스 기본 타임존 고정: UTC -> Asia/Seoul` 이 찍히면 적용된 것입니다.
> 과거에 잘못 저장된 `mission_date` 는 이 PR로 보정되지 않습니다 (정상적으로 전날 밤 미리 정한 미션과 구분이 어려워 별도 처리하지 않음).