### PR TITLE
[Fix] #186 초대코드를 추측 어려운 6자리로 교체

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,10 @@
 module.exports = {
   root: true,
   extends: ['expo'],
+  // 백엔드는 Gradle 프로젝트라 프론트 lint 대상이 아니다.
+  // 특히 ./gradlew test 가 만드는 backend/build/reports/jacoco 의 서드파티 JS가
+  // no-undef 에러로 잡혀서, 백엔드 테스트를 돌린 뒤에는 커밋 훅이 항상 막혔다.
+  ignorePatterns: ['backend/'],
   env: {
     browser: true, // setTimeout, setInterval, requestAnimationFrame 등 전역 허용
   },

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/InviteCodeGenerator.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/InviteCodeGenerator.java
@@ -1,0 +1,34 @@
+package com.offmode.boundedcontext.room.service;
+
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+/**
+ * 방 초대코드를 만든다.
+ *
+ * <p>사람이 눈으로 읽고 손으로 옮겨 적는 값이라 헷갈리는 문자를 뺐다 — 숫자 0/1 과 알파벳 O/I/L, 그리고 모음이다. 모음을 빼면 우연히 불쾌한 단어가 만들어지지
+ * 않는다. 남은 28자로 6자리를 만들어 약 4.8억 가지가 나온다.
+ *
+ * <p>이전 형식("OFF" + 3자리 숫자)은 조합이 1000개뿐이라 방이 늘면 발급 자체가 실패했고, 순차 대입으로 남의 방에 들어갈 수 있었다. 추측을 막아야 하는
+ * 값이므로 난수는 {@link SecureRandom} 을 쓴다.
+ *
+ * <p>이미 발급된 {@code OFFxxx} 코드는 그대로 유효하다 — 조회가 형식과 무관한 정확 일치라서다. 새 알파벳에는 O 가 없으니 옛 코드와 겹칠 일도 없다.
+ */
+@Component
+public class InviteCodeGenerator {
+
+  /** 숫자 2~9 + 모음과 O·I·L 을 제외한 자음. */
+  static final String ALPHABET = "23456789BCDFGHJKMNPQRSTVWXYZ";
+
+  static final int LENGTH = 6;
+
+  private final SecureRandom random = new SecureRandom();
+
+  public String generate() {
+    StringBuilder code = new StringBuilder(LENGTH);
+    for (int i = 0; i < LENGTH; i++) {
+      code.append(ALPHABET.charAt(random.nextInt(ALPHABET.length())));
+    }
+    return code.toString();
+  }
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,6 +63,7 @@ public class RoomService {
   private final RoomProofAssembler proofAssembler;
   private final BlockService blockService;
   private final PushService pushService;
+  private final InviteCodeGenerator inviteCodeGenerator;
 
   // ===== 방 생성/참여/목록 =====
 
@@ -446,7 +446,7 @@ public class RoomService {
 
   private String generateUniqueInviteCode() {
     for (int attempt = 0; attempt < INVITE_CODE_MAX_ATTEMPTS; attempt++) {
-      String code = "OFF" + String.format("%03d", ThreadLocalRandom.current().nextInt(0, 1000));
+      String code = inviteCodeGenerator.generate();
       if (!roomRepository.existsByInviteCode(code)) {
         return code;
       }

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/InviteCodeGeneratorTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/InviteCodeGeneratorTest.java
@@ -1,0 +1,55 @@
+package com.offmode.boundedcontext.room.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class InviteCodeGeneratorTest {
+
+  private final InviteCodeGenerator generator = new InviteCodeGenerator();
+
+  @Test
+  void generatesSixCharacterUppercaseCode() {
+    assertThat(generator.generate()).hasSize(6).matches("[A-Z0-9]{6}");
+  }
+
+  @Test
+  void usesOnlyAllowedAlphabet() {
+    IntStream.range(0, 500)
+        .forEach(
+            i ->
+                assertThat(generator.generate())
+                    .matches("[" + InviteCodeGenerator.ALPHABET + "]{6}"));
+  }
+
+  @Test
+  void excludesCharactersThatAreEasilyConfused() {
+    // 0/O, 1/I/L 은 손으로 옮겨 적을 때 서로 헷갈린다
+    assertThat(InviteCodeGenerator.ALPHABET).doesNotContain("0", "1", "O", "I", "L");
+  }
+
+  @Test
+  void excludesVowelsSoCodesCannotSpellWords() {
+    assertThat(InviteCodeGenerator.ALPHABET).doesNotContain("A", "E", "I", "O", "U");
+  }
+
+  @Test
+  void producesDistinctCodesAcrossManyCalls() {
+    // 4.8억 조합에서 1000개를 뽑으면 충돌 확률은 사실상 0이다.
+    // 상수를 반환하거나 난수원이 고장 난 경우를 잡는다.
+    Set<String> codes = new HashSet<>();
+    IntStream.range(0, 1000).forEach(i -> codes.add(generator.generate()));
+
+    assertThat(codes).hasSize(1000);
+  }
+
+  @Test
+  void doesNotCollideWithLegacyOffPrefixedCodes() {
+    // 기존 코드는 "OFF"로 시작한다. 새 알파벳에 O 가 없어 구조적으로 겹칠 수 없다.
+    assertThat(InviteCodeGenerator.ALPHABET).doesNotContain("O");
+    IntStream.range(0, 200).forEach(i -> assertThat(generator.generate()).doesNotStartWith("OFF"));
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomServiceTest.java
@@ -3,11 +3,14 @@ package com.offmode.boundedcontext.room.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.offmode.boundedcontext.room.dto.request.CreateRoomRequest;
 import com.offmode.boundedcontext.room.dto.request.JoinRoomRequest;
 import com.offmode.boundedcontext.room.dto.response.NudgeResponse;
 import com.offmode.boundedcontext.room.dto.response.RoomListResponse;
@@ -22,6 +25,7 @@ import com.offmode.boundedcontext.room.repository.RoomNudgeRepository;
 import com.offmode.boundedcontext.room.repository.RoomProofRepository;
 import com.offmode.boundedcontext.room.repository.RoomRepository;
 import com.offmode.boundedcontext.room.types.ProofStatus;
+import com.offmode.boundedcontext.room.types.RoomIconKey;
 import com.offmode.boundedcontext.room.types.RoomRole;
 import com.offmode.boundedcontext.room.types.RoomType;
 import com.offmode.boundedcontext.user.entity.User;
@@ -29,10 +33,12 @@ import com.offmode.boundedcontext.user.service.BlockService;
 import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.push.PushService;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -62,7 +68,8 @@ class RoomServiceTest {
         userService,
         proofAssembler,
         blockService,
-        pushService);
+        pushService,
+        new InviteCodeGenerator());
   }
 
   @Test
@@ -264,6 +271,84 @@ class RoomServiceTest {
 
     assertThat(res.soloRoom().todayDone()).isFalse();
     assertThat(res.soloRoom().todayPhotoUrl()).isNull();
+  }
+
+  @Test
+  void createRoomIssuesGeneratedInviteCodeAndRetriesOnCollision() {
+    User owner = User.builder().id(1L).name("나").build();
+    Room saved = Room.builder().id(2L).name("함께 걷기").type(RoomType.GROUP).build();
+    RoomMember membership =
+        RoomMember.builder().id(10L).room(saved).user(owner).role(RoomRole.OWNER).build();
+
+    when(userService.getById(1L)).thenReturn(owner);
+    // 첫 코드는 이미 쓰이고 있어 한 번 더 뽑아야 한다
+    when(roomRepository.existsByInviteCode(anyString())).thenReturn(true, false);
+    when(roomRepository.save(any(Room.class))).thenReturn(saved);
+    stubDetailLookupsFor(saved, membership, owner);
+
+    service().createRoom(1L, createRequest("함께 걷기", RoomType.GROUP));
+
+    ArgumentCaptor<Room> captor = ArgumentCaptor.forClass(Room.class);
+    verify(roomRepository).save(captor.capture());
+    String issued = captor.getValue().getInviteCode();
+
+    assertThat(issued).matches("[" + InviteCodeGenerator.ALPHABET + "]{6}");
+    assertThat(issued).doesNotStartWith("OFF");
+    // 충돌 한 번 → 검사도 두 번
+    verify(roomRepository, times(2)).existsByInviteCode(anyString());
+  }
+
+  @Test
+  void createRoomLeavesInviteCodeNullForSoloRoom() {
+    User owner = User.builder().id(1L).name("나").build();
+    Room saved = Room.builder().id(2L).name("혼자 하기").type(RoomType.SOLO).build();
+    RoomMember membership =
+        RoomMember.builder().id(10L).room(saved).user(owner).role(RoomRole.OWNER).build();
+
+    when(userService.getById(1L)).thenReturn(owner);
+    when(roomRepository.save(any(Room.class))).thenReturn(saved);
+    stubDetailLookupsFor(saved, membership, owner);
+
+    service().createRoom(1L, createRequest("혼자 하기", RoomType.SOLO));
+
+    ArgumentCaptor<Room> captor = ArgumentCaptor.forClass(Room.class);
+    verify(roomRepository).save(captor.capture());
+
+    assertThat(captor.getValue().getInviteCode()).isNull();
+    verify(roomRepository, never()).existsByInviteCode(anyString());
+  }
+
+  /** createRoom 이 마지막에 호출하는 getDetail 이 통과하도록 최소한의 조회만 채운다. */
+  private void stubDetailLookupsFor(Room room, RoomMember membership, User owner) {
+    Long roomId = room.getId();
+    when(roomRepository.findById(roomId)).thenReturn(Optional.of(room));
+    when(memberRepository.findByRoomIdAndUserId(roomId, owner.getId()))
+        .thenReturn(Optional.of(membership));
+    when(memberRepository.findWithUserByRoomIdOrderByJoinedAtAsc(roomId))
+        .thenReturn(List.of(membership));
+    when(missionRepository.findByRoomIdAndDate(eq(roomId), any(LocalDate.class)))
+        .thenReturn(Optional.empty());
+    when(blockService.blockedUserIds(owner.getId())).thenReturn(Set.of());
+    when(proofRepository.findVerifiedDates(roomId, ProofStatus.VERIFIED)).thenReturn(List.of());
+  }
+
+  private CreateRoomRequest createRequest(String name, RoomType type) {
+    CreateRoomRequest request = new CreateRoomRequest();
+    try {
+      set(request, "name", name);
+      set(request, "iconKey", RoomIconKey.FIRE);
+      set(request, "type", type);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+    return request;
+  }
+
+  private static void set(Object target, String fieldName, Object value)
+      throws ReflectiveOperationException {
+    var field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
   }
 
   private JoinRoomRequest request(String inviteCode) {

--- a/screens/JoinRoomScreen.jsx
+++ b/screens/JoinRoomScreen.jsx
@@ -46,7 +46,7 @@ export default function JoinRoomScreen({ onBack, onJoined, initialCode }) {
           <TextInput
             value={code}
             onChangeText={(t) => { setCode(t.toUpperCase()); setError(''); }}
-            placeholder="예) OFF111"
+            placeholder="예) K7M2QP"
             placeholderTextColor={C.brown}
             autoCapitalize="characters"
             autoCorrect={false}


### PR DESCRIPTION
## 🔗 Issue

- close #186

---

## 📌 Summary

- 초대코드가 `"OFF" + %03d` 라 전체 조합이 **1000개뿐**이었습니다. 방이 늘면 20회 재시도가 모두 실패해 방 생성이 500으로 떨어지고, 그 전에 `OFF000` 부터 순차 대입하면 남의 방에 입장할 수 있었습니다. 난수도 `ThreadLocalRandom` 이라 추측 저항성이 없었습니다.
- `InviteCodeGenerator` 추가 — `SecureRandom` 으로 6자리를 뽑습니다. 손으로 옮겨 적는 값이라 헷갈리는 `0/1/O/I/L` 을 뺐고, 우연히 불쾌한 단어가 만들어지지 않도록 모음도 뺐습니다. 남은 28자로 **약 4.8억 가지**입니다.
- **기존 `OFFxxx` 코드는 그대로 유효합니다.** 조회가 형식과 무관한 정확 일치이고, 새 알파벳에 `O` 가 없어 옛 코드와 겹칠 수도 없습니다.
- 컬럼이 `VARCHAR(255)` 라 **스키마 변경·마이그레이션 없습니다.**
- 프론트는 입력을 대문자로 강제하고(`autoCapitalize` + `toUpperCase`) 딥링크 파서도 `[A-Za-z0-9]{3,12}` 를 받아 이미 호환됩니다. 안내용 placeholder 예시만 새 형식으로 바꿨습니다.

### 곁들인 수정

`.eslintrc.js` 에 `ignorePatterns: ['backend/']` 를 추가했습니다. `./gradlew test` 가 만드는 `backend/build/reports/jacoco` 의 서드파티 JS(`prettify.js`, `sort.js`)가 `no-undef` 에러 9건으로 잡혀서, **백엔드 테스트를 돌린 뒤에는 커밋 훅의 lint 검사가 항상 실패**했습니다. CI는 잡이 분리돼 `backend/build/` 가 없어 드러나지 않던 문제입니다. 백엔드는 Gradle 프로젝트라 프론트 lint 대상이 아닙니다.

---

## ✅ Test

- [x] `InviteCodeGeneratorTest` 6건 — 길이·허용 알파벳(500회 반복), 혼동 문자 제외, 모음 제외, 1000회 생성 시 전부 유일, 옛 `OFF` 접두어와 비충돌
- [x] `RoomServiceTest` 에 2건 추가 — GROUP 방 생성 시 새 형식 코드 발급 + **충돌 시 재발급**(`existsByInviteCode` 2회 호출) 검증, SOLO 방은 코드 `null` 유지
- [x] `./gradlew spotlessCheck test` 전체 통과 (RoomServiceTest 12건 포함)
- [x] `npm run lint` 에러 0 (기존 warning 68건은 #34 부채로 남김)

> 실기기 확인 요청: 새 방 만들기 → 초대코드 표시(`RoomSettingsScreen`) → 다른 계정에서 코드 입력 참여, 카톡 링크 공유 후 딥링크 참여