### PR TITLE
[Fix] #197 통계·배지 조회의 전건 로드를 count 쿼리로 교체

### DIFF
--- a/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/badge/service/BadgeService.java
@@ -110,11 +110,8 @@ public class BadgeService {
         userMissionRepository.countByStatusAndHourRange(
             userId, MissionStatus.VERIFIED, fromHour, toHour);
     long room =
-        roomProofRepository.findCreatedAtByUserIdAndStatus(userId, ProofStatus.VERIFIED).stream()
-            .filter(java.util.Objects::nonNull)
-            .map(LocalDateTime::getHour)
-            .filter(hour -> hour >= fromHour && hour < toHour)
-            .count();
+        roomProofRepository.countByStatusAndHourRange(
+            userId, ProofStatus.VERIFIED, fromHour, toHour);
     return legacy + room;
   }
 

--- a/backend/src/main/java/com/offmode/boundedcontext/mission/repository/UserMissionRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/mission/repository/UserMissionRepository.java
@@ -21,6 +21,8 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
 
   boolean existsByUserId(Long userId);
 
+  long countByUserId(Long userId);
+
   long countByUserIdAndStatus(Long userId, MissionStatus status);
 
   long countByUserIdAndStatusAndMissionCategory(

--- a/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/room/repository/RoomProofRepository.java
@@ -5,7 +5,6 @@ import com.offmode.boundedcontext.room.entity.RoomProof;
 import com.offmode.boundedcontext.room.types.ProofStatus;
 import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -109,10 +108,19 @@ public interface RoomProofRepository extends JpaRepository<RoomProof, Long> {
   long countByUserIdAndStatusAndRoomMissionTitleContaining(
       Long userId, ProofStatus status, String keyword);
 
-  // 시간대 배지용 — VERIFIED 방 인증의 생성 시각 목록(시(hour) 필터는 Java에서 수행)
-  @Query("SELECT p.createdAt FROM RoomProof p WHERE p.user.id = :userId AND p.status = :status")
-  List<LocalDateTime> findCreatedAtByUserIdAndStatus(
-      @Param("userId") Long userId, @Param("status") ProofStatus status);
+  // 시간대 배지용 — VERIFIED 방 인증 중 생성 시각이 [fromHour, toHour) 에 드는 건수
+  @Query(
+      """
+        SELECT COUNT(p)
+        FROM RoomProof p
+        WHERE p.user.id = :userId AND p.status = :status
+          AND HOUR(p.createdAt) >= :fromHour AND HOUR(p.createdAt) < :toHour
+    """)
+  long countByStatusAndHourRange(
+      @Param("userId") Long userId,
+      @Param("status") ProofStatus status,
+      @Param("fromHour") int fromHour,
+      @Param("toHour") int toHour);
 
   // 유저 연속 달성 일수 계산용: 유저가 VERIFIED 한 방 미션의 날짜들
   @Query(

--- a/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
+++ b/backend/src/main/java/com/offmode/boundedcontext/user/service/UserService.java
@@ -114,8 +114,7 @@ public class UserService {
     // 누적 통계는 레거시 개인 미션(UserMission)과 Rooms v2 방 인증(RoomProof)을 합산한다.
     // (현재 실제 인증은 방 인증으로만 저장되므로 RoomProof 미합산 시 누적이 오르지 않음)
     long totalMissions =
-        userMissionRepository.findByUserIdOrderByAssignedAtDesc(userId).size()
-            + roomProofRepository.countByUserId(userId);
+        userMissionRepository.countByUserId(userId) + roomProofRepository.countByUserId(userId);
     long totalVerified = totalVerifiedCount(userId);
 
     // 카테고리 통계도 개인 미션 + 방 인증(해당 category)을 합산한다.

--- a/backend/src/test/java/com/offmode/boundedcontext/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/offmode/boundedcontext/user/service/UserServiceTest.java
@@ -101,8 +101,7 @@ class UserServiceTest {
 
   @Test
   void getStats_방인증을_누적_통계에_합산한다() {
-    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L))
-        .thenReturn(List.of()); // 레거시 0
+    when(userMissionRepository.countByUserId(1L)).thenReturn(0L); // 레거시 0
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(2L);
     stubCategoryCounts();
     when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
@@ -120,7 +119,7 @@ class UserServiceTest {
 
   @Test
   void getStats_연속달성은_방인증_날짜도_포함한다() {
-    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
+    when(userMissionRepository.countByUserId(1L)).thenReturn(0L);
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
     stubCategoryCounts();
     when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
@@ -138,7 +137,7 @@ class UserServiceTest {
 
   @Test
   void getStats_오늘_미인증이어도_어제까지_이어진_연속달성은_유지된다() {
-    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
+    when(userMissionRepository.countByUserId(1L)).thenReturn(0L);
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
     stubCategoryCounts();
     when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
@@ -160,7 +159,7 @@ class UserServiceTest {
 
   @Test
   void getStats_어제도_인증이_없으면_연속달성은_0이다() {
-    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
+    when(userMissionRepository.countByUserId(1L)).thenReturn(0L);
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
     stubCategoryCounts();
     when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))
@@ -178,7 +177,7 @@ class UserServiceTest {
 
   @Test
   void getStats_카테고리_통계에_방인증을_합산한다() {
-    when(userMissionRepository.findByUserIdOrderByAssignedAtDesc(1L)).thenReturn(List.of());
+    when(userMissionRepository.countByUserId(1L)).thenReturn(0L);
     when(userMissionRepository.countByUserIdAndStatus(1L, MissionStatus.VERIFIED)).thenReturn(0L);
     stubCategoryCounts(); // 레거시 카테고리 0
     when(userMissionRepository.findVerifiedDateTimes(1L, MissionStatus.VERIFIED))


### PR DESCRIPTION
## 🔗 Issue

- close #197

---

## 📌 Summary

- `UserService.getStats`: `findByUserIdOrderByAssignedAtDesc(userId).size()` → `countByUserId` — 개수만 필요한데 정렬까지 걸어 전건을 영속성 컨텍스트에 올리던 것을 제거
- `BadgeService.verifiedByHour`: RoomProof `createdAt` 전건 로드 후 Java 스트림 필터 → `RoomProofRepository.countByStatusAndHourRange` 쿼리로 대체. 이 메서드는 시간대 배지 3종 판정마다 호출돼 배지 체크 1회에 3번 반복된다
- 새 쿼리는 `UserMissionRepository.countByStatusAndHourRange` 가 이미 쓰던 JPQL `HOUR()` 방식을 그대로 따랐다 (H2/MySQL 동일)
- 사용처가 사라진 `findCreatedAtByUserIdAndStatus` 및 미사용 import 제거

---

## ✅ Test

- [x] `./gradlew spotlessApply test` 통과
- [x] `UserServiceTest` 의 stub 을 count 기반으로 갱신 — 기대값(누적/카테고리/연속달성)은 그대로 두고 통과 확인
- [ ] 실기기에서 프로필 통계·시간대 배지 값이 이전과 같은지 확인

> `#147` 의 checkAndAward 배치화와 교차 proof race 는 범위에서 제외했습니다.