### PR TITLE
[Fix] #188 인원이 줄면 오늘 인증을 다시 판정

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -31,6 +31,10 @@ public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
   @Query("SELECT p FROM RoomProof p WHERE p.id = :id")
   Optional<RoomProof> findWithLockById(@Param("id") Long id);
 
+  // 멤버가 나가 요구치가 줄었을 때 다시 판정할 대상.
+  // id 오름차순으로 고정해 동시에 나가는 요청들이 같은 순서로 락을 잡게 한다 (데드락 방지).
+  List<RoomProof> findByRoomMissionIdAndStatusOrderByIdAsc(Long roomMissionId, ProofStatus status);
+
   // 방 목록용: 미션별 VERIFIED 수를 한 번에 집계 (방 개수만큼 반복 호출하지 않는다)
   @Query(
       """

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofReconciler.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomProofReconciler.java
@@ -1,0 +1,82 @@
+package com.offmode.boundedcontext.room.service;
+
+import com.offmode.boundedcontext.badge.service.BadgeService;
+import com.offmode.boundedcontext.room.entity.RoomMission;
+import com.offmode.boundedcontext.room.entity.RoomProof;
+import com.offmode.boundedcontext.room.repository.RoomMissionRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofConfirmRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.types.ProofStatus;
+import com.offmode.boundedcontext.user.service.UserService;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 방 인원이 줄어 피어 확인 요구치가 낮아졌을 때, 이미 올라온 인증을 다시 판정한다.
+ *
+ * <p>요구치는 {@code memberCount - 1} 로 매번 새로 계산하는데 상태 전환은 {@code confirm} 이 호출될 때만 평가한다. 그래서 멤버가 나가면
+ * 이미 조건을 채운 인증이 {@code PENDING} 에 갇힌다 — 3인방에서 확인 1개를 받은 인증은 한 명이 나가는 순간 요구치가 1로 줄어 완료여야 하지만, 남은
+ * 확인자는 이미 확인을 마쳐 다시 호출할 일이 없다. 화면에는 "1/1 완료"로 보이는데 레벨업·배지는 영영 실행되지 않는다.
+ *
+ * <p>요구치를 직접 계산하지 않고 호출부에서 받는다. 계산에 필요한 방 정보는 {@link RoomService} 가 이미 들고 있고, 여기서 다시 가져오면 순환 의존이
+ * 생긴다.
+ *
+ * <p>과거 미션은 건드리지 않는다. 지난 날짜가 완료로 바뀌면 연속 달성일과 누적 통계가 소급 변동해 사용자가 혼란스럽다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomProofReconciler {
+
+  private final RoomMissionRepository missionRepository;
+  private final RoomProofRepository proofRepository;
+  private final RoomProofConfirmRepository confirmRepository;
+  private final UserService userService;
+  private final BadgeService badgeService;
+
+  /**
+   * 오늘 미션의 미완료 인증 중 새 요구치를 채운 것을 완료 처리한다.
+   *
+   * @param requiredConfirm 멤버가 빠진 뒤의 요구 확인 수 (호출부가 계산해 넘긴다)
+   */
+  @Transactional
+  public void reconcileTodayProofs(Long roomId, int requiredConfirm) {
+    RoomMission todayMission =
+        missionRepository.findByRoomIdAndDate(roomId, LocalDate.now()).orElse(null);
+    if (todayMission == null) return;
+
+    List<RoomProof> pending =
+        proofRepository.findByRoomMissionIdAndStatusOrderByIdAsc(
+            todayMission.getId(), ProofStatus.PENDING);
+
+    for (RoomProof stale : pending) {
+      // 목록을 읽은 뒤 confirm 이 끼어들 수 있으므로 행 락으로 다시 읽어 직렬화한다.
+      // 락 없이 전환하면 같은 인증에 레벨업·배지가 두 번 실행될 수 있다.
+      RoomProof proof = proofRepository.findWithLockById(stale.getId()).orElse(null);
+      if (proof == null || proof.getStatus() == ProofStatus.VERIFIED) continue;
+
+      long confirmCount = confirmRepository.countByRoomProofId(proof.getId());
+      if (confirmCount < requiredConfirm) continue;
+
+      proof.setStatus(ProofStatus.VERIFIED);
+      proofRepository.save(proof);
+
+      // RoomProofService.applyVerifiedProgress 와 같은 처리. 그쪽을 부르면
+      // RoomProofService → RoomService → 여기로 도는 순환이 생겨 두 줄을 그대로 둔다.
+      Long ownerId = proof.getUser().getId();
+      userService.applyVerifiedProgress(ownerId);
+      badgeService.checkAndAward(ownerId);
+
+      log.info(
+          "인원 감소로 인증 완료 처리: proofId={}, roomId={}, 확인 {}/{}",
+          proof.getId(),
+          roomId,
+          confirmCount,
+          requiredConfirm);
+    }
+  }
+}

--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
@@ -64,6 +64,7 @@ public class RoomService {
   private final BlockService blockService;
   private final PushService pushService;
   private final InviteCodeGenerator inviteCodeGenerator;
+  private final RoomProofReconciler proofReconciler;
 
   // ===== 방 생성/참여/목록 =====
 
@@ -295,7 +296,7 @@ public class RoomService {
 
   @Transactional
   public void leave(Long userId, Long roomId) {
-    getRoomOrThrow(roomId);
+    Room room = getRoomOrThrow(roomId);
     RoomMember membership = getMembershipOrThrow(roomId, userId);
     memberRepository.delete(membership);
 
@@ -309,11 +310,13 @@ public class RoomService {
                 memberRepository.save(next);
               });
     }
+
+    reconcileTodayProofs(room);
   }
 
   @Transactional
   public void kickMember(Long userId, Long roomId, Long memberId) {
-    getRoomOrThrow(roomId);
+    Room room = getRoomOrThrow(roomId);
     requireOwner(roomId, userId);
 
     RoomMember target =
@@ -326,6 +329,15 @@ public class RoomService {
       throw new BusinessException(ErrorStatus.ROOM_FORBIDDEN);
     }
     memberRepository.delete(target);
+
+    reconcileTodayProofs(room);
+  }
+
+  // 인원이 줄면 요구 확인 수도 줄어든다. 이미 그 수를 채운 오늘 인증을 완료로 넘겨준다
+  // (멤버 삭제 뒤에 호출해야 새 인원이 반영된 요구치가 나온다).
+  private void reconcileTodayProofs(Room room) {
+    int remaining = (int) getMemberCount(room.getId());
+    proofReconciler.reconcileTodayProofs(room.getId(), requiredConfirm(room.getType(), remaining));
   }
 
   // ===== 콕 찌르기 =====

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofReconcilerTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofReconcilerTest.java
@@ -1,0 +1,149 @@
+package com.offmode.boundedcontext.room.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.offmode.boundedcontext.badge.service.BadgeService;
+import com.offmode.boundedcontext.room.entity.Room;
+import com.offmode.boundedcontext.room.entity.RoomMission;
+import com.offmode.boundedcontext.room.entity.RoomProof;
+import com.offmode.boundedcontext.room.repository.RoomMissionRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofConfirmRepository;
+import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.types.ProofStatus;
+import com.offmode.boundedcontext.room.types.RoomType;
+import com.offmode.boundedcontext.user.entity.User;
+import com.offmode.boundedcontext.user.service.UserService;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RoomProofReconcilerTest {
+
+  private static final Long ROOM_ID = 2L;
+  private static final Long MISSION_ID = 30L;
+
+  @Mock private RoomMissionRepository missionRepository;
+  @Mock private RoomProofRepository proofRepository;
+  @Mock private RoomProofConfirmRepository confirmRepository;
+  @Mock private UserService userService;
+  @Mock private BadgeService badgeService;
+
+  private RoomProofReconciler reconciler() {
+    return new RoomProofReconciler(
+        missionRepository, proofRepository, confirmRepository, userService, badgeService);
+  }
+
+  @Test
+  void verifiesProofThatNowMeetsTheLoweredRequirement() {
+    RoomProof proof = pendingProof(100L, 7L);
+    stubTodayMission();
+    when(proofRepository.findByRoomMissionIdAndStatusOrderByIdAsc(MISSION_ID, ProofStatus.PENDING))
+        .thenReturn(List.of(proof));
+    when(proofRepository.findWithLockById(100L)).thenReturn(Optional.of(proof));
+    when(confirmRepository.countByRoomProofId(100L)).thenReturn(1L);
+
+    reconciler().reconcileTodayProofs(ROOM_ID, 1);
+
+    assertThat(proof.getStatus()).isEqualTo(ProofStatus.VERIFIED);
+    verify(proofRepository).save(proof);
+    verify(userService).applyVerifiedProgress(7L);
+    verify(badgeService).checkAndAward(7L);
+  }
+
+  @Test
+  void leavesProofPendingWhenConfirmsAreStillShort() {
+    RoomProof proof = pendingProof(100L, 7L);
+    stubTodayMission();
+    when(proofRepository.findByRoomMissionIdAndStatusOrderByIdAsc(MISSION_ID, ProofStatus.PENDING))
+        .thenReturn(List.of(proof));
+    when(proofRepository.findWithLockById(100L)).thenReturn(Optional.of(proof));
+    when(confirmRepository.countByRoomProofId(100L)).thenReturn(1L);
+
+    // 4명이던 방에서 한 명만 빠져 요구치는 아직 2
+    reconciler().reconcileTodayProofs(ROOM_ID, 2);
+
+    assertThat(proof.getStatus()).isEqualTo(ProofStatus.PENDING);
+    verify(proofRepository, never()).save(any(RoomProof.class));
+    verify(userService, never()).applyVerifiedProgress(anyLong());
+    verify(badgeService, never()).checkAndAward(anyLong());
+  }
+
+  @Test
+  void verifiesEveryPendingProofWhenNoConfirmIsRequiredAnymore() {
+    RoomProof mine = pendingProof(100L, 7L);
+    RoomProof theirs = pendingProof(101L, 8L);
+    stubTodayMission();
+    when(proofRepository.findByRoomMissionIdAndStatusOrderByIdAsc(MISSION_ID, ProofStatus.PENDING))
+        .thenReturn(List.of(mine, theirs));
+    when(proofRepository.findWithLockById(100L)).thenReturn(Optional.of(mine));
+    when(proofRepository.findWithLockById(101L)).thenReturn(Optional.of(theirs));
+    when(confirmRepository.countByRoomProofId(anyLong())).thenReturn(0L);
+
+    // 혼자만 남아 확인해 줄 사람이 없다 — 요구치 0
+    reconciler().reconcileTodayProofs(ROOM_ID, 0);
+
+    assertThat(mine.getStatus()).isEqualTo(ProofStatus.VERIFIED);
+    assertThat(theirs.getStatus()).isEqualTo(ProofStatus.VERIFIED);
+    verify(userService).applyVerifiedProgress(7L);
+    verify(userService).applyVerifiedProgress(8L);
+  }
+
+  @Test
+  void skipsProofAlreadyVerifiedByAConcurrentConfirm() {
+    RoomProof stale = pendingProof(100L, 7L);
+    // 목록을 읽은 뒤 confirm 이 먼저 끝나 락 조회 시점엔 이미 완료된 상태
+    RoomProof locked = pendingProof(100L, 7L);
+    locked.setStatus(ProofStatus.VERIFIED);
+
+    stubTodayMission();
+    when(proofRepository.findByRoomMissionIdAndStatusOrderByIdAsc(MISSION_ID, ProofStatus.PENDING))
+        .thenReturn(List.of(stale));
+    when(proofRepository.findWithLockById(100L)).thenReturn(Optional.of(locked));
+
+    reconciler().reconcileTodayProofs(ROOM_ID, 0);
+
+    // 레벨업·배지가 두 번 실행되지 않아야 한다
+    verify(proofRepository, never()).save(any(RoomProof.class));
+    verify(userService, never()).applyVerifiedProgress(anyLong());
+    verify(badgeService, never()).checkAndAward(anyLong());
+  }
+
+  @Test
+  void doesNothingWhenTodayHasNoMission() {
+    when(missionRepository.findByRoomIdAndDate(eq(ROOM_ID), any(LocalDate.class)))
+        .thenReturn(Optional.empty());
+
+    reconciler().reconcileTodayProofs(ROOM_ID, 0);
+
+    verify(proofRepository, never())
+        .findByRoomMissionIdAndStatusOrderByIdAsc(anyLong(), any(ProofStatus.class));
+    verify(userService, never()).applyVerifiedProgress(anyLong());
+  }
+
+  private void stubTodayMission() {
+    Room room = Room.builder().id(ROOM_ID).type(RoomType.GROUP).build();
+    RoomMission mission =
+        RoomMission.builder().id(MISSION_ID).room(room).date(LocalDate.now()).build();
+    when(missionRepository.findByRoomIdAndDate(eq(ROOM_ID), any(LocalDate.class)))
+        .thenReturn(Optional.of(mission));
+  }
+
+  private static RoomProof pendingProof(Long proofId, Long ownerId) {
+    return RoomProof.builder()
+        .id(proofId)
+        .user(User.builder().id(ownerId).build())
+        .status(ProofStatus.PENDING)
+        .build();
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomProofServiceConcurrencyTest.java
@@ -37,7 +37,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 /**
- * 피어 인증(confirm) 동시성 검증 — 같은 인증에 동시에 confirm 이 몰려도 임계치 판정과 진급/뱃지 처리가 정확히 한 번만 일어나야 한다.
+ * 인증 상태 전환 동시성 검증 — 같은 인증에 confirm 이 몰리거나 확인과 나가기가 겹쳐도, 임계치 판정과 진급/뱃지 처리는 정확히 한 번만 일어나야 한다.
  *
  * <p>스레드 간 커밋 가시성이 필요하므로 테스트에 @Transactional 을 붙이지 않는다 (각 서비스 호출이 자체 트랜잭션으로 커밋된다).
  */
@@ -53,6 +53,7 @@ import org.springframework.test.context.TestPropertySource;
 class RoomProofServiceConcurrencyTest {
 
   @Autowired private RoomProofService proofService;
+  @Autowired private RoomService roomService;
   @Autowired private UserRepository userRepository;
   @Autowired private RoomRepository roomRepository;
   @Autowired private RoomMemberRepository memberRepository;
@@ -109,6 +110,29 @@ class RoomProofServiceConcurrencyTest {
                     f.confirmerA.getId(), f.room.getId(), f.proof.getId(), "🔥"));
 
     assertThat(errors).isEmpty();
+  }
+
+  @Test
+  void leavingWhileAnotherMemberConfirmsStillVerifiesExactlyOnce() throws Exception {
+    // 3명 방(requiredConfirm=2)에서 한 명이 나가는 동시에 다른 한 명이 확인한다.
+    // 인증 행 락이 두 경로를 직렬화하므로 어느 순서가 되든 결과는 "2명 + 확인 1건" 이고,
+    // 요구치가 1로 낮아졌으니 최종 상태는 VERIFIED 여야 한다.
+    //  - confirm 이 먼저면: 아직 3명이라 미달로 두고 커밋 → 나가기의 재판정이 완료 처리
+    //  - 나가기가 먼저면: 확인 0건이라 미달로 두고 커밋 → confirm 이 2명 기준으로 완료 처리
+    // 어느 쪽이든 진급·뱃지는 한 번만 실행되어야 한다.
+    Fixture f = createGroupRoomWithProof("room-c4", 2);
+
+    List<Throwable> errors =
+        runConcurrently(
+            () -> proofService.confirm(f.confirmerA.getId(), f.room.getId(), f.proof.getId()),
+            () -> roomService.leave(f.confirmerB.getId(), f.room.getId()));
+
+    assertThat(errors).isEmpty();
+    RoomProof reloaded = proofRepository.findById(f.proof.getId()).orElseThrow();
+    assertThat(reloaded.getStatus()).isEqualTo(ProofStatus.VERIFIED);
+    assertThat(confirmRepository.countByRoomProofId(f.proof.getId())).isEqualTo(1);
+    assertThat(memberRepository.countByRoomId(f.room.getId())).isEqualTo(2);
+    assertBadgesNotDuplicated(f.uploader.getId());
   }
 
   // ===== 픽스처/헬퍼 =====

--- a/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/room/service/RoomServiceTest.java
@@ -57,6 +57,7 @@ class RoomServiceTest {
   @Mock private RoomProofAssembler proofAssembler;
   @Mock private BlockService blockService;
   @Mock private PushService pushService;
+  @Mock private RoomProofReconciler proofReconciler;
 
   private RoomService service() {
     return new RoomService(
@@ -69,7 +70,8 @@ class RoomServiceTest {
         proofAssembler,
         blockService,
         pushService,
-        new InviteCodeGenerator());
+        new InviteCodeGenerator(),
+        proofReconciler);
   }
 
   @Test
@@ -123,6 +125,60 @@ class RoomServiceTest {
     verify(memberRepository).save(captor.capture());
     assertThat(captor.getValue().getRole()).isEqualTo(RoomRole.OWNER);
     assertThat(captor.getValue().getId()).isEqualTo(11L);
+  }
+
+  @Test
+  void leaveRevisesTodayProofsWithTheLoweredRequirement() {
+    Room room = Room.builder().id(2L).type(RoomType.GROUP).build();
+    User owner = User.builder().id(1L).provider("kakao").providerId("owner").build();
+    RoomMember ownerMember =
+        RoomMember.builder().id(10L).room(room).user(owner).role(RoomRole.MEMBER).build();
+
+    when(roomRepository.findById(2L)).thenReturn(Optional.of(room));
+    when(memberRepository.findByRoomIdAndUserId(2L, 1L)).thenReturn(Optional.of(ownerMember));
+    // 3명이던 방에서 한 명이 빠져 2명 → 요구 확인 수는 1
+    when(memberRepository.countByRoomId(2L)).thenReturn(2L);
+
+    service().leave(1L, 2L);
+
+    verify(proofReconciler).reconcileTodayProofs(2L, 1);
+  }
+
+  @Test
+  void kickMemberRevisesTodayProofsWithTheLoweredRequirement() {
+    Room room = Room.builder().id(2L).type(RoomType.GROUP).build();
+    User owner = User.builder().id(1L).provider("kakao").providerId("owner").build();
+    RoomMember ownerMember =
+        RoomMember.builder().id(10L).room(room).user(owner).role(RoomRole.OWNER).build();
+    User target = User.builder().id(2L).provider("kakao").providerId("target").build();
+    RoomMember targetMember =
+        RoomMember.builder().id(11L).room(room).user(target).role(RoomRole.MEMBER).build();
+
+    when(roomRepository.findById(2L)).thenReturn(Optional.of(room));
+    when(memberRepository.findByRoomIdAndUserId(2L, 1L)).thenReturn(Optional.of(ownerMember));
+    when(memberRepository.findByIdAndRoomId(11L, 2L)).thenReturn(Optional.of(targetMember));
+    when(memberRepository.countByRoomId(2L)).thenReturn(2L);
+
+    service().kickMember(1L, 2L, 11L);
+
+    verify(memberRepository).delete(targetMember);
+    verify(proofReconciler).reconcileTodayProofs(2L, 1);
+  }
+
+  @Test
+  void soloRoomNeedsNoConfirmAfterMemberLeaves() {
+    Room room = Room.builder().id(2L).type(RoomType.SOLO).build();
+    User owner = User.builder().id(1L).provider("kakao").providerId("owner").build();
+    RoomMember ownerMember =
+        RoomMember.builder().id(10L).room(room).user(owner).role(RoomRole.OWNER).build();
+
+    when(roomRepository.findById(2L)).thenReturn(Optional.of(room));
+    when(memberRepository.findByRoomIdAndUserId(2L, 1L)).thenReturn(Optional.of(ownerMember));
+    when(memberRepository.countByRoomId(2L)).thenReturn(0L);
+
+    service().leave(1L, 2L);
+
+    verify(proofReconciler).reconcileTodayProofs(2L, 0);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Issue

- close #188

---

## 📌 Summary

확인 요구치는 `memberCount - 1` 로 매번 새로 계산하는데 상태 전환은 `confirm` 이 호출될 때만 평가했습니다. 그래서 멤버가 나가 요구치가 줄면 이미 조건을 채운 인증이 `PENDING` 에 갇혔습니다.

```
3인방 A·B·C — A가 인증(요구치 2), B가 확인(1/2) → PENDING
  ▼ C 탈퇴 (요구치 2 → 1)
확인 1건 ≥ 요구치 1 이지만 아무도 confirm 을 다시 부르지 않는다
  → 화면은 "1/1 완료", 상태는 PENDING, 레벨업·뱃지는 영영 실행 안 됨
```

- `RoomProofReconciler` 추가 — `leave` / `kickMember` 로 인원이 줄면 **오늘 미션의 `PENDING` 인증**을 새 요구치로 다시 판정하고, 충족한 건을 `VERIFIED` 로 넘기며 진급·뱃지를 처리합니다.
- 요구치는 **호출부에서 계산해 넘깁니다.** 방 정보를 재조회하면 `RoomService` 와 순환 의존이 생깁니다. 덕분에 `RoomService.requiredConfirm` 을 static 으로 바꿀 필요도 없어 기존 테스트가 그대로 삽니다.
- 상태 전환에 부수효과(레벨업·뱃지)가 붙으므로 대상 행에 `PESSIMISTIC_WRITE` 락을 걸어 `confirm` 과의 경합에서 이중 실행을 막습니다. 목록은 **id 오름차순으로 고정**해 동시에 나가는 요청들이 같은 순서로 락을 잡게 했습니다(데드락 방지).

### 범위에서 뺀 것

- **과거 미션은 재판정하지 않습니다.** 지난 날짜가 완료로 바뀌면 연속 달성일·누적 통계가 소급 변동해 사용자가 혼란스럽습니다.
- **탈퇴(`UserService.deleteAccount`) 경로는 제외했습니다.** 같은 문제가 있지만 `UserService` 가 방 정리까지 맡고 있어 그대로 연결하면 순환 의존이 생깁니다. 방 정리 책임 분리가 선행되어야 해서 후속 이슈로 다루겠습니다.

---

## ✅ Test

- [x] `RoomProofReconcilerTest` 5건 — 요구치 충족 시 전환+진급·뱃지, 미달 시 유지, 요구치 0이면 전원 완료, **동시 confirm 이 먼저 끝난 경우 건너뛰기**(이중 진급 방지), 오늘 미션 없으면 no-op
- [x] `RoomServiceTest` 3건 추가 — `leave`/`kickMember` 가 **낮아진 요구치로** 재판정을 호출하는지, SOLO 는 0으로 넘기는지
- [x] `RoomProofServiceConcurrencyTest` 1건 추가 — **나가기와 확인을 동시 실행**. 어느 순서로 직렬화되든 최종 `VERIFIED` + 뱃지 미중복. 타이밍 의존이라 **3회 반복 실행해 안정성 확인**
- [x] `TZ=UTC ./gradlew spotlessCheck test` 전체 통과

> 실기기 확인 요청: 3인 방에서 인증 1건에 확인 1개만 받은 상태로 한 명 내보내기 → 그 인증이 완료로 바뀌고 프로필 누적/레벨에 반영되는지
