### PR TITLE
[Fix] #191 오늘 미인증이어도 어제까지의 연속 달성 일수 유지

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/service/RoomService.java
@@ -33,6 +33,7 @@ import com.offmode.boundedcontext.user.service.UserService;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.push.PushService;
 import com.offmode.global.status.ErrorStatus;
+import com.offmode.global.util.StreakCalculator;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -444,16 +445,7 @@ public class RoomService {
   private int computeStreak(Long roomId) {
     Set<LocalDate> verifiedDates =
         new HashSet<>(proofRepository.findVerifiedDates(roomId, ProofStatus.VERIFIED));
-    if (verifiedDates.isEmpty()) return 0;
-
-    LocalDate today = LocalDate.now();
-    LocalDate cursor = verifiedDates.contains(today) ? today : today.minusDays(1);
-    int streak = 0;
-    while (verifiedDates.contains(cursor)) {
-      streak++;
-      cursor = cursor.minusDays(1);
-    }
-    return streak;
+    return StreakCalculator.compute(verifiedDates, LocalDate.now());
   }
 
   private String generateUniqueInviteCode() {

--- a/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
@@ -23,6 +23,7 @@ import com.offmode.boundedcontext.user.repository.UserBlockRepository;
 import com.offmode.boundedcontext.user.repository.UserRepository;
 import com.offmode.global.exception.BusinessException;
 import com.offmode.global.status.ErrorStatus;
+import com.offmode.global.util.StreakCalculator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -140,7 +141,7 @@ public class UserService {
             .map(LocalDateTime::toLocalDate)
             .collect(Collectors.toCollection(HashSet::new));
     verifiedDates.addAll(roomProofRepository.findVerifiedDatesByUser(userId, ProofStatus.VERIFIED));
-    int streak = calcStreak(verifiedDates);
+    int streak = StreakCalculator.compute(verifiedDates, LocalDate.now());
 
     return new UserStatsResponse(
         totalMissions,
@@ -152,19 +153,6 @@ public class UserService {
         level(intellect),
         fill(vitality),
         level(vitality));
-  }
-
-  // 연속 달성 일수 계산 (오늘부터 역순으로 확인)
-  private int calcStreak(Set<LocalDate> dates) {
-    if (dates.isEmpty()) return 0;
-
-    LocalDate check = LocalDate.now();
-    int streak = 0;
-    while (dates.contains(check)) {
-      streak++;
-      check = check.minusDays(1);
-    }
-    return streak;
   }
 
   @Transactional

--- a/backend/src/main/java/com/offmode/global/util/StreakCalculator.java
+++ b/backend/src/main/java/com/offmode/global/util/StreakCalculator.java
@@ -1,0 +1,32 @@
+package com.offmode.global.util;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+/**
+ * 연속 달성 일수(스트릭) 계산기.
+ *
+ * <p>오늘 아직 인증하지 않았어도 어제까지 이어진 기록은 유지된다. 개인 통계(UserService)와 방 통계(RoomService)가 같은 규칙을 쓰도록 한 곳에 모았다.
+ */
+public final class StreakCalculator {
+
+  private StreakCalculator() {}
+
+  /**
+   * 오늘 인증이 있으면 오늘부터, 없으면 어제부터 거꾸로 이어진 인증 일수를 센다.
+   *
+   * @param verifiedDates 인증 완료된 날짜 집합
+   * @param today 기준 날짜
+   */
+  public static int compute(Set<LocalDate> verifiedDates, LocalDate today) {
+    if (verifiedDates == null || verifiedDates.isEmpty()) return 0;
+
+    LocalDate cursor = verifiedDates.contains(today) ? today : today.minusDays(1);
+    int streak = 0;
+    while (verifiedDates.contains(cursor)) {
+      streak++;
+      cursor = cursor.minusDays(1);
+    }
+    return streak;
+  }
+}

--- a/backend/src/test/java/com/offmode/boundedcontext/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/user/service/UserServiceTest.java
@@ -137,6 +137,46 @@ class UserServiceTest {
   }
 
   @Test
+  void getStats_오늘_미인증이어도_어제까지_이어진_연속달성은_유지된다() {
+    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
+    stubCategoryCounts();
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(List.of());
+    when(roomProofRepository.countByUserId(1L)).thenReturn(3L);
+    when(roomProofRepository.countByUserIdAndStatus(1L, ProofStatus.VERIFIED)).thenReturn(3L);
+    // 오늘은 아직 인증 전, 어제부터 3일 연속
+    when(roomProofRepository.findVerifiedDatesByUser(1L, ProofStatus.VERIFIED))
+        .thenReturn(
+            List.of(
+                LocalDate.now().minusDays(1),
+                LocalDate.now().minusDays(2),
+                LocalDate.now().minusDays(3)));
+
+    UserStatsResponse res = service().getStats(1L);
+
+    assertThat(res.getStreak()).isEqualTo(3);
+  }
+
+  @Test
+  void getStats_어제도_인증이_없으면_연속달성은_0이다() {
+    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
+    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
+    stubCategoryCounts();
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(List.of());
+    when(roomProofRepository.countByUserId(1L)).thenReturn(1L);
+    when(roomProofRepository.countByUserIdAndStatus(1L, ProofStatus.VERIFIED)).thenReturn(1L);
+    // 오늘·어제 모두 없음 → 끊긴 기록
+    when(roomProofRepository.findVerifiedDatesByUser(1L, ProofStatus.VERIFIED))
+        .thenReturn(List.of(LocalDate.now().minusDays(2)));
+
+    UserStatsResponse res = service().getStats(1L);
+
+    assertThat(res.getStreak()).isZero();
+  }
+
+  @Test
   void getStats_카테고리_통계에_방인증을_합산한다() {
     when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);

--- a/backend/src/test/java/com/offmode/global/util/StreakCalculatorTest.java
+++ b/backend/src/test/java/com/offmode/global/util/StreakCalculatorTest.java
@@ -1,0 +1,45 @@
+package com.offmode.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class StreakCalculatorTest {
+
+  private static final LocalDate TODAY = LocalDate.of(2026, 8, 17);
+
+  @Test
+  void 인증기록이_없으면_0이다() {
+    assertThat(StreakCalculator.compute(Set.of(), TODAY)).isZero();
+  }
+
+  @Test
+  void 오늘_인증했으면_오늘부터_센다() {
+    Set<LocalDate> dates = Set.of(TODAY, TODAY.minusDays(1), TODAY.minusDays(2));
+
+    assertThat(StreakCalculator.compute(dates, TODAY)).isEqualTo(3);
+  }
+
+  @Test
+  void 오늘_미인증이면_어제부터_센다() {
+    Set<LocalDate> dates = Set.of(TODAY.minusDays(1), TODAY.minusDays(2), TODAY.minusDays(3));
+
+    assertThat(StreakCalculator.compute(dates, TODAY)).isEqualTo(3);
+  }
+
+  @Test
+  void 오늘도_어제도_없으면_0이다() {
+    Set<LocalDate> dates = Set.of(TODAY.minusDays(2), TODAY.minusDays(3));
+
+    assertThat(StreakCalculator.compute(dates, TODAY)).isZero();
+  }
+
+  @Test
+  void 중간에_끊기면_이어진_구간까지만_센다() {
+    Set<LocalDate> dates = Set.of(TODAY, TODAY.minusDays(1), TODAY.minusDays(3));
+
+    assertThat(StreakCalculator.compute(dates, TODAY)).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
## 🔗 Issue

- close #191

---

## 📌 Summary

- `UserService.calcStreak`가 오늘 날짜부터 역순으로 세는 탓에, 오늘 아직 인증하지 않았으면 어제까지 며칠을 이어왔든 `streak`이 0으로 내려갔습니다. 오늘 기록이 없으면 어제부터 세도록 고쳤습니다.
- 같은 규칙을 이미 올바르게 쓰던 `RoomService.computeStreak`와 로직이 중복돼 있어, `global/util/StreakCalculator`로 추출해 개인 통계·방 통계가 한 구현을 공유하게 했습니다.
- `FeedService`의 `streakDays`도 `UserService.getStats` 값을 그대로 쓰므로 함께 정상화됩니다. 스트릭은 조회 시점 계산이라 과거 데이터 보정은 필요 없습니다.

---

## ✅ Test

- [x] `StreakCalculatorTest` 신규 — 기록 없음 / 오늘부터 / 어제부터 / 이틀 전에 끊김 / 중간에 끊김 5케이스
- [x] `UserServiceTest` 추가 — 오늘 미인증이어도 어제까지 3일 유지, 오늘·어제 모두 없으면 0
- [x] `./gradlew spotlessCheck` 통과
- [x] `./gradlew test` 전체 통과
