### PR TITLE
[Fix] #196 리액션 배지 2종 실제 조건으로 판정

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
@@ -8,6 +8,7 @@ import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.repository.RoomReactionRepository;
 import com.offmode.boundedcontext.room.types.ProofStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
@@ -27,6 +28,7 @@ public class BadgeService {
   private final UserMissionRepository userMissionRepository;
   private final UserRepository userRepository;
   private final RoomProofRepository roomProofRepository;
+  private final RoomReactionRepository roomReactionRepository;
 
   /** 모든 배지 정의 + 획득 여부 반환 */
   public List<BadgeResponse> getUserBadges(Long userId) {
@@ -74,8 +76,9 @@ public class BadgeService {
       case AFTERNOON_FREE -> verifiedByHour(userId, 12, 18) >= 5;
       case EVENING_WARDEN -> verifiedByHour(userId, 18, 22) >= 5;
 
-        // 소셜 (리액션 시스템 미구현 → 항상 false)
-      case EMOJI_ARTIST, REACTION_MASTER -> false;
+        // 소셜 (셀프 리액션은 양쪽 모두 집계에서 제외)
+      case EMOJI_ARTIST -> roomReactionRepository.countGivenToOthers(userId) >= 50;
+      case REACTION_MASTER -> roomReactionRepository.countReceivedFromOthers(userId) >= 100;
 
         // 유니크
       case OFFMODE_ENTRY -> userMissionRepository.existsByUserId(userId);

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomReactionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomReactionRepository.java
@@ -21,6 +21,25 @@ public interface RoomReactionRepository extends JpaRepository<RoomReaction, Long
   @Query("DELETE FROM RoomReaction r WHERE r.roomProof.user.id = :userId")
   void deleteByProofOwnerUserId(@Param("userId") Long userId);
 
+  // 배지(EMOJI_ARTIST): 내가 '다른 유저' 인증에 남긴 리액션 수.
+  // 셀프 리액션은 토글 API가 막지 않으므로 여기서 제외한다.
+  @Query(
+      """
+        SELECT COUNT(r)
+        FROM RoomReaction r
+        WHERE r.user.id = :userId AND r.roomProof.user.id <> :userId
+    """)
+  long countGivenToOthers(@Param("userId") Long userId);
+
+  // 배지(REACTION_MASTER): 내 인증에 '남이' 남긴 리액션 수. 셀프 리액션 제외.
+  @Query(
+      """
+        SELECT COUNT(r)
+        FROM RoomReaction r
+        WHERE r.roomProof.user.id = :userId AND r.user.id <> :userId
+    """)
+  long countReceivedFromOthers(@Param("userId") Long userId);
+
   @Query(
       """
         SELECT r.roomProof.id, r.emoji, r.user.id

--- a/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
@@ -11,6 +11,7 @@ import com.offmode.boundedcontext.mission.repository.UserMissionRepository;
 import com.offmode.boundedcontext.mission.types.MissionCategory;
 import com.offmode.boundedcontext.mission.types.MissionStatus;
 import com.offmode.boundedcontext.room.repository.RoomProofRepository;
+import com.offmode.boundedcontext.room.repository.RoomReactionRepository;
 import com.offmode.boundedcontext.room.types.ProofStatus;
 import com.offmode.boundedcontext.user.entity.User;
 import com.offmode.boundedcontext.user.repository.UserRepository;
@@ -30,12 +31,20 @@ class BadgeServiceTest {
   @Mock private UserMissionRepository userMissionRepository;
   @Mock private UserRepository userRepository;
   @Mock private RoomProofRepository roomProofRepository;
+  @Mock private RoomReactionRepository roomReactionRepository;
+
+  private BadgeService service() {
+    return new BadgeService(
+        userBadgeRepository,
+        userMissionRepository,
+        userRepository,
+        roomProofRepository,
+        roomReactionRepository);
+  }
 
   @Test
   void checkAndAwardAwardsFirstMissionAcceptedBadge() {
-    BadgeService service =
-        new BadgeService(
-            userBadgeRepository, userMissionRepository, userRepository, roomProofRepository);
+    BadgeService service = service();
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
     when(userMissionRepository.existsByUserId(1L)).thenReturn(true);
@@ -52,9 +61,7 @@ class BadgeServiceTest {
 
   @Test
   void checkAndAwardAwardsVerifiedCountAndCategoryBadges() {
-    BadgeService service =
-        new BadgeService(
-            userBadgeRepository, userMissionRepository, userRepository, roomProofRepository);
+    BadgeService service = service();
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(10L);
@@ -76,9 +83,7 @@ class BadgeServiceTest {
 
   @Test
   void checkAndAwardAwardsSevenDayStreakBadge() {
-    BadgeService service =
-        new BadgeService(
-            userBadgeRepository, userMissionRepository, userRepository, roomProofRepository);
+    BadgeService service = service();
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     LocalDateTime start = LocalDateTime.now().minusDays(6);
     when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
@@ -95,9 +100,7 @@ class BadgeServiceTest {
 
   @Test
   void checkAndAwardCountsRoomProofsForExplorerBadge() {
-    BadgeService service =
-        new BadgeService(
-            userBadgeRepository, userMissionRepository, userRepository, roomProofRepository);
+    BadgeService service = service();
     User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
     when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
     // 개인 미션 인증 0, 방 인증 1 → verifiedCount 1 → EXPLORER 획득
@@ -112,5 +115,38 @@ class BadgeServiceTest {
     List<BadgeDefinition> awarded = service.checkAndAward(1L);
 
     assertThat(awarded).contains(BadgeDefinition.EXPLORER_LV01);
+  }
+
+  @Test
+  void checkAndAwardAwardsReactionBadgesWhenThresholdsMet() {
+    BadgeService service = service();
+    User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
+    when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
+    when(roomReactionRepository.countGivenToOthers(1L)).thenReturn(50L);
+    when(roomReactionRepository.countReceivedFromOthers(1L)).thenReturn(100L);
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(Collections.emptyList());
+    when(userRepository.getReferenceById(1L)).thenReturn(user);
+    when(userBadgeRepository.save(any(UserBadge.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    List<BadgeDefinition> awarded = service.checkAndAward(1L);
+
+    assertThat(awarded).contains(BadgeDefinition.EMOJI_ARTIST, BadgeDefinition.REACTION_MASTER);
+  }
+
+  @Test
+  void checkAndAwardSkipsReactionBadgesBelowThresholds() {
+    BadgeService service = service();
+    when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
+    when(roomReactionRepository.countGivenToOthers(1L)).thenReturn(49L);
+    when(roomReactionRepository.countReceivedFromOthers(1L)).thenReturn(99L);
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(Collections.emptyList());
+
+    List<BadgeDefinition> awarded = service.checkAndAward(1L);
+
+    assertThat(awarded)
+        .doesNotContain(BadgeDefinition.EMOJI_ARTIST, BadgeDefinition.REACTION_MASTER);
   }
 }


### PR DESCRIPTION
## 🔗 Issue

- close #196

---

## 📌 Summary

- `BadgeService`에서 `EMOJI_ARTIST`·`REACTION_MASTER`가 조건 판별 없이 `false`를 반환해 영구 획득 불가였던 것을 실제 리액션 집계로 연결
- `RoomReactionRepository`에 `countGivenToOthers`(내가 남긴 리액션) / `countReceivedFromOthers`(내 인증에 달린 리액션) 추가 — 기존 삭제 쿼리의 조건식을 그대로 count로 옮김
- 리액션 토글 API는 `confirm`과 달리 셀프 리액션을 막지 않아, 배지 정의("다른 유저 피드에")와 셀프 파밍 방지를 위해 양쪽 쿼리에서 자기 리액션 제외
- `BadgeServiceTest`의 반복되던 생성자 조립을 `service()` 팩토리로 정리 (백엔드 테스트 컨벤션)

---

## ✅ Test

- [x] `./gradlew spotlessApply test` 통과
- [x] 임계값 충족 시 배지 획득 / 미달(49·99) 시 미획득 테스트 추가
- [ ] 실기기에서 리액션 누적 후 배지 표시 확인

> 쿼리 배치화·교차 proof race(#147)는 범위에서 분리했습니다.