### PR TITLE
[Fix] #136 레거시 피어인증 레벨업·연속일 배지에 방 인증 합산

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
@@ -118,14 +118,15 @@ public class BadgeService {
     return legacy + room;
   }
 
-  /** 최대 연속 미션 달성 일수 계산 */
+  /** 최대 연속 미션 달성 일수 계산 — 개인 미션 인증 날짜 + 방 인증 날짜를 합산 */
   private int maxConsecutiveDays(Long userId) {
-    List<LocalDate> dates =
+    Set<LocalDate> verifiedDates =
         userMissionRepository.findVerifiedDateTimes(userId, MissionStatus.VERIFIED).stream()
             .map(LocalDateTime::toLocalDate)
-            .distinct()
-            .sorted()
-            .toList();
+            .collect(Collectors.toCollection(HashSet::new));
+    verifiedDates.addAll(roomProofRepository.findVerifiedDatesByUser(userId, ProofStatus.VERIFIED));
+
+    List<LocalDate> dates = verifiedDates.stream().sorted().toList();
 
     if (dates.isEmpty()) return 0;
 

--- a/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/feed/service/FeedService.java
@@ -111,10 +111,10 @@ public class FeedService {
         userMissionRepository.save(mission);
 
         // 레벨업 + 배지 체크 (미션 주인에게)
+        // 누적 인증 수는 '개인 미션 + 방 인증' 합산이라 UserService 로 위임한다.
+        // 여기서 UserMission 만 세면 방 인증 위주 유저의 승급이 누락된다.
         Long ownerId = mission.getUser().getId();
-        long verifiedCount =
-            userMissionRepository.countByUserIdAndStatus(ownerId, MissionStatus.VERIFIED);
-        userService.levelUp(ownerId, (int) verifiedCount);
+        userService.applyVerifiedProgress(ownerId);
         badgeService.checkAndAward(ownerId);
       }
     }

--- a/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/badge/service/BadgeServiceTest.java
@@ -149,4 +149,24 @@ class BadgeServiceTest {
     assertThat(awarded)
         .doesNotContain(BadgeDefinition.EMOJI_ARTIST, BadgeDefinition.REACTION_MASTER);
   }
+
+  @Test
+  void checkAndAwardCountsRoomProofDatesForStreakBadge() {
+    BadgeService service = service();
+    User user = User.builder().id(1L).provider("kakao").providerId("p1").build();
+    java.time.LocalDate start = java.time.LocalDate.now().minusDays(6);
+    when(userBadgeRepository.findEarnedKeys(1L)).thenReturn(Set.of());
+    // 개인 미션 인증은 없고 방 인증만 7일 연속 → SPEEDRUNNER 획득
+    when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
+        .thenReturn(Collections.emptyList());
+    when(roomProofRepository.findVerifiedDatesByUser(1L, ProofStatus.VERIFIED))
+        .thenReturn(java.util.stream.IntStream.range(0, 7).mapToObj(start::plusDays).toList());
+    when(userRepository.getReferenceById(1L)).thenReturn(user);
+    when(userBadgeRepository.save(any(UserBadge.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    List<BadgeDefinition> awarded = service.checkAndAward(1L);
+
+    assertThat(awarded).contains(BadgeDefinition.SPEEDRUNNER);
+  }
 }

--- a/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/feed/service/FeedServiceTest.java
@@ -109,14 +109,14 @@ class FeedServiceTest {
     when(confirmRepository.existsByVerificationIdAndUserId(20L, 2L)).thenReturn(false);
     when(userService.getById(2L)).thenReturn(confirmer);
     when(confirmRepository.countByVerificationId(20L)).thenReturn(1L);
-    when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(1L);
 
     feedService.confirm(2L, 20L);
 
     assertThat(mission.getStatus()).isEqualTo(MissionStatus.VERIFIED);
     assertThat(mission.getVerifiedAt()).isNotNull();
     verify(userMissionRepository).save(mission);
-    verify(userService).levelUp(1L, 1);
+    // 누적 인증 수 계산은 UserService 로 위임한다 (개인 미션 + 방 인증 합산)
+    verify(userService).applyVerifiedProgress(1L);
     verify(badgeService).checkAndAward(1L);
   }
 


### PR DESCRIPTION
## 🔗 Issue

- close #136

---

## 📌 Summary

- `FeedService.confirm`: 레거시 피어인증으로 미션이 VERIFIED 될 때 `UserMission` 개수만으로 `levelUp` 을 호출해, 방 인증 위주 유저(방 9건 + 레거시 1건)의 승급이 누락되던 문제를 `UserService.applyVerifiedProgress` 위임으로 교체
- `BadgeService.maxConsecutiveDays`: `findVerifiedDateTimes`(개인 미션)만 보던 것을 `roomProofRepository.findVerifiedDatesByUser` 와 병합 — 방 인증만으로 7일 연속을 채워도 `SPEEDRUNNER` 획득 가능
- 합산 정의가 여러 서비스에 복사돼 누락이 재발하던 구조를, 이번 두 지점은 `UserService` 쪽 공유 지점으로 모으는 방향으로 정리

---

## ✅ Test

- [x] `./gradlew spotlessApply test` 통과
- [x] `FeedServiceTest` 를 위임 검증으로 갱신
- [x] 개인 미션 0건 + 방 인증 7일 연속 → SPEEDRUNNER 획득 테스트 추가
- [ ] 실기기에서 방 인증 누적 후 레벨·배지 반영 확인

> 이슈 본문의 "참고(범위 아님)" 항목(history id 혼용·verifiedAt 근사치·limit 30)은 그대로 남겨뒀습니다.